### PR TITLE
[Danger Runner] Ensure that Danger does not leave changes to the Dangerfile around

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ then edit the local `Dangerfile.js` and run `yarn run danger pr https://github.c
 
 This will post the results to your console, instead of on the PR itself.
 
+* Danger changes to your Dangerfile are not persisted after the run - orta
 * Add summary comment for danger message - kwonoj
 * Add `jest-environment-node` to the Package.json - orta
 

--- a/source/runner/DangerfileRunner.ts
+++ b/source/runner/DangerfileRunner.ts
@@ -69,10 +69,33 @@ export async function runDangerfileEnvironment(filename: Path, environment: Dang
   const runtime = environment.runtime
   // Require our dangerfile
 
-  updateDangerfile(filename)
-  runtime.requireModule(filename)
+  ensureCleanDangerfile(filename, () => {
+    runtime.requireModule(filename)
+  })
 
   return environment.context.results
+}
+
+/**
+ * Passes in a dangerfile path, will remove any references to import/require `danger`
+ * then runs the internal closure with a "safe" version of the Dangerfile.
+ * Then it will clean itself up afterwards, and use the new version.
+ * 
+ * Note: We check for equality to not trigger the jest watcher for tests.
+ *
+ * @param {string} filename the file path for the dangerfile
+ * @param {Function} closure code to run with a cleaned Dangerfile
+ * @returns {void} 
+ */
+function ensureCleanDangerfile(filename: string, closure: Function) {
+  const originalContents = fs.readFileSync(filename).toString()
+  updateDangerfile(filename)
+
+  closure()
+
+  if (originalContents !== fs.readFileSync(filename).toString()) {
+    fs.writeFileSync(filename, originalContents)
+  }
 }
 
 /**


### PR DESCRIPTION
An implementation detail of Danger requires that we "sanitize" the dangerfile to not include a reference to danger as an import. Realistically though, if you want awesome tooling as a user then you need to have that include for the global imports.

So now running `danger pr` or doing the [manual route](https://github.com/danger/danger-js#runningtesting-manually-against-a-repo) won't change your `Dangerfile.js`.