### PR TITLE
feat(debug): debug module for dump status

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,8 @@
 ### master
 
 //  Add your own contribution below
+* Allow debug dump output via `DEBUG=danger:*` environment variable - kwonoj
 * Adds surf-build ci provider - kwonoj
-
 * Forward environment variable to external module constructor - kwonoj
 
 ### 0.8.0

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   "homepage": "https://github.com/danger/danger-js#readme",
   "devDependencies": {
     "@types/commander": "^2.3.31",
+    "@types/debug": "0.0.29",
     "@types/es6-promise": "0.0.32",
     "@types/jest": "^16.0.3",
     "@types/node-fetch": "^1.6.6",
@@ -96,6 +97,7 @@
   "dependencies": {
     "babel-polyfill": "^6.20.0",
     "commander": "^2.9.0",
+    "debug": "^2.6.0",
     "jest-runtime": "^18.0.0",
     "lodash.find": "^4.6.0",
     "lodash.includes": "^4.3.0",

--- a/source/commands/danger.ts
+++ b/source/commands/danger.ts
@@ -3,9 +3,13 @@
 // import app from "./app"
 import { version } from "../../package.json"
 import * as program from "commander"
+import * as debug from "debug"
+
+const d = debug("danger:runner")
+
+d(`argv: ${process.argv}`)
 
 // Provides the root node to the command-line architecture
-
 program
   .version(version)
   .command("run", "Runs danger on your local system", {isDefault: true})

--- a/source/runner/Executor.ts
+++ b/source/runner/Executor.ts
@@ -6,10 +6,12 @@ import { DangerResults } from "../dsl/DangerResults"
 import { template as githubResultsTemplate } from "./templates/github-issue-template"
 import { createDangerfileRuntimeEnvironment, runDangerfileEnvironment } from "./DangerfileRunner"
 import { DangerfileRuntimeEnv } from "./types"
-
+import * as debug from "debug"
 // This is still badly named, maybe it really should just be runner?
 
 export class Executor {
+  private readonly d = debug("danger:executor")
+
   constructor(public readonly ciSource: CISource, public readonly platform: Platform) {
   }
 
@@ -69,6 +71,8 @@ export class Executor {
 
     const failureCount = [...fails, ...warnings].length
     const messageCount = [...messages, ...markdowns].length
+
+    this.d(results)
 
     if (failureCount + messageCount === 0) {
       console.log("No messages are collected.")


### PR DESCRIPTION
This PR allows to debug dump if needed, by setting `DEBUG` environment. As this PR uses prefix `danger:`, running 

`DEBUG=danger:* danger` 

will output all debug dump specified.