### PR TITLE
Add Drone provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Danger on Node, wonder what's going on? see [VISION.md](VISION.md)
 *Welcome!*
 
 So, what's the deal? Well, right now Danger JS does a lot of the simpler parts of [the Ruby version](http://danger.systems).
-You can look at [Git](https://github.com/danger/danger-js/blob/master/source/dsl/GitDSL.ts) metadata, or [GitHub](https://github.com/danger/danger-js/blob/master/source/dsl/GitHubDSL.ts) metadata on Travis, Circle, Semaphore, Jenkins, Docker Cloud, or Codeship.
+You can look at [Git](https://github.com/danger/danger-js/blob/master/source/dsl/GitDSL.ts) metadata, or [GitHub](https://github.com/danger/danger-js/blob/master/source/dsl/GitHubDSL.ts) metadata on Travis, Circle, Semaphore, Jenkins, Docker Cloud, Codeship or Drone.
 
 Danger can fail your build, write a comment on GitHub, edit it as your PR changes and then delete it once you've passed review. Perfect.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ### master
 
 //  Add your own contribution below
+* Add support for [Drone](http://readme.drone.io) - gabro
 
 ### 0.12.0
 

--- a/source/ci_source/providers/Drone.ts
+++ b/source/ci_source/providers/Drone.ts
@@ -1,0 +1,23 @@
+import { Env, CISource } from "../ci_source"
+import { ensureEnvKeysExist, ensureEnvKeysAreInt } from "../ci_source_helpers"
+
+export class Drone implements CISource {
+  constructor(private readonly env: Env) {
+  }
+
+  get name(): string { return "Drone" }
+
+  get isCI(): boolean {
+    return ensureEnvKeysExist(this.env, ["DRONE"])
+  }
+
+  get isPR(): boolean {
+    const mustHave = ["DRONE", "DRONE_PULL_REQUEST", "DRONE_REPO"]
+    const mustBeInts = ["DRONE_PULL_REQUEST"]
+    return ensureEnvKeysExist(this.env, mustHave) && ensureEnvKeysAreInt(this.env, mustBeInts)
+  }
+
+  get pullRequestID(): string { return this.env.DRONE_PULL_REQUEST }
+  get repoSlug(): string { return this.env.DRONE_REPO }
+  get supportedPlatforms(): string[] { return ["github"] }
+}

--- a/source/ci_source/providers/_tests/_drone.test.ts
+++ b/source/ci_source/providers/_tests/_drone.test.ts
@@ -1,0 +1,78 @@
+import {Drone} from "../Drone"
+import {getCISourceForEnv} from "../../get_ci_source"
+
+const correctEnv = {
+  "DRONE": "true",
+  "DRONE_PULL_REQUEST": "800",
+  "DRONE_REPO": "artsy/eigen"
+}
+
+describe("being found when looking for CI", () => {
+  it("finds Drone with the right ENV", () => {
+    const ci = getCISourceForEnv(correctEnv)
+    expect(ci).toBeInstanceOf(Drone)
+  })
+})
+
+describe(".isCI", () => {
+  test("validates when all Drone environment vars are set", () => {
+    const drone = new Drone(correctEnv)
+    expect(drone.isCI).toBeTruthy()
+  })
+
+  test("does not validate without DRONE", () => {
+    const drone = new Drone({})
+    expect(drone.isCI).toBeFalsy()
+  })
+})
+
+describe(".isPR", () => {
+  test("validates when all Drone environment vars are set", () => {
+    const drone = new Drone(correctEnv)
+    expect(drone.isPR).toBeTruthy()
+  })
+
+  test("does not validate without DRONE_PULL_REQUEST", () => {
+    const drone = new Drone({})
+    expect(drone.isPR).toBeFalsy()
+  })
+
+  const envs = ["DRONE_PULL_REQUEST", "DRONE_REPO"]
+  envs.forEach((key: string) => {
+    let env = {
+      "DRONE": "true",
+      "DRONE_PULL_REQUEST": "800",
+      "DRONE_REPO": "artsy/eigen"
+    }
+    env[key] = null
+
+    test(`does not validate when ${key} is missing`, () => {
+      const drone = new Drone(env)
+      expect(drone.isPR).toBeFalsy()
+    })
+  })
+
+  it("needs to have a PR number", () => {
+    let env = {
+      "DRONE": "true",
+      "DRONE_PULL_REQUEST": "asdasd",
+      "DRONE_REPO": "artsy/eigen"
+    }
+    const drone = new Drone(env)
+    expect(drone.isPR).toBeFalsy()
+  })
+})
+
+describe(".pullRequestID", () => {
+  it("pulls it out of the env", () => {
+    const drone = new Drone(correctEnv)
+    expect(drone.pullRequestID).toEqual("800")
+  })
+})
+
+describe(".repoSlug", () => {
+  it("pulls it out of the env", () => {
+    const drone = new Drone(correctEnv)
+    expect(drone.repoSlug).toEqual("artsy/eigen")
+  })
+})

--- a/source/ci_source/providers/index.ts
+++ b/source/ci_source/providers/index.ts
@@ -6,8 +6,9 @@ import {FakeCI} from "./Fake"
 import {Surf} from "./Surf"
 import {DockerCloud} from "./DockerCloud"
 import {Codeship} from "./Codeship"
+import {Drone} from "./Drone"
 
-const providers: Array<any> = [Travis, Circle, Semaphore, Jenkins, FakeCI, Surf, DockerCloud, Codeship]
+const providers: Array<any> = [Travis, Circle, Semaphore, Jenkins, FakeCI, Surf, DockerCloud, Codeship, Drone]
 export {
   providers
 };


### PR DESCRIPTION
Add support for [Drone](http://readme.drone.io).

Essentially a copy of the Travis provider, with different ENVs.