### PR TITLE
Ship the types, in a way that works with both VS Code and Atom

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 //  Add your own contribution below
 
-### 0.6.6 - 0.6.7
+### 0.6.6 - 0.6.7 - 0.6.8
 
 * Ship flow annotations with the npm module - orta
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danger",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Unit tests for Team Culture",
   "main": "distribution/danger.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -19,12 +19,11 @@
     "flow": "flow check",
     "lint": "eslint ./source",
     "fix": "eslint ./source --fix",
-    "prepublish": "in-publish && npm run build && npm run export-flowtype && npm run inline-flowtype || not-in-publish",
+    "prepublish": "in-publish && npm run build && npm run export-flowtype || not-in-publish",
     "build": "babel source --out-dir distribution --source-maps",
     "buildwatch": "babel source --watch --out-dir distribution",
     "link": "npm run build ; chmod +x distribution/commands/danger.js ; npm link",
-    "export-flowtype": "node scripts/create-flow-typed-export.js",
-    "inline-flowtype": "cp flow-typed/npm/danger_v0.x.x.js distribution/danger.js"
+    "export-flowtype": "node scripts/create-flow-typed-export.js"
   },
   "repository": {
     "type": "git",

--- a/source/danger.js
+++ b/source/danger.js
@@ -2,4 +2,4 @@
 // This file represents the module that is exposed as the danger API
 import "babel-polyfill"
 
-// Decide what to do with this file in the future.
+// Empty on purpose


### PR DESCRIPTION
Third time lucky - should work with both atom and vscode now.