### PR TITLE
feat(danger): support custom dangerfile name

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ### master
 
 //  Add your own contribution below
+* Support custom dangerfile via `-d` commandline arg - kwonoj
 * Allow debug dump output via `DEBUG=danger:*` environment variable - kwonoj
 * Adds surf-build ci provider - kwonoj
 * Forward environment variable to external module constructor - kwonoj


### PR DESCRIPTION
This PR adds one additional commandline arg `-d`, allow to specify specific path / name of dangerfile other than default one. Additionally, it'll check if given / default dangerfile exists before excutes.