### PR TITLE
introduce the eslint `prefer-const` rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,10 @@
             "ClassDeclaration": false
         }
     }],
+    "prefer-const": ["error", {
+        "destructuring": "any",
+        "ignoreReadBeforeAssign": false
+    }],
     "space-before-function-paren": ["error", "never"],
     "quotes": [1, "double", "avoid-escape"],
     "flowtype/define-flow-type": 1,

--- a/source/ci_source/_tests/_travis.test.js
+++ b/source/ci_source/_tests/_travis.test.js
@@ -1,6 +1,6 @@
 import Travis from "../travis.js"
 
-let correctEnv = {
+const correctEnv = {
   "HAS_JOSH_K_SEAL_OF_APPROVAL": "true",
   "TRAVIS_PULL_REQUEST": "800",
   "TRAVIS_REPO_SLUG": "artsy/eigen"
@@ -8,28 +8,28 @@ let correctEnv = {
 
 describe(".isCI", () => {
   test("validates when all Travis environment vars are set and Josh K says so", () => {
-    let travis = new Travis(correctEnv)
+    const travis = new Travis(correctEnv)
     expect(travis.isCI).toBeTruthy()
   })
 
   test("does not validate without josh", () => {
-    let travis = new Travis({})
+    const travis = new Travis({})
     expect(travis.isCI).toBeFalsy()
   })
 })
 
 describe(".isPR", () => {
   test("validates when all Travis environment vars are set and Josh K says so", () => {
-    let travis = new Travis(correctEnv)
+    const travis = new Travis(correctEnv)
     expect(travis.isPR).toBeTruthy()
   })
 
   test("does not validate without josh", () => {
-    let travis = new Travis({})
+    const travis = new Travis({})
     expect(travis.isPR).toBeFalsy()
   })
 
-  let envs = ["TRAVIS_PULL_REQUEST", "TRAVIS_REPO_SLUG"]
+  const envs = ["TRAVIS_PULL_REQUEST", "TRAVIS_REPO_SLUG"]
   envs.forEach((key: string) => {
     var env = {
       "HAS_JOSH_K_SEAL_OF_APPROVAL": "true",
@@ -39,7 +39,7 @@ describe(".isPR", () => {
     env[key] = null
 
     test(`does not validate when ${key} is missing`, () => {
-      let travis = new Travis({})
+      const travis = new Travis({})
       expect(travis.isPR).toBeFalsy()
     })
   })
@@ -50,21 +50,21 @@ describe(".isPR", () => {
       "TRAVIS_PULL_REQUEST": "asdasd",
       "TRAVIS_REPO_SLUG": "artsy/eigen"
     }
-    let travis = new Travis(env)
+    const travis = new Travis(env)
     expect(travis.isPR).toBeFalsy()
   })
 })
 
 describe(".pullReuestID", () => {
   it("pulls it out of the env", () => {
-    let travis = new Travis(correctEnv)
+    const travis = new Travis(correctEnv)
     expect(travis.pullRequestID).toEqual("800")
   })
 })
 
 describe(".repoSlug", () => {
   it("pulls it out of the env", () => {
-    let travis = new Travis(correctEnv)
+    const travis = new Travis(correctEnv)
     expect(travis.repoSlug).toEqual("artsy/eigen")
   })
 })

--- a/source/ci_source/ci_source.js
+++ b/source/ci_source/ci_source.js
@@ -43,7 +43,7 @@ import Fake from "./fake"
 */
 export function getCISourceForEnv(env: Env) : ?CISource {
   // Fake is what I'm using during dev for the minute
-  let travis = new Travis(env)
+  const travis = new Travis(env)
   if (travis.isCI) {
     return travis
   } else {

--- a/source/ci_source/ci_source_helpers.js
+++ b/source/ci_source/ci_source_helpers.js
@@ -10,7 +10,7 @@ import type { Env } from "./ci_source"
  * @returns {bool} true if they exist, false if not
 */
 export function ensureEnvKeysExist(env: Env, keys: string[]) : boolean {
-  let hasKeys = keys.map((key: string) : boolean => {
+  const hasKeys = keys.map((key: string) : boolean => {
     return env.hasOwnProperty(key) && env[key].length > 0
   })
   return !hasKeys.includes(false)
@@ -23,7 +23,7 @@ export function ensureEnvKeysExist(env: Env, keys: string[]) : boolean {
  * @returns {bool} true if they are all good, false if not
 */
 export function ensureEnvKeysAreInt(env: Env, keys: string[]) : boolean {
-  let hasKeys = keys.map((key: string) : boolean => {
+  const hasKeys = keys.map((key: string) : boolean => {
     return env.hasOwnProperty(key) && !isNaN(parseInt(env.TRAVIS_PULL_REQUEST))
   })
   return !hasKeys.includes(false)

--- a/source/ci_source/travis.js
+++ b/source/ci_source/travis.js
@@ -14,8 +14,8 @@ export default class Travis {
   }
 
   get isPR() : boolean {
-    let mustHave = ["HAS_JOSH_K_SEAL_OF_APPROVAL", "TRAVIS_PULL_REQUEST"]
-    let mustBeInts = ["TRAVIS_REPO_SLUG"]
+    const mustHave = ["HAS_JOSH_K_SEAL_OF_APPROVAL", "TRAVIS_PULL_REQUEST"]
+    const mustBeInts = ["TRAVIS_REPO_SLUG"]
     return ensureEnvKeysExist(this.env, mustHave) && ensureEnvKeysAreInt(this.env, mustBeInts)
   }
 

--- a/source/commands/danger-run.js
+++ b/source/commands/danger-run.js
@@ -13,7 +13,7 @@ program
   .option("-f, --fail-on-errors", "TODO: Fail on errors")
   .parse(process.argv)
 
-let source = getCISourceForEnv(process.env)
+const source = getCISourceForEnv(process.env)
 if (!source) {
   console.log("Could not find a CI source for this run")
   process.exitCode = 1

--- a/source/platforms/github.js
+++ b/source/platforms/github.js
@@ -27,20 +27,20 @@ export class GitHub {
   name: "GitHub"
 
   async getReviewInfo() : Promise<any> {
-    let deets = await this.getPullRequestInfo()
+    const deets = await this.getPullRequestInfo()
     return await deets.json()
   }
 
   async getReviewDiff() : Promise<GitDSL> {
-    let diffReq = await this.getPullRequestDiff()
-    let diff = await diffReq.text()
+    const diffReq = await this.getPullRequestDiff()
+    const diff = await diffReq.text()
 
     // Worth trying to add a flow-typed for this as a tester?
-    let fileDiffs: [any] = parseDiff(diff)
+    const fileDiffs: [any] = parseDiff(diff)
 
-    let addedDiffs = fileDiffs.filter((diff: any) => diff["new"])
-    let removedDiffs = fileDiffs.filter((diff: any) => diff["deleted"])
-    let modifiedDiffs = fileDiffs.filter((diff: any) => !addedDiffs.includes(diff) && !removedDiffs.includes(diff))
+    const addedDiffs = fileDiffs.filter((diff: any) => diff["new"])
+    const removedDiffs = fileDiffs.filter((diff: any) => diff["deleted"])
+    const modifiedDiffs = fileDiffs.filter((diff: any) => !addedDiffs.includes(diff) && !removedDiffs.includes(diff))
 
     return {
       modified_files: modifiedDiffs.map((d: any) => d.to),

--- a/source/platforms/platform.js
+++ b/source/platforms/platform.js
@@ -49,7 +49,7 @@ import { GitHub } from "./github"
  * @returns {?Platform} returns a platform if it can be supported
 */
 export function getPlatformForEnv(env: Env, source: CISource) : ?Platform {
-  let github = new GitHub(env["DANGER_GITHUB_API_TOKEN"], source)
+  const github = new GitHub(env["DANGER_GITHUB_API_TOKEN"], source)
   return github
 }
 

--- a/source/runner/Executor.js
+++ b/source/runner/Executor.js
@@ -16,7 +16,7 @@ export default class Executor {
   async run() {
     const git = await this.platform.getReviewDiff()
     const pr = await this.platform.getReviewInfo()
-    let dsl = new DangerDSL(pr, git)
+    const dsl = new DangerDSL(pr, git)
     const dangerfile = new Dangerfile(dsl)
     dangerfile.run("dangerfile.js")
   }


### PR DESCRIPTION
Some files already use `const`, but some use `let` nearly exclusive. Eslint offers the `prefer const` which detects possible constant values. This PR introduces the rule and fixes all reported violations.


I've created two separated commits for:
- introducing the rule
- fixing the issues


Should I squash them together?