### PR TITLE
Set exit code to 1 when error running Dangerfile

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 //  Add your own contribution below
 
+* Set exit code to 1 when running `danger` throws an error - macklinu
+
 ### 0.7.0
 
 

--- a/source/commands/danger-run.js
+++ b/source/commands/danger-run.js
@@ -40,6 +40,7 @@ if (source && source.isPR) {
       const exec = new Executor(source, platform)
       exec.runDanger()
     } catch (error) {
+      process.exitCode = 1
       console.error(error.message)
       console.error(error)
     }


### PR DESCRIPTION
Resolves #50 

@orta I wasn't sure how to test this. `danger-run.js` is more of a script than something that can be imported and unit tested individually. Any thoughts on adding integration tests for a scenario like this? Not sure what that would look like (maybe use something like [bats](https://github.com/sstephenson/bats)). Might also be overkill here and wondering what your thoughts are.