### PR TITLE
Remove danger imports in dangerfiles

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,7 +2,7 @@
 distribution
 .*/_tests/.*
 .*dangerfile.js
-node_modules/jest*
+node_modules/jest*/**/**
 
 [include]
 

--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,7 @@ docs
 .editorconfig
 .babelrc
 scripts
+dangerfile.js
+env
+.eslintrc.json
+jsconfig.json

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 //  Add your own contribution below
 
+### 0.7.4
+
+* Fix Dangerfile parsing which broke due to Peril related changes - orta
+
 ### 0.7.3
 
 * Tweak the npmignore, ship less random stuff to others - orta

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 //  Add your own contribution below
 
-### 0.7.2
+### 0.7.3
 
 * Tweak the npmignore, ship less random stuff to others - orta
 

--- a/source/dsl/GitHubDSL.js
+++ b/source/dsl/GitHubDSL.js
@@ -187,6 +187,60 @@ export interface GitHubPRDSL {
    * The User who submitted the PR
    * @type {GitHubUser}
    */
-  user: GitHubUser
+  user: GitHubUser,
+
+  /**
+   * The User who is assigned the PR
+   * @type {GitHubUser}
+   */
+  assignee: GitHubUser,
+
+  /**
+   * The Users who are assigned to the PR
+   * @type {GitHubUser}
+   */
+  assignees: GitHubUser[],
+
+  /**
+   * Has the PR been merged yet
+   * @type {boolean}
+   */
+  merged: boolean,
+
+   /**
+   * The nuber of comments on the PR
+   * @type {number}
+   */
+  comments: number,
+
+  /**
+   * The nuber of review-specific comments on the PR
+   * @type {number}
+   */
+  review_comments: number,
+
+  /**
+   * The number of commits in the PR
+   * @type {number}
+   */
+  commits: number,
+
+  /**
+   * The number of additional lines in the PR
+   * @type {number}
+   */
+  additions: number,
+
+  /**
+   * The number of deleted lines in the PR
+   * @type {number}
+   */
+  deletions: number,
+
+  /**
+   * The number of changed files in the PR
+   * @type {number}
+   */
+  changed_files: number,
 }
 

--- a/source/runner/DangerfileRunner.js
+++ b/source/runner/DangerfileRunner.js
@@ -3,6 +3,7 @@
 import Runtime from "jest-runtime"
 import NodeEnvironment from "jest-environment-node"
 import os from "os"
+import fs from "fs"
 
 import type { DangerResults } from "../dsl/DangerResults"
 import type { DangerContext } from "../runner/Dangerfile"
@@ -12,7 +13,7 @@ import type { DangerfileRuntimeEnv, Environment, Path } from "./types"
  * Executes a Dangerfile at a specific path, with a context.
  * The values inside a Danger context are applied as globals to the Dangerfiles runtime.
  *
- * @param {DangerContext} dangerfileContext the gloabl danger context
+ * @param {DangerContext} dangerfileContext the global danger context
  * @returns {any} the results of the run
  */
 export async function createDangerfileRuntimeEnvironment(dangerfileContext: DangerContext): Promise<DangerfileRuntimeEnv> {
@@ -69,7 +70,30 @@ export async function createDangerfileRuntimeEnvironment(dangerfileContext: Dang
 export async function runDangerfileEnvironment(filename: Path, environment: DangerfileRuntimeEnv): Promise<DangerResults> {
   const runtime = environment.runtime
   // Require our dangerfile
+
+  updateDangerfile(filename)
   runtime.requireModule(filename)
 
   return environment.context.results
+}
+
+/**
+ * Updates a Dangerfile to remove the import for Danger
+ * @param {string} filename the file path for the dangerfile
+ * @returns {void}
+ */
+export function updateDangerfile(filename: Path) {
+  const contents = fs.readFileSync(filename).toString()
+  fs.writeFileSync(filename, cleanDangerfile(contents))
+}
+
+/**
+ * Updates a Dangerfile to remove the import for Danger
+ * @param {string} contents the file path for the dangerfile
+ * @returns {string} the revised Dangerfile
+ */
+export function cleanDangerfile(contents: string): string {
+  return contents
+           .replace(/import danger /gi, "// import danger ")
+           .replace(/import { danger/gi, "// import { danger")
 }

--- a/source/runner/_tests/DangerRunner.test.js
+++ b/source/runner/_tests/DangerRunner.test.js
@@ -1,10 +1,18 @@
 // @flow
 
 import { contextForDanger } from "../Dangerfile"
-import {createDangerfileRuntimeEnvironment, runDangerfileEnvironment} from "../DangerfileRunner"
+import {
+  createDangerfileRuntimeEnvironment,
+  runDangerfileEnvironment,
+  updateDangerfile,
+  cleanDangerfile
+} from "../DangerfileRunner"
 import Fake from "../../ci_source/Fake"
 import FakePlatform from "../../platforms/FakePlatform"
 import Executor from "../Executor"
+
+import os from "os"
+import fs from "fs"
 
 import { resolve } from "path"
 const fixtures = resolve(__dirname, "fixtures")
@@ -69,5 +77,19 @@ describe("with fixtures", () => {
     const context = await setupDangerfileContext()
     const runtime = await createDangerfileRuntimeEnvironment(context)
     await runDangerfileEnvironment(resolve(fixtures, "__DangerfileImportRelative.js"), runtime)
+  })
+})
+
+describe("cleaning Dangerfiles", () => {
+  it("Supports removing the danger import", () => {
+    const path = resolve(os.tmpdir(), "fake_dangerfile_1")
+    fs.writeFileSync(path, "import { danger, warn, fail, message } from 'danger'")
+    updateDangerfile(path)
+    expect(fs.readFileSync(path).toString()).toEqual("// import { danger, warn, fail, message } from 'danger'")
+  })
+
+  it("also handles typescript style imports", () => {
+    const before = "import danger from 'danger'"
+    expect(cleanDangerfile(before)).toEqual("// import danger from 'danger'")
   })
 })


### PR DESCRIPTION
When you include the `import { danger, warn, fail, message } from 'danger'` for Flow typings, then we need to make sure it gets wiped out. Will also release with this.