### PR TITLE
clarify scripts setup in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,15 @@ yarn add danger --dev
 # or with npm
 npm install --save-dev danger
 ```
+
 If using NPM, add a run command to your `package.json`
 
-```js
-"danger": "danger"
+```json
+{
+  "scripts": {
+    "danger": "danger"  
+  }
+}
 ```
 
 Then create a `dangerfile.js` in the project root with some rules:


### PR DESCRIPTION
This PR clarifies how the run script should be added to package.json, to prevent new folks from mistakenly adding `danger` as a top-level key in the file.