### PR TITLE
Allow access to the issue behind a PR

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danger",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "Unit tests for Team Culture",
   "main": "distribution/danger.js",
   "typings": "distribution/danger.d.ts",

--- a/source/dsl/GitHubDSL.ts
+++ b/source/dsl/GitHubDSL.ts
@@ -150,6 +150,19 @@ export interface GitHubPRDSL {
   assignees: Array<GitHubUser>
 
   /**
+   * The people requested to review this PR
+   * @type {GitHubReview}
+   */
+  requestedReviewers: Array<GitHubUser>
+
+  /**
+   * The reviews left on this pull request
+   * @type {Array<GitHubReview>}
+   * @memberOf GitHubPRDSL
+   */
+  reviews: Array<GitHubReview>
+
+  /**
    * Has the PR been merged yet
    * @type {boolean}
    */
@@ -314,4 +327,48 @@ export interface GitHubMergeRef {
    * @type {string}
    */
   user: GitHubUser
+}
+
+/**
+ * GitHubReview
+ * While a review is pending, it will only have a user.  Once a review is complete, the rest of
+ * the review attributes will be present
+ * @export
+ * @interface GitHubReview
+ */
+export interface GitHubReview {
+  /**
+   * The user requested to review, or the user who has completed the review
+   * @type {GitHubUser}
+   * @memberOf GitHubReview
+   */
+  user: GitHubUser
+  /**
+   * @type {number}
+   * @memberOf GitHubReview
+   */
+  id?: number
+
+  /**
+   * The body of the review
+   * @type {string}
+   * @memberOf GitHubReview
+   */
+  body?: string
+
+  /**
+   * The commit ID this review was made on
+   * @type {string}
+   * @memberOf GitHubReview
+   */
+  commit_id?: string
+
+  /**
+   * The state of the review
+   * APPROVED, REQUEST_CHANGES, COMMENT or PENDING
+   * @type {string}
+   * @memberOf GitHubReview
+   */
+  state?: string
+
 }

--- a/source/dsl/GitHubDSL.ts
+++ b/source/dsl/GitHubDSL.ts
@@ -4,10 +4,60 @@ import { GitCommit } from "./Commit"
 
 /** The GitHub metadata for your PR */
 export interface GitHubDSL {
+  /** The issue metadata for a code review session */
+  issue: GitHubIssue,
   /** The PR metadata for a code review session */
   pr: GitHubPRDSL,
   /** The github commit metadata for a code review session */
   commits: Array<GitHubCommit>
+}
+
+/**
+ * This is `danger.github.issue`
+ * It refers to the issue that makes up the Pull Request
+ * GitHub treats all pull requests as a special type of issue
+ * This DSL contains only parts of the issue that are not found in the PR DSL
+ * A GitHub Issue
+ */
+export interface GitHubIssue {
+  /**
+   * The labels associated with this issue
+   * @type {Array<GitHubIssueLabel>}
+   */
+
+  labels: Array<GitHubIssueLabel>
+}
+
+// Subtypes specific to issues
+
+export interface GitHubIssueLabel {
+  /**
+   * The identifying number of this label
+   * @type {number}
+   * @memberOf GitHubIssueLabel
+   */
+  id: number,
+
+  /**
+   * The URL that links to this label
+   * @type {string}
+   * @memberOf GitHubIssueLabel
+   */
+  url: string,
+
+  /**
+   * The name of the label
+   * @type {string}
+   * @memberOf GitHubIssueLabel
+   */
+  name: string,
+
+  /**
+   * The color associated with this label
+   * @type {string}
+   * @memberOf GitHubIssueLabel
+   */
+  color: string
 }
 
 // This is `danger.github.pr`

--- a/source/platforms/GitHub.ts
+++ b/source/platforms/GitHub.ts
@@ -64,6 +64,9 @@ export class GitHub {
 
   async getIssue(): Promise<GitHubIssue> {
     const issue = await this.api.getIssue()
+    if (!issue) {
+      return { labels: [] }
+    }
     const labels = issue.labels.map((label: any): GitHubIssueLabel => ({
       id: label.id,
       url: label.url,

--- a/source/platforms/GitHub.ts
+++ b/source/platforms/GitHub.ts
@@ -1,6 +1,6 @@
 import { GitDSL } from "../dsl/GitDSL"
 import { GitCommit } from "../dsl/Commit"
-import { GitHubCommit, GitHubDSL } from "../dsl/GitHubDSL"
+import { GitHubCommit, GitHubDSL, GitHubIssue, GitHubIssueLabel } from "../dsl/GitHubDSL"
 import { GitHubAPI } from "./github/GitHubAPI"
 
 import * as parseDiff from "parse-diff"
@@ -62,15 +62,31 @@ export class GitHub {
     }
   }
 
+  async getIssue(): Promise<GitHubIssue> {
+    const issue = await this.api.getIssue()
+    const labels = issue.labels.map((label: any): GitHubIssueLabel => ({
+      id: label.id,
+      url: label.url,
+      name: label.name,
+      color: label.color,
+    }))
+
+    return {
+      labels,
+    }
+  }
+
   /**
    * Returns the `github` object on the Danger DSL
    *
    * @returns {Promise<GitHubDSL>} JSON response of the DSL
    */
   async getPlatformDSLRepresentation(): Promise<GitHubDSL> {
+    const issue = await this.getIssue()
     const pr = await this.getReviewInfo()
     const commits = await this.api.getPullRequestCommits()
     return {
+      issue,
       pr,
       commits
     }

--- a/source/platforms/GitHub.ts
+++ b/source/platforms/GitHub.ts
@@ -1,6 +1,6 @@
 import { GitDSL } from "../dsl/GitDSL"
 import { GitCommit } from "../dsl/Commit"
-import { GitHubCommit, GitHubDSL, GitHubIssue, GitHubIssueLabel } from "../dsl/GitHubDSL"
+import { GitHubPRDSL, GitHubCommit, GitHubDSL, GitHubIssue, GitHubIssueLabel } from "../dsl/GitHubDSL"
 import { GitHubAPI } from "./github/GitHubAPI"
 
 import * as parseDiff from "parse-diff"
@@ -23,9 +23,14 @@ export class GitHub {
    *
    * @returns {Promise<any>} JSON representation
    */
-  async getReviewInfo(): Promise<any> {
+  async getReviewInfo(): Promise<GitHubPRDSL> {
     const deets = await this.api.getPullRequestInfo()
-    return await deets.json()
+
+    return {
+      ...await deets.json(),
+      reviews: await this.api.getReviews(),
+      requestedReviewers: await this.api.getReviewerRequests(),
+    }
   }
 
   /**

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -125,10 +125,14 @@ export class GitHubAPI {
     return []
   }
 
-  getIssue(): Promise<any> {
+  async getIssue(): Promise<any> {
     const repo = this.ciSource.repoSlug
     const prID = this.ciSource.pullRequestID
-    return this.get(`repos/${repo}/issues/${prID}`)
+    const res = await this.get(`repos/${repo}/issues/${prID}`)
+    if (res.ok) {
+      return res.json()
+    }
+    return {}
   }
 
   private api(path: string, headers: any = {}, body: any = {}, method: string): Promise<any> {

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -125,6 +125,12 @@ export class GitHubAPI {
     return []
   }
 
+  getIssue(): Promise<any> {
+    const repo = this.ciSource.repoSlug
+    const prID = this.ciSource.pullRequestID
+    return this.get(`repos/${repo}/issues/${prID}`)
+  }
+
   private api(path: string, headers: any = {}, body: any = {}, method: string): Promise<any> {
     if (this.token !== undefined) {
       headers["Authorization"] = `token ${this.token}`

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -125,6 +125,30 @@ export class GitHubAPI {
     return []
   }
 
+  async getReviewerRequests(): Promise<any> {
+    const repo = this.ciSource.repoSlug
+    const prID = this.ciSource.pullRequestID
+    const res = await this.get(`repos/${repo}/pulls/${prID}/requested_reviewers`, {
+      accept: "application/vnd.github.black-cat-preview+json"
+    })
+    if (res.ok) {
+      return res.json()
+    }
+    return []
+  }
+
+  async getReviews(): Promise<any> {
+    const repo = this.ciSource.repoSlug
+    const prID = this.ciSource.pullRequestID
+    const res = await this.get(`repos/${repo}/pulls/${prID}/reviews`, {
+      accept: "application/vnd.github.black-cat-preview+json"
+    })
+    if (res.ok) {
+      return res.json()
+    }
+    return []
+  }
+
   async getIssue(): Promise<any> {
     const repo = this.ciSource.repoSlug
     const prID = this.ciSource.pullRequestID


### PR DESCRIPTION
Now, users can access `danger.github.issue` to check if labels are applied, etc.

There is not much in an issue that isn't in a PR, so at the moment all the is under `issue` is `labels`.

This has expanded a little and also adds reviews and requested reviews, so users can make sure there is at least x reviewers requested/made

Closes #154 