### PR TITLE
Add danger pr VSCode debug configuration #trivial

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,14 +22,16 @@
         "outFiles": [
           "${workspaceRoot}/distribution"
         ]
-    },
-    {
-        "name": "Launch Local",
+    }, {
+        "name": "Launch PR",
         "type": "node",
         "request": "launch",
-        "program": "${workspaceRoot}/source/commands/danger-local.js",
+        "program": "${workspaceRoot}/distribution/commands/danger-pr.js",
         "stopOnEntry": false,
-        "args": [],
+        "args": [
+          // pass a GitHub PR URL below for testing
+        ],
+        "envFile": "${workspaceRoot}/env/development.env",
         "cwd": "${workspaceRoot}",
         "preLaunchTask": "build",
         "runtimeExecutable": null,
@@ -42,8 +44,8 @@
         "console": "internalConsole",
         "sourceMaps": true,
         "outFiles": [
-          "${workspaceRoot}/distribution"
-        ],
+          "${workspaceRoot}/distribution/**/*.js"
+        ]
     }, {
         "name": "Run Tests With Debugger (slower, use npm run watch for normal work)",
         "type": "node",


### PR DESCRIPTION
I'm getting more familiar with VSCode and got a `danger pr` debug configuration going in `launch.json`. 📟 

![image](https://cloud.githubusercontent.com/assets/2344137/22276158/bd527cb0-e27f-11e6-93c5-1ab34f8cd6ad.png)
