### PR TITLE
Adds support for shipping the danger annotations during publishing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 //  Add your own contribution below
 
+### 0.6.6
+
+* Ship flow annotations with the npm module - orta
+
 ### 0.6.5
 
 * Adds more node instances to travis - romanki + orta

--- a/package.json
+++ b/package.json
@@ -19,11 +19,12 @@
     "flow": "flow check",
     "lint": "eslint ./source",
     "fix": "eslint ./source --fix",
-    "prepublish": "npm run build",
+    "prepublish": "npm run build; npm run export-flowtype; npm run inline-flowtype",
     "build": "babel source --out-dir distribution --source-maps",
     "buildwatch": "babel source --watch --out-dir distribution",
     "link": "npm run build ; chmod +x distribution/commands/danger.js ; npm link",
-    "export-flowtype": "node scripts/create-flow-typed-export.js"
+    "export-flowtype": "node scripts/create-flow-typed-export.js",
+    "inline-flowtype": "cp flow-typed/npm/danger_v0.x.x.js distribution/danger.js.flow"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "flow": "flow check",
     "lint": "eslint ./source",
     "fix": "eslint ./source --fix",
-    "prepublish": "npm run build; npm run export-flowtype; npm run inline-flowtype",
+    "prepublish": "in-publish && npm run build && npm run export-flowtype && npm run inline-flowtype || not-in-publish",
     "build": "babel source --out-dir distribution --source-maps",
     "buildwatch": "babel source --watch --out-dir distribution",
     "link": "npm run build ; chmod +x distribution/commands/danger.js ; npm link",
@@ -57,6 +57,7 @@
     "eslint-plugin-promise": "^3.4.0",
     "eslint-plugin-standard": "^2.0.0",
     "flow-bin": "^0.35.0",
+    "in-publish": "^2.0.0",
     "jest-cli": "^17.0.3"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1608,6 +1608,10 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
+in-publish@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/in-publish/-/in-publish-2.0.0.tgz#e20ff5e3a2afc2690320b6dc552682a9c7fadf51"
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"


### PR DESCRIPTION
This _should_ provide typings for danger, without flow-install, I believe.

It's based on the technique used by [GraphQL team](https://github.com/graphql/graphql-js/blob/master/package.json#L31) which is to just ship their actual source (with normal flow annotations) alongside the babel derived sources for consuming in node. Clever.

So in this case, instead of the file generated to ship to flow-typed  which typically looks like

![screen shot 2016-12-14 at 9 23 51 am](https://cloud.githubusercontent.com/assets/49038/21185537/0f5b1768-c1df-11e6-8780-f2eb6ded8167.png)

it is passed along into the npm module.