### PR TITLE
Enable jsdoc-format lint rule

### DIFF
--- a/source/ci_source/ci_source.ts
+++ b/source/ci_source/ci_source.ts
@@ -3,7 +3,7 @@ export type Env = any
 
 /** The shape of an object that represents an individual CI */
 export interface CISource {
-  //** The project name, mainly for showing errors */
+  /** The project name, mainly for showing errors */
   readonly name: string
 
   /** Does this validate as being on a particular CI? */

--- a/source/ci_source/ci_source_helpers.ts
+++ b/source/ci_source/ci_source_helpers.ts
@@ -5,7 +5,7 @@ import { Env } from "./ci_source"
  * @param {Env} env The environment.
  * @param {[string]} keys Keys to ensure existence of
  * @returns {bool} true if they exist, false if not
-*/
+ */
 export function ensureEnvKeysExist(env: Env, keys: Array<string>): boolean {
   /*const hasKeys = keys.map((key: string): boolean => {
     return env.hasOwnProperty(key) && env[key] != null && env[key].length > 0
@@ -21,7 +21,7 @@ export function ensureEnvKeysExist(env: Env, keys: Array<string>): boolean {
  * @param {Env} env The environment.
  * @param {[string]} keys Keys to ensure existence and number-ness of
  * @returns {bool} true if they are all good, false if not
-*/
+ */
 export function ensureEnvKeysAreInt(env: Env, keys: Array<string>): boolean {
   /*const hasKeys = keys.map((key: string): boolean => {
     return env.hasOwnProperty(key) && !isNaN(parseInt(env[key]))

--- a/source/ci_source/get_ci_source.ts
+++ b/source/ci_source/get_ci_source.ts
@@ -8,7 +8,7 @@ import { Env, CISource } from "./ci_source"
  * sources if they can be represented in this environment.
  * @param {Env} env The environment.
  * @returns {?CISource} a CI source if it's OK, otherwise Danger can't run.
-*/
+ */
 export function getCISourceForEnv(env: Env): CISource | undefined {
   const availableProviders = [...providers as any]
     .map(Provider => new Provider(env))

--- a/source/dsl/GitHubDSL.ts
+++ b/source/dsl/GitHubDSL.ts
@@ -106,13 +106,13 @@ export interface GitHubPRDSL {
   merged: boolean
 
   /**
-  * The nuber of comments on the PR
-  * @type {number}
-  */
+   * The number of comments on the PR
+   * @type {number}
+   */
   comments: number
 
   /**
-   * The nuber of review-specific comments on the PR
+   * The number of review-specific comments on the PR
    * @type {number}
    */
   review_comments: number

--- a/source/platforms/platform.ts
+++ b/source/platforms/platform.ts
@@ -63,7 +63,7 @@ export interface Platform {
  * @param {Env} env The environment.
  * @param {CISource} source The existing source, to ensure they can run against each other
  * @returns {Platform} returns a platform if it can be supported
-*/
+ */
 export function getPlatformForEnv(env: Env, source: CISource): Platform {
   const token = env["DANGER_GITHUB_API_TOKEN"]
   if (!token) {

--- a/source/runner/Executor.ts
+++ b/source/runner/Executor.ts
@@ -46,9 +46,10 @@ export class Executor {
     await this.handleResults(results)
   }
 
-  /** Sets up all the related objects for running the Dangerfile
-  * @returns {void} It's a promise, so a void promise
-  */
+  /**
+   * Sets up all the related objects for running the Dangerfile
+   * @returns {void} It's a promise, so a void promise
+   */
   async dslForDanger(): Promise<DangerDSL> {
     const git = await this.platform.getReviewDiff()
     const platformDSL = await this.platform.getPlatformDSLRepresentation()

--- a/source/runner/_tests/DangerRunner.test.ts
+++ b/source/runner/_tests/DangerRunner.test.ts
@@ -18,7 +18,7 @@ const fixtures = resolve(__dirname, "fixtures")
 /**
  * Sets up an example context
  * @returns {Promise<DangerContext>} a context
-*/
+ */
 async function setupDangerfileContext() {
   const platform = new FakePlatform()
   const exec = new Executor(new FakeCI({}), platform)

--- a/tslint.json
+++ b/tslint.json
@@ -5,6 +5,7 @@
     "align": [true, "parameters"],
     "class-name": true,
     "indent": [true, "spaces"],
+    "jsdoc-format": true,
     "max-line-length": [true, 150],
     "no-consecutive-blank-lines": [true],
     "no-trailing-whitespace": true,


### PR DESCRIPTION
https://palantir.github.io/tslint/rules/jsdoc-format/

Thoughts on introducing this lint rule? I also fixed a couple of documentation typos.

#trivial
