### PR TITLE
Add tests directory to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 source
+**/_tests

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 //  Add your own contribution below
 
+* Add tests directory to .npmignore - macklinu
+
 ### 0.6.10
 
 * Brings back the ability to emulate a fake CI run locally via `danger` - orta


### PR DESCRIPTION
Resolves #42

Checking out the codebase and hoping to get involved, wanted to help resolve a simple open issue in the process. 😺 

## Testing steps

- Run [`npm pack`](https://docs.npmjs.com/cli/pack)
- Open the resulting tarball. At the time of opening this PR, `tar -xf danger-0.6.10.tgz`
- Inspect the `package/` directory (the unzipped tarball) and ensure there are no test files or directories

Running through the steps on master and inspecting the output: 

```
$ find package/ -type d -name "_tests" -print
package//distribution/ci_source/_tests
```

And the result of running through the steps on this branch:

```
$ find package/ -type d -name "_tests" -print
# no results
```