### PR TITLE
Remove flow from CircleCI build config #trivial

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,5 +8,4 @@ test:
     - npm run link
     - danger
   post:
-    - npm run flow
     - npm run lint

--- a/circle.yml
+++ b/circle.yml
@@ -9,3 +9,4 @@ test:
     - danger
   post:
     - npm run lint
+    - npm test

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,15 +1,16 @@
 // import { danger, warn } from "danger"
 import fs from "fs"
 
-// Request a CHANGELOG entry
+// Request a CHANGELOG entry if not declared #trivial
 const hasChangelog = danger.git.modified_files.includes("changelog.md")
-if (!hasChangelog) { warn("Please add a changelog entry for your changes.") }
+const isTrivial = (danger.github.pr.body + danger.github.pr.title).includes("#trivial")
+if (!hasChangelog && !isTrivial) {
+  warn("Please add a changelog entry for your changes.")
 
-// Politely ask for their name on the entry too
-const changelogDiff = danger.git.diffForFile("changelog.md")
-const contributorName = danger.github.pr.user.login
-if (changelogDiff && changelogDiff.indexOf(contributorName) === -1) {
-  warn("Please add your GitHub name to the changelog entry, so we can attribute you.")
+  // Politely ask for their name on the entry too
+  const changelogDiff = danger.git.diffForFile("changelog.md")
+  const contributorName = danger.github.pr.user.login
+  if (changelogDiff && changelogDiff.indexOf(contributorName) === -1) {
+    warn("Please add your GitHub name to the changelog entry, so we can attribute you.")
+  }
 }
-
-const jsFiles = danger.git.created_files.filter(path => path.endsWith("js"))


### PR DESCRIPTION
Should resolve the failing build in https://circleci.com/gh/danger/danger-js/113 after merging #78.

Questions:

- Does a change like this require a Changelog entry?
- Do we want to run the tests on CircleCI as well (before it was just the lint and flow npm tasks)