### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 //  Add your own contribution below
 
+* Add .editorconfig - macklinu
+
 ### 0.7.0
 
 


### PR DESCRIPTION
http://editorconfig.org/

I found during development that ESLint would want me to remove trailing whitespace and use a 2 space indent, and I'm used to an `.editorconfig` helping enforce that when a file is saved (that way you don't have to think about it). Thought I'd bring it in here to help support the code style across IDEs (I'm trying out VSCode for now, but EditorConfig is supported by many IDEs). 📔 