### PR TITLE
Display build status code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,11 @@ matrix:
         - danger
     - node_js: "6"
     - node_js: "7"
- 
+
 script:
-  - npm test
+  - npm test -- --coverage
   - npm run flow
   - npm run lint
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/danger/danger-js.svg?branch=master)](https://travis-ci.org/danger/danger-js)
+
 Danger on Node, wonder what's going on? see [VISION.md](VISION.md)
 
 *Welcome!*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/danger/danger-js.svg?branch=master)](https://travis-ci.org/danger/danger-js)
+[![Build Status](https://ci.appveyor.com/api/projects/status/ep5hgeox3lbc5c7f?svg=true)](https://ci.appveyor.com/project/orta/danger-js/branch/master)
 
 Danger on Node, wonder what's going on? see [VISION.md](VISION.md)
 


### PR DESCRIPTION
This PR is very simple chore, enable codecov code coverage (https://codecov.io) in PR, also display travis build status badge in readme document. I couldn't find appveyor project for its badge.

for code coverage, repo owner need to enable it by visiting codecov.io . long term plan is to use danger itself to give coverage threshold warning.