### PR TITLE
Add support for downloading and reading the diff from the github API

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,7 @@
     "quotes": [1, "double", "avoid-escape"],
     "flowtype/define-flow-type": 1,
     "flowtype/require-parameter-type": 1,
-    "flowtype/require-return-type": [ 1,"always", { "annotateUndefined": "never" } ],
+    "flowtype/require-return-type": [ 0,"always", { "annotateUndefined": "never" } ],
     "flowtype/space-after-type-colon": [ 1, "always" ],
     "flowtype/space-before-type-colon": [ 1, "never" ],
     "flowtype/type-id-match": [ 0, "^([A-Z][a-z0-9]+)+Type$" ],

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "babel-plugin-syntax-async-functions": "^6.13.0",
     "babel-plugin-transform-regenerator": "^6.16.1",
     "commander": "^2.9.0",
-    "node-fetch": "^1.6.3"
+    "node-fetch": "^1.6.3",
+    "parse-diff": "^0.4.0"
   }
 }

--- a/source/ci_source/fake.js
+++ b/source/ci_source/fake.js
@@ -10,7 +10,7 @@ export default class FakeCI {
   get isCI() : boolean { return true }
   get isPR() : boolean { return true }
 
-  get pullRequestID(): string { return "350" }
+  get pullRequestID(): string { return "327" }
   get repoSlug(): string { return "artsy/emission" }
   get repoURL(): string { return "maybe not needed?" }
   get supportedPlatforms() : string[] { return ["github"] }

--- a/source/commands/danger-run.js
+++ b/source/commands/danger-run.js
@@ -22,7 +22,7 @@ program
 
 let source = getCISourceForEnv(process.env)
 let fake = new FakeCI(process.env)
-let github = new GitHub("insert here", fake)
+let github = new GitHub("OK", fake)
 github.getInfo()
 
 if (source) {

--- a/source/platforms/github.js
+++ b/source/platforms/github.js
@@ -2,6 +2,7 @@
 "use strict"
 
 import type { CISource } from "../ci_source/ci_source"
+import parseDiff from "parse-diff"
 
 // import type { Metadata, Comment, Platform } from "./platform"
 import fetch from "node-fetch"
@@ -24,6 +25,18 @@ export class GitHub {
     let deets = await this.getPullRequestInfo()
     let pr = await deets.json()
     console.log(pr)
+
+    let diffReq = await this.getPullRequestDiff()
+    let diff = await diffReq.text()
+    let fileDiffs: [any] = parseDiff(diff)
+
+    let addedDiffs = fileDiffs.filter((diff: any) => diff["new"])
+    let removedDiffs = fileDiffs.filter((diff: any) => diff["deleted"])
+    let modified = fileDiffs.filter((diff: any) => !addedDiffs.includes(diff) && !removedDiffs.includes(diff))
+
+    console.log("Added: ", addedDiffs)
+    console.log("Removed: ", removedDiffs)
+    console.log("Modified: ", modified)
   }
 
   getUserInfo(): Promise<Response> {
@@ -36,11 +49,19 @@ export class GitHub {
     return this.get(`repos/${repo}/pulls/${prID}`)
   }
 
-  get(path: string, body: any = {}): Promise<Response> {
+  getPullRequestDiff(): Promise<Response> {
+    const repo = this.ciSource.repoSlug
+    const prID = this.ciSource.pullRequestID
+    return this.get(`repos/${repo}/pulls/${prID}`, {
+      accept: "application/vnd.github.v3.diff"
+    })
+  }
+
+  get(path: string, headers: any = {}, body: any = {}): Promise<Response> {
     return fetch(`https://api.github.com/${path}`, {
       method: "GET",
       body: body,
-      headers: { "Authorization": `token ${this.token}` }
+      headers: { "Authorization": `token ${this.token}`, ...headers }
     })
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2619,6 +2619,10 @@ output-file-sync@^1.1.0:
     mkdirp "^0.5.1"
     object-assign "^4.1.0"
 
+parse-diff:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/parse-diff/-/parse-diff-0.4.0.tgz#9ce35bcce8fc0b7c58f46d71113394fc0b4982dd"
+
 parse-glob@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"


### PR DESCRIPTION
So I had to add a new dependency, I know, I know, but I'm not sure that reading diffs is the domain of   Danger. 

However, this will grab a PR, and pull out the `modified_files`, `added_file` directly from the provided diff in the API - in theory, I could get a working build of Danger with a bit of work now.