### PR TITLE
Remove all types of imports/requires

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 * Adds `--verbose` to `danger`, which for now will echo out all the URLs Danger has requested - orta
 * A failing network request will raise an error - orta
 * Migrate codebase into TypeScript from flow - kwonoj
+* Handle removing all sorts  of import types for Danger in the Dangerfile - orta
 
 ### 0.7.3-4
 

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "babel-preset-stage-3": "^6.17.0",
     "husky": "^0.12.0",
     "in-publish": "^2.0.0",
-    "jest": "^18.0.0",
+    "jest": "^18.1.0",
     "lint-staged": "^3.2.5",
     "madge": "^1.4.4",
     "shx": "^0.2.1",

--- a/source/runner/DangerfileRunner.ts
+++ b/source/runner/DangerfileRunner.ts
@@ -85,6 +85,11 @@ export function updateDangerfile(filename: Path) {
   fs.writeFileSync(filename, cleanDangerfile(contents))
 }
 
+// https://regex101.com/r/dUq4yB/1
+const requirePattern = /^.* require\(('|")danger('|")\);?$/gm
+//  https://regex101.com/r/dUq4yB/2
+const es6Pattern = /^.* from ('|")danger('|");?$/gm
+
 /**
  * Updates a Dangerfile to remove the import for Danger
  * @param {string} contents the file path for the dangerfile
@@ -92,6 +97,6 @@ export function updateDangerfile(filename: Path) {
  */
 export function cleanDangerfile(contents: string): string {
   return contents
-    .replace(/import danger /gi, "// import danger ")
-    .replace(/import { danger/gi, "// import { danger")
+    .replace(es6Pattern, "// Removed import")
+    .replace(requirePattern, "// Removed require")
 }

--- a/source/runner/_tests/DangerRunner.test.ts
+++ b/source/runner/_tests/DangerRunner.test.ts
@@ -83,11 +83,40 @@ describe("cleaning Dangerfiles", () => {
     const path = resolve(os.tmpdir(), "fake_dangerfile_1")
     fs.writeFileSync(path, "import { danger, warn, fail, message } from 'danger'")
     updateDangerfile(path)
-    expect(fs.readFileSync(path).toString()).toEqual("// import { danger, warn, fail, message } from 'danger'")
+    expect(fs.readFileSync(path).toString()).toEqual("// Removed import")
   })
 
   it("also handles typescript style imports", () => {
-    const before = "import danger from 'danger'"
-    expect(cleanDangerfile(before)).toEqual("// import danger from 'danger'")
+    const before = `
+import { danger, warn, fail, message } from 'danger'
+import { danger, warn, fail, message } from "danger"
+import { danger, warn, fail, message } from "danger";
+import danger from "danger"
+import danger from 'danger'
+import danger from 'danger';
+`
+    const after = `
+// Removed import
+// Removed import
+// Removed import
+// Removed import
+// Removed import
+// Removed import
+`
+    expect(cleanDangerfile(before)).toEqual(after)
+  })
+
+  it("also handles require style imports", () => {
+        const before = `
+const { danger, warn, fail, message } = require('danger')
+var { danger, warn, fail, message } = require("danger")
+let { danger, warn, fail, message } = require('danger');
+`
+    const after = `
+// Removed require
+// Removed require
+// Removed require
+`
+    expect(cleanDangerfile(before)).toEqual(after)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2218,7 +2218,7 @@ jest-util@^18.1.0:
     jest-mock "^18.0.0"
     mkdirp "^0.5.1"
 
-jest@^18.0.0:
+jest@^18.1.0:
   version "18.1.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-18.1.0.tgz#bcebf1e203dee5c2ad2091c805300a343d9e6c7d"
   dependencies:


### PR DESCRIPTION
I forgot that `require` imports even exist, so when I was creating the Dangerfile for Jest I realized I needed to add this in 👍 

--

Note: Jest is currently infinitely looping on `yarn run jest -- --watch` - I assume it's the code coverage stuff that is triggering a new run, will try dig into it tomorrow.