### PR TITLE
Don't output table if no violations are specified

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 //  Add your own contribution below
 
-* Add support for failing the build without outputting any text - mxstbr
+* Builds which only use markdown now only show the markdown, and no violations table is shown - mxstbr
 
 ### 0.10.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,11 +2,13 @@
 
 //  Add your own contribution below
 
+* Add support for failing the build without outputting any text - mxstbr
+
 ### 0.10.0
 
 * Adds support for running Danger against a PR locally - orta
 
-The workflow is that you find a PR that exhibits the behavior you'd like Danger to run against, 
+The workflow is that you find a PR that exhibits the behavior you'd like Danger to run against,
 then edit the local `Dangerfile.js` and run `yarn run danger pr https://github.com/facebook/jest/pull/2629`.
 
 This will post the results to your console, instead of on the PR itself.
@@ -19,8 +21,8 @@ This will post the results to your console, instead of on the PR itself.
 
 * Adds support for `git.commits` and `github.commits` - orta
 
-  Why two? Well github.commits contains a bunch of github specific metadata ( e.g. GitHub user creds, 
-  commit comment counts. ) Chances are, you're always going to use `git.commits` however if you 
+  Why two? Well github.commits contains a bunch of github specific metadata ( e.g. GitHub user creds,
+  commit comment counts. ) Chances are, you're always going to use `git.commits` however if you
   want more rich data, the GitHub one is available too. Here's an example:
 
 ```js

--- a/source/runner/_tests/fixtures/ExampleDangerResults.ts
+++ b/source/runner/_tests/fixtures/ExampleDangerResults.ts
@@ -7,6 +7,13 @@ export const emptyResults: DangerResults = {
   markdowns: []
 }
 
+export const resultsWithoutMessages: DangerResults = {
+  fails: [{}],
+  warnings: [{}],
+  messages: [{}],
+  markdowns: [{}]
+}
+
 export const warnResults: DangerResults = {
   fails: [],
   warnings: [{ message: "Warning message" }],

--- a/source/runner/_tests/fixtures/ExampleDangerResults.ts
+++ b/source/runner/_tests/fixtures/ExampleDangerResults.ts
@@ -7,11 +7,11 @@ export const emptyResults: DangerResults = {
   markdowns: []
 }
 
-export const resultsWithoutMessages: DangerResults = {
-  fails: [{}],
-  warnings: [{}],
-  messages: [{}],
-  markdowns: [{}]
+export const failsResultsWithoutMessages: DangerResults = {
+  fails: [{}, {}],
+  warnings: [],
+  messages: [],
+  markdowns: []
 }
 
 export const warnResults: DangerResults = {

--- a/source/runner/templates/_tests/github-issue-templates.test.ts
+++ b/source/runner/templates/_tests/github-issue-templates.test.ts
@@ -1,4 +1,4 @@
-import { emptyResults, resultsWithoutMessages, warnResults, failsResults, summaryResults } from "../../_tests/fixtures/ExampleDangerResults"
+import { emptyResults, failsResultsWithoutMessages, warnResults, failsResults, summaryResults } from "../../_tests/fixtures/ExampleDangerResults"
 import { template as githubResultsTemplate } from "../../templates/github-issue-template"
 
 describe("generating messages", () => {
@@ -10,7 +10,7 @@ describe("generating messages", () => {
   })
 
   it("shows no tables for results without messages", () => {
-    const issues = githubResultsTemplate(resultsWithoutMessages)
+    const issues = githubResultsTemplate(failsResultsWithoutMessages)
     expect(issues).not.toContain("Fails")
     expect(issues).not.toContain("Warnings")
     expect(issues).not.toContain("Messages")

--- a/source/runner/templates/_tests/github-issue-templates.test.ts
+++ b/source/runner/templates/_tests/github-issue-templates.test.ts
@@ -1,9 +1,16 @@
-import { emptyResults, warnResults, failsResults, summaryResults } from "../../_tests/fixtures/ExampleDangerResults"
+import { emptyResults, resultsWithoutMessages, warnResults, failsResults, summaryResults } from "../../_tests/fixtures/ExampleDangerResults"
 import { template as githubResultsTemplate } from "../../templates/github-issue-template"
 
 describe("generating messages", () => {
   it("shows no tables for empty results", () => {
     const issues = githubResultsTemplate(emptyResults)
+    expect(issues).not.toContain("Fails")
+    expect(issues).not.toContain("Warnings")
+    expect(issues).not.toContain("Messages")
+  })
+
+  it("shows no tables for results without messages", () => {
+    const issues = githubResultsTemplate(resultsWithoutMessages)
     expect(issues).not.toContain("Fails")
     expect(issues).not.toContain("Warnings")
     expect(issues).not.toContain("Messages")

--- a/source/runner/templates/github-issue-template.ts
+++ b/source/runner/templates/github-issue-template.ts
@@ -11,7 +11,7 @@ import * as v from "voca"
  * @returns {string} HTML
  */
 function table(name: string, emoji: string, violations: Array<Violation>): string {
-  if (violations.length === 0 || (violations.length === 1 && !violations[0].message)) { return "" }
+  if (violations.length === 0 || violations.every(violation => !violation.message)) { return "" }
   return `
 <table>
   <thead>

--- a/source/runner/templates/github-issue-template.ts
+++ b/source/runner/templates/github-issue-template.ts
@@ -11,7 +11,7 @@ import * as v from "voca"
  * @returns {string} HTML
  */
 function table(name: string, emoji: string, violations: Array<Violation>): string {
-  if (violations.length === 0) { return "" }
+  if (violations.length === 0 || (violations.length === 1 && !violations[0].message)) { return "" }
   return `
 <table>
   <thead>


### PR DESCRIPTION
Right now when using `fail` just to fail the build, but not to output
any information (i.e. just using `fail()`), Danger outputs an empty
table with a message of "undefined", which is annoying. (see #109 for
context)

I _think_ this fixes it, but I'm not sure if it's the right fix and/or
if there's a better way to do it. Please let me know!