### PR TITLE
Don't export our own promise interfaces to the d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
   "devDependencies": {
     "@types/commander": "^2.3.31",
     "@types/debug": "0.0.29",
-    "@types/es6-promise": "0.0.32",
     "@types/jest": "^18.1.0",
     "@types/node-fetch": "^1.6.6",
     "babel-cli": "^6.16.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "moduleResolution": "node",
     "pretty": true,
     "target": "es5",
-    "outDir": "distribution"
+    "outDir": "distribution",
+    "lib": ["es5", "es2015.promise"]
   },
   "formatCodeOptions": {
     "indentSize": 2,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,10 +12,6 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-0.0.29.tgz#a1e514adfbd92f03a224ba54d693111dbf1f3754"
 
-"@types/es6-promise@0.0.32":
-  version "0.0.32"
-  resolved "https://registry.yarnpkg.com/@types/es6-promise/-/es6-promise-0.0.32.tgz#3bcf44fb1e429f3df76188c8c6d874463ba371fd"
-
 "@types/jest@^18.1.0":
   version "18.1.0"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-18.1.0.tgz#ed18f4c75b3d76de966f543fb6e3bad77d3caa17"


### PR DESCRIPTION
Currently we use the Promise implementation provided by TypeScript for ES2015 support, so don't include references to a different version.