### PR TITLE
Adds command structure, and the ability to use async functions

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,10 @@
 {
     "presets": [
-        "es2015"
+        "es2015",
+        "stage-3"
     ],
-    "plugins": ["transform-flow-strip-types"]
+    "plugins": [
+        "transform-flow-strip-types",
+        "transform-regenerator"
+      ]
 }

--- a/.vscode/spell.json
+++ b/.vscode/spell.json
@@ -1,0 +1,29 @@
+{
+  "language": "en",
+  "ignoreWordsList": [
+    "GitHub",
+    "GitLab"
+  ],
+  "mistakeTypeToStatus": {
+    "Passive voice": "Hint",
+    "Spelling": "Error",
+    "Complex Expression": "Disable",
+    "Hidden Verbs": "Information",
+    "Hyphen Required": "Disable",
+    "Redundant Expression": "Disable",
+    "Did you mean...": "Disable",
+    "Repeated Word": "Warning",
+    "Missing apostrophe": "Warning",
+    "Cliches": "Disable",
+    "Missing Word": "Disable",
+    "Make I uppercase": "Warning"
+  },
+  "languageIDs": [
+    "markdown",
+    "plaintext"
+  ],
+  "ignoreRegExp": [
+    "/\\(.*\\.(jpg|jpeg|png|md|gif|JPG|JPEG|PNG|MD|GIF)\\)/g",
+    "/((http|https|ftp|git)\\S*)/g"
+  ]
+}

--- a/VISION.md
+++ b/VISION.md
@@ -4,19 +4,22 @@ A year in, [Danger](https://github.com/danger/danger) is doing just fine. See th
 
 The amount of issues we get in comparison to the number of downloads on Rubygems makes me feel pretty confident about her state of production quality and maturity. I wanted to start thinking about the larger patterns in software. At Artsy, we are starting to use JavaScript in many, many places.
 
-I've explored [running JavaScript](https://github.com/danger/danger/pull/423) from the ruby Danger, ([example](https://github.com/artsy/emission/blob/d58b3d57bf41100e3cce3c2c1b1c4d6c19581a68/Dangerfile.js)) but this pattern isn't going to work on the larger scale: You cannot use npm modules, nor work with babel to transpile your `Dangerfile.js`. That isn't going to work.
+I've explored [running JavaScript](https://github.com/danger/danger/pull/423) from the ruby Danger, ([example](https://github.com/artsy/emission/blob/d58b3d57bf41100e3cce3c2c1b1c4d6c19581a68/Dangerfile.js)) but this pattern isn't going to work on the larger scale: You cannot use npm modules, nor work with babel to transpile your `Dangerfile.js` and the requirements on the project to [include are too high](https://github.com/artsy/emission/pull/233). That isn't going to work.
 
-This comes at the same time as thinking about a hosted version of Danger. This time around we can limit the exposed API to only something that can be obtained over the API on a hosted server. 
+This comes at the same time as thinking about a hosted version of Danger. With the NPM version we can limit the exposed API to only something that can be obtained over the API on a hosted server. By doing this, a hosted Danger does not need to clone and run the associated projects. This is essential for my sanity. I cannot run multiple [servers like CocoaDocs](http://cocoadocs.org). So far, I'm calling this Peril. 
 
-One technique for doing this is to lazy load information required, e.g. by default only get the PR metadata, and file changed. 
+I _do not_ know how to deal with babel-y compilation stuff, or danger plugins to work in Peril. Figure I'll know more about the systems as I get there.  
+
+One technique for doing this is to lazy load information required, e.g. by default only get the PR metadata, and file changed. I think memoized get functions in ES6 will be useful there. 
 
 ### So, initial vision?
 
 * As few dependencies as possible
 * Feel native to JS
-* Provide Flow/TypeScript types for Danger objects
-* Be API agnostic from day one
-* If an exposed API can't be done via the APIs, it can't be done for that platform
+* Provide Flow/TypeScript types for Danger API
+* Be platform API agnostic from day one
+* If an exposed end-user API can't be done via the platform APIs, it can't be done for that platform
+  E.g. if GitLab had an API not available on GitHub, then for GitHub we cannot do that same thing. Platform APIs dictates the end-user experience.
 * Re-use abstractions from the Gem when possible, it took a long time to get those
 * Re-use CI source detection from Ruby Danger
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -237,6 +237,11 @@
         }
       }
     },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.15.0",
+      "from": "babel-helper-builder-binary-assignment-operator-visitor@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.15.0.tgz"
+    },
     "babel-helper-call-delegate": {
       "version": "6.8.0",
       "from": "babel-helper-call-delegate@>=6.8.0 <7.0.0",
@@ -246,6 +251,11 @@
       "version": "6.9.0",
       "from": "babel-helper-define-map@>=6.9.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.9.0.tgz"
+    },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.8.0",
+      "from": "babel-helper-explode-assignable-expression@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.8.0.tgz"
     },
     "babel-helper-function-name": {
       "version": "6.8.0",
@@ -271,6 +281,11 @@
       "version": "6.9.0",
       "from": "babel-helper-regex@>=6.8.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.9.0.tgz"
+    },
+    "babel-helper-remap-async-to-generator": {
+      "version": "6.16.2",
+      "from": "babel-helper-remap-async-to-generator@>=6.16.2 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.16.2.tgz"
     },
     "babel-helper-replace-supers": {
       "version": "6.16.0",
@@ -307,10 +322,45 @@
       "from": "babel-plugin-jest-hoist@>=15.0.0 <16.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-15.0.0.tgz"
     },
