### PR TITLE
feat(surf): add surf ci provider

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ### master
 
 //  Add your own contribution below
+* Adds surf-build ci provider - kwonoj
 
 ### 0.8.0
 

--- a/source/ci_source/providers/Surf.ts
+++ b/source/ci_source/providers/Surf.ts
@@ -1,0 +1,32 @@
+import { Env, CISource } from "../ci_source"
+import { ensureEnvKeysExist, ensureEnvKeysAreInt } from "../ci_source_helpers"
+
+export class Surf implements CISource {
+  constructor(private readonly env: Env) {
+  }
+
+  get name(): string {
+    return "surf-build"
+  }
+
+  get isCI(): boolean {
+    return ensureEnvKeysExist(this.env, ["SURF_REPO", "SURF_NWO"])
+  }
+
+  get isPR(): boolean {
+    return this.isCI
+  }
+
+  get pullRequestID(): string {
+    const key = "SURF_PR_NUM"
+    return ensureEnvKeysAreInt(this.env, [key]) ? this.env[key] : ""
+  }
+
+  get repoSlug(): string {
+    return this.env["SURF_NWO"]
+  }
+
+  get supportedPlatforms(): string[] {
+    return ["github"]
+  }
+}

--- a/source/ci_source/providers/index.ts
+++ b/source/ci_source/providers/index.ts
@@ -3,8 +3,9 @@ import {Circle} from "./Circle"
 import {Semaphore} from "./Semaphore"
 import {Jenkins} from "./Jenkins"
 import {FakeCI} from "./Fake"
+import {Surf} from "./Surf"
 
-const providers: Array<any> = [Travis, Circle, Semaphore, Jenkins, FakeCI]
+const providers: Array<any> = [Travis, Circle, Semaphore, Jenkins, FakeCI, Surf]
 export {
   providers
 };


### PR DESCRIPTION
This PR adds support to surf-build (https://github.com/surf-build/surf) ci provider.