### PR TITLE
emit console error if `DANGER_GITHUB_API_TOKEN` is not set.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,13 +2,15 @@
 
 //  Add your own contribution below
 
+* Improved error messaging around not including a `DANGER_GITHUB_API_TOKEN` in the ENV - nsfmc / orta
+
 ### 0.6.3
 
 * Does not break commonmark on GitHub - orta
-* upgrades to flow 0.35.0 and fixes associated type errors in covariant/invariant interfaces
-* omits flow requirement for new test files
-* adds support for circleci
-* defines CISource properties in flow as read-only
+* upgrades to flow 0.35.0 and fixes associated type errors in covariant/invariant interfaces - nsfmc 
+* omits flow requirement for new test files - nsfmc
+* adds support for circleci - nsfmc
+* defines CISource properties in flow as read-only - nsfmc
 
 ### 0.5.0
 

--- a/source/platforms/_tests/platform.test.js
+++ b/source/platforms/_tests/platform.test.js
@@ -1,0 +1,9 @@
+// @flow
+
+import { getPlatformForEnv } from "../platform"
+
+it("should bail if there is no DANGER_GITHUB_API_TOKEN found", () => {
+  expect(() => {
+    getPlatformForEnv({}, {})
+  }).toThrow("Cannot use authenticated API requests")
+})

--- a/source/platforms/platform.js
+++ b/source/platforms/platform.js
@@ -69,7 +69,12 @@ import { GitHub } from "./GitHub"
  * @returns {?Platform} returns a platform if it can be supported
 */
 export function getPlatformForEnv(env: Env, source: CISource): ?Platform {
-  const github = new GitHub(env["DANGER_GITHUB_API_TOKEN"], source)
+  const token = env["DANGER_GITHUB_API_TOKEN"]
+  if (!token) {
+    console.error("The DANGER_GITHUB_API_TOKEN environmental variable is missing")
+    console.error("Without an api token, danger will be unable to comment on a PR")
+  }
+  const github = new GitHub(token, source)
   return github
 }
 

--- a/source/platforms/platform.js
+++ b/source/platforms/platform.js
@@ -73,8 +73,9 @@ export function getPlatformForEnv(env: Env, source: CISource): ?Platform {
   if (!token) {
     console.error("The DANGER_GITHUB_API_TOKEN environmental variable is missing")
     console.error("Without an api token, danger will be unable to comment on a PR")
+    throw new Error("Cannot use authenticated API requests.")
   }
+
   const github = new GitHub(token, source)
   return github
 }
-


### PR DESCRIPTION
Without this, danger will appear to fail because it is unable to
execute `.find()` within the PR's comments, this at least 
explains the root cause.