### PR TITLE
Include the jest-runtime dep and prepare for deploy of 0.7.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,12 +2,14 @@
 
 //  Add your own contribution below
 
+### 0.7.1
+
 * Set exit code to 1 when running `danger` throws an error - macklinu
 * Add Jenkins CI source - macklinu
 * Add .editorconfig - macklinu
+* Adds jest-runtime to the dependencies - orta
 
 ### 0.7.0
-
 
 * You can build and run in vscode using your own custom `env/development.env` file. This is useful because you can use the debugger against a real PR. See `env/development.env.example` for syntax.  - orta
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danger",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Unit tests for Team Culture",
   "main": "distribution/danger.js",
   "bin": {
@@ -54,13 +54,14 @@
     "eslint-plugin-flowtype": "^2.25.0",
     "eslint-plugin-promise": "^3.4.0",
     "eslint-plugin-standard": "^2.0.0",
-    "jest": "^18.0.0",
     "flow-bin": "^0.35.0",
-    "in-publish": "^2.0.0"
+    "in-publish": "^2.0.0",
+    "jest": "^18.0.0"
   },
   "dependencies": {
     "babel-polyfill": "^6.16.0",
     "commander": "^2.9.0",
+    "jest-runtime": "^18.0.0",
     "node-fetch": "^1.6.3",
     "parse-diff": "^0.4.0"
   }


### PR DESCRIPTION
Oops! All my projects use Jest so I never noticed it wasn't including the dependency.