### PR TITLE
Add support for `danger pr --repl`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 //  Add your own contribution below
 
+* Add `danger pr --repl`, which drops into a Node.js REPL after evaluating the dangerfile - macklinu
+
 ### 0.11.0 - 0.11.2
 
 * Add support for [Docker Cloud](https://cloud.docker.com) - camacho 

--- a/source/commands/danger-pr.ts
+++ b/source/commands/danger-pr.ts
@@ -1,6 +1,7 @@
 import * as program from "commander"
 import * as debug from "debug"
 import * as fs from "fs"
+import * as repl from "repl"
 import * as jsome from "jsome"
 
 import { FakeCI } from "../ci_source/providers/Fake"
@@ -8,11 +9,13 @@ import { GitHub } from "../platforms/GitHub"
 import { Executor } from "../runner/Executor"
 import { pullRequestParser } from "../platforms/github/pullRequestParser"
 import { runDangerfileEnvironment } from "../runner/DangerfileRunner"
+import { DangerContext } from "../runner/Dangerfile"
 
 const d = debug("danger:pr")
 
 program
-  .option("-d, --dangerfile [filePath]", "Specify custom dangefile other than default dangerfile.js")
+  .option("-d, --dangerfile [filePath]", "Specify custom dangerfile other than default dangerfile.js")
+  .option("-r, --repl", "Drop into a Node REPL after evaluating the dangerfile")
   .parse(process.argv)
 
 const dangerFile = (program as any).dangerfile || "dangerfile.js"
@@ -61,5 +64,43 @@ async function runDanger(source: FakeCI, platform: GitHub, file: string) {
 
   const runtimeEnv = await exec.setupDanger()
   const results = await runDangerfileEnvironment(file, runtimeEnv)
-  jsome(results)
+  if (program["repl"]) {
+    openRepl(runtimeEnv.context)
+  } else {
+    jsome(results)
+  }
+}
+
+function openRepl(dangerContext: DangerContext): void {
+  /**
+   * Injects a read-only, global variable into the REPL
+   *
+   * @param {repl.REPLServer} repl The Node REPL created via `repl.start()`
+   * @param {string} name The name of the global variable
+   * @param {*} value The value of the global variable
+   */
+  function injectReadOnlyProperty(repl: repl.REPLServer, name: string, value: any) {
+    Object.defineProperty(repl["context"], name, {
+      configurable: false,
+      enumerable: true,
+      value
+    })
+  }
+
+  /**
+   * Sets up the Danger REPL with `danger` and `results` global variables
+   *
+   * @param {repl.REPLServer} repl The Node REPL created via `repl.start()`
+   */
+  function setup(repl: repl.REPLServer) {
+    injectReadOnlyProperty(repl, "danger", dangerContext.danger)
+    injectReadOnlyProperty(repl, "results", dangerContext.results)
+  }
+
+  const dangerRepl = repl.start({ prompt: "> " })
+  setup(dangerRepl)
+  dangerRepl.on("exit", () => process.exit())
+  // Called when `.clear` is executed in the Node REPL
+  // This ensures that `danger` and `results` are not cleared from the REPL context
+  dangerRepl.on("reset", () => setup(dangerRepl))
 }


### PR DESCRIPTION
Resolves #21

With the new `--repl` flag

![image](https://cloud.githubusercontent.com/assets/2344137/22490068/fdec4a12-e7e8-11e6-83fb-bde0bf9e2020.png)

Previous behavior remains unchanged (logs `jsome(results)`)

![image](https://cloud.githubusercontent.com/assets/2344137/22490091/1e36cdec-e7e9-11e6-9dd4-30a134c7e191.png)