+    "babel-plugin-syntax-async-functions": {
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-async-functions@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz"
+    },
+    "babel-plugin-syntax-async-generators": {
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-async-generators@>=6.5.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz"
+    },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-exponentiation-operator@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz"
+    },
     "babel-plugin-syntax-flow": {
       "version": "6.13.0",
       "from": "babel-plugin-syntax-flow@>=6.8.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.13.0.tgz"
+    },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-object-rest-spread@>=6.8.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz"
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-trailing-function-commas@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.13.0.tgz"
+    },
+    "babel-plugin-transform-async-generator-functions": {
+      "version": "6.17.0",
+      "from": "babel-plugin-transform-async-generator-functions@>=6.17.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.17.0.tgz"
+    },
+    "babel-plugin-transform-async-to-generator": {
+      "version": "6.16.0",
+      "from": "babel-plugin-transform-async-to-generator@>=6.16.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.16.0.tgz"
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.8.0",
@@ -422,10 +472,20 @@
       "from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.11.0.tgz"
     },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.8.0",
+      "from": "babel-plugin-transform-exponentiation-operator@>=6.3.13 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.8.0.tgz"
+    },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.14.0",
       "from": "babel-plugin-transform-flow-strip-types@>=6.8.0 <7.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.14.0.tgz"
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.16.0",
+      "from": "babel-plugin-transform-object-rest-spread@>=6.16.0 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.16.0.tgz"
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.16.1",
@@ -451,6 +511,11 @@
       "version": "15.0.0",
       "from": "babel-preset-jest@>=15.0.0 <16.0.0",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-15.0.0.tgz"
+    },
+    "babel-preset-stage-3": {
+      "version": "6.17.0",
+      "from": "babel-preset-stage-3@latest",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.17.0.tgz"
     },
     "babel-register": {
       "version": "6.16.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Automate your culture",
   "main": "distribution/danger.js",
   "bin": {
-    "danger": "distribution/runner.js"
+    "danger": "distribution/commands/runner.js"
   },
   "scripts": {
     "test": "jest",
@@ -36,6 +36,7 @@
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-polyfill": "^6.13.0",
     "babel-preset-es2015": "^6.16.0",
+    "babel-preset-stage-3": "^6.17.0",
     "eslint": "^3.3.1",
     "eslint-config-standard": "^6.0.0-beta.3",
     "eslint-plugin-flow-vars": "^0.5.0",
@@ -46,6 +47,7 @@
     "jest-cli": "^15.1.1"
   },
   "dependencies": {
+    "babel-polyfill": "^6.16.0",
     "commander": "^2.9.0"
   }
 }

--- a/source/commands/app.js
+++ b/source/commands/app.js
@@ -1,0 +1,13 @@
+var program = require("commander")
+
+import { version } from "../../package.json"
+
+// Provides the root node to the command-line architecture
+
+program
+  .version(version)
+  .command("run", "Runs danger on your local system", {isDefault: true})
+  .command("init", "Creates a new Dangerfile.js")
+  .command("local", "Runs your changes against ")
+
+export default program

--- a/source/commands/danger-local.js
+++ b/source/commands/danger-local.js
@@ -1,0 +1,8 @@
+// @flow
+
+var program = require("commander")
+
+program
+  .parse(process.argv)
+
+console.log("Not Yet implmented")

--- a/source/commands/danger-pr.js
+++ b/source/commands/danger-pr.js
@@ -1,0 +1,8 @@
+// @flow
+
+var program = require("commander")
+
+program
+  .parse(process.argv)
+
+console.log("Not Yet implmented")

--- a/source/commands/danger-run.js
+++ b/source/commands/danger-run.js
@@ -1,23 +1,14 @@
-#! /usr/bin/env node
 // @flow
 
 var program = require("commander")
-import { version } from "../package.json"
-import { getCISourceForEnv } from "./ci_source/ci_source_selector"
+
+import { getCISourceForEnv } from "../ci_source/ci_source_selector"
 
 program
-  .version(version)
   .option("-h, --head [commitish]", "TODO: Set the head commitish")
   .option("-b, --base [commitish]", "TODO: Set the base commitish")
   .option("-f, --fail-on-errors", "TODO: Fail on errors")
   .parse(process.argv)
-
-// program["head"]
-// if (program.head) console.log("  - peppers")
-// if (program.base) console.log("  - pineapple")
-// if (program.fail_on_errors) console.log("  - bbq")
-
-// console.log("  - %s cheese", program.cheese)
 
 let source = getCISourceForEnv(process.env)
 if (source) {
@@ -29,4 +20,3 @@ if (source) {
   console.log("Could not find a CI source for this run")
   process.exit(0)
 }
-

--- a/source/commands/runner.js
+++ b/source/commands/runner.js
@@ -1,0 +1,8 @@
+#! /usr/bin/env node
+// @flow
+
+// This is needed so that other files can use async funcs
+import "babel-polyfill"
+
+import app from "./app"
+app.parse(process.argv)

--- a/source/danger.js
+++ b/source/danger.js
@@ -1,5 +1,6 @@
 // @flow
 // This file represents the module that is exposed as the danger API
+import "babel-polyfill"
 
 type DangerGit = {
   modified_files: string[],


### PR DESCRIPTION
I want to use fetch, and async - they seem like pretty solid tech choices. So I've got all that in, including the babel thing was a bit of an odditiy, but I figured it out

I kept seeing the error:

```sh
ReferenceError: regeneratorRuntime is not defined
```

Solution was to add `import "babel-polyfill"` before everything had started, and before the file with `async` functions were referenced. I removed the source code for them for now, not relevant.

In other news, this means there are a few commands for Danger now.