### PR TITLE
Prepare for v0.12.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 //  Add your own contribution below
 
+### 0.12.0
+
 * Added support for handling async code in a Dangerfile - deecewan
 
   This is still a bit of a work in progress, however, there is a new function added to the DSL: `schedule`.
@@ -29,8 +31,16 @@
   })
   ```
 
+* Adds new GitHub DSL elements - deecewan
+
+ - `danger.github.issue` - As a PR is an issue in GitHub terminology, the issue contains a bit more metadata. Mainly labels, so if you want to know what labels are applied to a PR, use `danger.github.issue.labels`
+ - `danger.github.reviews` - Find out about your reviews in the new GitHub Reviewer systems,
+ - `danger.github.requested_reviewers` - Find out who has been requested to review a PR.
+
 * Updated TypeScript and Jest dependencies - orta
 * Add support for Github Enterprise via DANGER_GITHUB_API_BASE_URL env var - mashbourne
+
+
 
 ### 0.11.3 - 0.11.5
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danger",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "description": "Unit tests for Team Culture",
   "main": "distribution/danger.js",
   "typings": "distribution/danger.d.ts",

--- a/source/dsl/GitHubDSL.ts
+++ b/source/dsl/GitHubDSL.ts
@@ -13,7 +13,7 @@ export interface GitHubDSL {
   /** The reviews left on this pull request */
   reviews: Array<GitHubReview>
   /** The people requested to review this PR */
-  requestedReviewers: Array<GitHubUser>
+  requested_reviewers: Array<GitHubUser>
 }
 
 /**
@@ -296,7 +296,7 @@ export interface GitHubRepo {
 
 export interface GitHubMergeRef {
   /**
-   * The human di 0 . 0splay name for the merge reference, e.g. "artsy:master"
+   * The human display name for the merge reference, e.g. "artsy:master"
    * @type {string}
    */
   label: string

--- a/source/platforms/GitHub.ts
+++ b/source/platforms/GitHub.ts
@@ -96,7 +96,7 @@ export class GitHub {
       pr,
       commits,
       reviews,
-      requestedReviewers
+      requested_reviewers: requestedReviewers
     }
   }
 


### PR DESCRIPTION
@deecewan - I switched `requestedReviewers` to `requested_reviewers` to make it consistent with the rest of the DSL. We'd either have to switch everything to camelCase or leave it as it comes from GitHub as snake_case.