### PR TITLE
feat(template): provides message summary on top of comment

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 //  Add your own contribution below
 
+* Add summary comment for danger message - kwonoj
+
 ### 0.9.0
 
 * Adds support for `git.commits` and `github.commits` - orta

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "lodash.find": "^4.6.0",
     "lodash.includes": "^4.3.0",
     "node-fetch": "^1.6.3",
-    "parse-diff": "^0.4.0"
+    "parse-diff": "^0.4.0",
+    "voca": "^1.2.0"
   }
 }

--- a/source/ambient.d.ts
+++ b/source/ambient.d.ts
@@ -4,5 +4,6 @@ declare module "lodash.includes";
 declare module "lodash.find";
 declare module "jest-runtime";
 declare module "jest-environment-node";
+declare module "voca";
 
 declare module "*/package.json";

--- a/source/runner/_tests/fixtures/ExampleDangerResults.ts
+++ b/source/runner/_tests/fixtures/ExampleDangerResults.ts
@@ -20,3 +20,10 @@ export const failsResults: DangerResults = {
   messages: [],
   markdowns: []
 }
+
+export const summaryResults: DangerResults = {
+  fails: [{ message: "Failing message Failing message" }],
+  warnings: [{ message: "Warning message Warning message" }],
+  messages: [{ message: "message" }],
+  markdowns: ["markdown"],
+}

--- a/source/runner/templates/_tests/github-issue-templates.test.ts
+++ b/source/runner/templates/_tests/github-issue-templates.test.ts
@@ -1,4 +1,4 @@
-import { emptyResults, warnResults, failsResults } from "../../_tests/fixtures/ExampleDangerResults"
+import { emptyResults, warnResults, failsResults, summaryResults } from "../../_tests/fixtures/ExampleDangerResults"
 import { template as githubResultsTemplate } from "../../templates/github-issue-template"
 
 describe("generating messages", () => {
@@ -24,5 +24,19 @@ describe("generating messages", () => {
   it("does not break commonmark rules around line breaks", () => {
     const issues = githubResultsTemplate(warnResults)
     expect(issues).not.toMatch(/(\r?\n){2}[ \t]+</)
+  })
+
+  it("Should include summary on top of message", () => {
+    const issues = githubResultsTemplate(summaryResults)
+    const expected =
+    `
+<!--
+  1 failure:  Failing message F...
+  1 warning:  Warning message W...
+  1 messages
+  1 markdown notices
+-->`
+
+    expect(issues).toContain(expected)
   })
 })

--- a/source/runner/templates/github-issue-template.ts
+++ b/source/runner/templates/github-issue-template.ts
@@ -1,5 +1,6 @@
 import { DangerResults } from "../../dsl/DangerResults"
 import { Violation } from "../../platforms/messaging/violation"
+import * as v from "voca"
 
 /**
  * Converts a set of violations into a HTML table
@@ -28,6 +29,21 @@ function table(name: string, emoji: string, violations: Array<Violation>): strin
 `
 }
 
+function getSummary(label: string, violations: Array<Violation>): string {
+  return violations.map(x => v.truncate(x.message, 20))
+    .reduce((acc, value, idx) => `${acc} ${value}${idx === violations.length - 1 ? "" : ","}`, `${violations.length} ${label}: `)
+}
+
+function buildSummaryMessage(results: DangerResults): string {
+  const {fails, warnings, messages, markdowns } = results
+  const summary =
+`  ${getSummary("failure", fails)}
+  ${getSummary("warning", warnings)}
+  ${messages.length > 0 ? `${messages.length} messages` : ""}
+  ${markdowns.length > 0 ? `${markdowns.length} markdown notices` : ""}`
+  return summary
+}
+
 /**
  * A template function for creating a GitHub issue comment from Danger Results
  * @param {DangerResults} results Data to work with
@@ -35,6 +51,9 @@ function table(name: string, emoji: string, violations: Array<Violation>): strin
  */
 export function template(results: DangerResults): string {
   return `
+<!--
+${buildSummaryMessage(results)}
+-->
 ${table("Fails", "no_entry_sign", results.fails)}
 ${table("Warnings", "warning", results.warnings)}
 ${table("Messages", "book", results.messages)}


### PR DESCRIPTION
This PR adds top-level comment in danger messages to provide short summary, formed as

```
<!--
  x failure:  Failing message F...
  x warning:  Warning message W...
  x messages
  x markdown notices
-->
```

in case of failure / warning message, each individual message's truncated by 20 chars.

- closes #98