### PR TITLE
Run the CI on all active node release lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
-  - "6.1"
+  - "4"
+  - "6"
+  - "7"
+  - "node"
 
 script:
   - npm test

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 //  Add your own contribution below
 
+* Travis CI uses all active release lines against the change/ PR
 * Danger will post a comment on a GitHub PR with any Fails - orta
 
 ### 0.0.2 


### PR DESCRIPTION
This commit allows Travis CI to run the tests on all active release lines to make sure that there are no changes between the different versions that affect danger. On the other hand, the CI run takes a little bit longer.
