### PR TITLE
Use multiple node instances in the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: node_js
-node_js:
-  - "6.1"
-
+matrix:
+  include:
+    - node_js: "node"
+      before_script:
+        - npm run build
+        - npm run link
+        - danger
+    - node_js: "6"
+    - node_js: "7"
+ 
 script:
   - npm test
-  - npm run build
-  - npm run link
-  - danger
-
-after_script:
   - npm run flow
   - npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: node_js
+
+cache:
+  yarn: true
+  directories:
+    - node_modules
+
 matrix:
   include:
     - node_js: "node"

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 //  Add your own contribution below
 
+* Adds more node instances to travis - romanki + orta
+
 ### 0.6.4
 
 * The env vars `DANGER_TEST_REPO` and `DANGER_TEST_PR` will allow you initialize the FakeCI with a repo of your choice. See README.md for more info


### PR DESCRIPTION
Supercedes #25 - thanks @romanki 

Main difference are:
 * the removeal of node 4, will poke someone in artsy about what's going on there. 
 * it only runs `danger` on our repo once.
 * flow / lint can now fail the build