### PR TITLE
Don't throw on request error / improve api consistency

### DIFF
--- a/source/api/fetch.ts
+++ b/source/api/fetch.ts
@@ -3,7 +3,7 @@ import * as debug from "debug"
 
 const d = debug("danger:networking")
 declare const global: any
-
+let isFirstRequest = true
 /**
  * Adds logging to every fetch request if a global var for `verbose` is set to true
  *
@@ -51,7 +51,11 @@ export function api(url: string | any, init: any): Promise<any> {
   .then(async (response) => {
     // Handle failing errors
     if (!response.ok) {
-      process.exitCode = 1
+      if (isFirstRequest) {
+        process.exitCode = 1
+        isFirstRequest = false
+      }
+
       const responseJSON = await response.json()
       console.warn(`Request failed [${response.status}]: ${response.url}`)
       console.warn(`Response: ${JSON.stringify(responseJSON, null, "  ")}`)

--- a/source/api/fetch.ts
+++ b/source/api/fetch.ts
@@ -55,9 +55,8 @@ export function api(url: string | any, init: any): Promise<any> {
       const responseJSON = await response.json()
       console.error(`Request failed [${response.status}]: ${response.url}`)
       console.error(`Response: ${JSON.stringify(responseJSON, null, "  ")}`)
-      const msg = response.status === 0 ? "Network Error" : response.statusText
-      throw new (Error as any)(response.status, msg, {response: response})
     }
+
     return response
   })
 }

--- a/source/api/fetch.ts
+++ b/source/api/fetch.ts
@@ -53,8 +53,8 @@ export function api(url: string | any, init: any): Promise<any> {
     if (!response.ok) {
       process.exitCode = 1
       const responseJSON = await response.json()
-      console.error(`Request failed [${response.status}]: ${response.url}`)
-      console.error(`Response: ${JSON.stringify(responseJSON, null, "  ")}`)
+      console.warn(`Request failed [${response.status}]: ${response.url}`)
+      console.warn(`Response: ${JSON.stringify(responseJSON, null, "  ")}`)
     }
 
     return response

--- a/source/api/fetch.ts
+++ b/source/api/fetch.ts
@@ -3,7 +3,6 @@ import * as debug from "debug"
 
 const d = debug("danger:networking")
 declare const global: any
-let isFirstRequest = true
 /**
  * Adds logging to every fetch request if a global var for `verbose` is set to true
  *
@@ -51,11 +50,6 @@ export function api(url: string | any, init: any): Promise<any> {
   .then(async (response) => {
     // Handle failing errors
     if (!response.ok) {
-      if (isFirstRequest) {
-        process.exitCode = 1
-        isFirstRequest = false
-      }
-
       const responseJSON = await response.json()
       console.warn(`Request failed [${response.status}]: ${response.url}`)
       console.warn(`Response: ${JSON.stringify(responseJSON, null, "  ")}`)

--- a/source/ci_source/ci_source_helpers.ts
+++ b/source/ci_source/ci_source_helpers.ts
@@ -46,7 +46,7 @@ export async function getPullRequestIDForBranch(source: CISource, env: Env, bran
   if (!token) {
     return 0
   }
-  const api = new GitHubAPI(token, source)
+  const api = new GitHubAPI(source, token)
   const prs = await api.getPullRequests()
   const prForBranch: GitHubPRDSL = prs.find((pr: GitHubPRDSL) => pr.head.ref === branch)
   if (prForBranch) {

--- a/source/ci_source/providers/Fake.ts
+++ b/source/ci_source/providers/Fake.ts
@@ -6,8 +6,8 @@ export class FakeCI implements CISource {
 
   constructor(env: Env) {
     const defaults = {
-      repo: env.DANGER_TEST_REPO || "artsy/emission",
-      pr: env.DANGER_TEST_PR || "327"
+      repo: env.DANGER_TEST_REPO || "artsy/emission", // TODO: default to empty string ?
+      pr: env.DANGER_TEST_PR || "327" // TODO: default to empty string ?
     }
 
     this.env = {...env, ...defaults}

--- a/source/commands/danger-pr.ts
+++ b/source/commands/danger-pr.ts
@@ -37,7 +37,7 @@ if (program.args.length === 0) {
     if (validateDangerfileExists(dangerFile)) {
       d(`executing dangerfile at ${dangerFile}`)
       const source = new FakeCI({ DANGER_TEST_REPO: pr.repo, DANGER_TEST_PR: pr.pullRequestNumber })
-      const api = new GitHubAPI(process.env["DANGER_GITHUB_API_TOKEN"], source)
+      const api = new GitHubAPI(source, process.env["DANGER_GITHUB_API_TOKEN"])
       const platform = new GitHub(api)
       runDanger(source, platform, dangerFile)
     }

--- a/source/platforms/GitHub.ts
+++ b/source/platforms/GitHub.ts
@@ -24,8 +24,7 @@ export class GitHub {
    * @returns {Promise<any>} JSON representation
    */
   async getReviewInfo(): Promise<GitHubPRDSL> {
-    const deets = await this.api.getPullRequestInfo()
-    return await deets.json()
+    return await this.api.getPullRequestInfo()
   }
 
   /**

--- a/source/platforms/GitHub.ts
+++ b/source/platforms/GitHub.ts
@@ -79,8 +79,17 @@ export class GitHub {
    * @returns {Promise<GitHubDSL>} JSON response of the DSL
    */
   async getPlatformDSLRepresentation(): Promise<GitHubDSL> {
-    const issue = await this.getIssue()
     const pr = await this.getReviewInfo()
+    if (pr === {}) {
+      process.exitCode = 1
+      throw `
+        Could not find pull request information,
+        if you are using a private repo then perhaps
+        Danger does not have permission to access that repo.
+      `
+    }
+
+    const issue = await this.getIssue()
     const commits = await this.api.getPullRequestCommits()
     const reviews = await this.api.getReviews()
     const requested_reviewers = await this.api.getReviewerRequests()

--- a/source/platforms/GitHub.ts
+++ b/source/platforms/GitHub.ts
@@ -70,9 +70,7 @@ export class GitHub {
       color: label.color,
     }))
 
-    return {
-      labels,
-    }
+    return { labels }
   }
 
   /**

--- a/source/platforms/GitHub.ts
+++ b/source/platforms/GitHub.ts
@@ -34,11 +34,8 @@ export class GitHub {
    * @returns {Promise<GitDSL>} the git DSL
    */
   async getReviewDiff(): Promise<GitDSL> {
-    const diffReq = await this.api.getPullRequestDiff()
-    const getCommitsResponse = await this.api.getPullRequestCommits()
-    const getCommits = await getCommitsResponse.json()
-
-    const diff = await diffReq.text()
+    const diff = await this.api.getPullRequestDiff()
+    const getCommits = await this.api.getPullRequestCommits()
 
     const fileDiffs: Array<any> = parseDiff(diff)
 
@@ -89,14 +86,14 @@ export class GitHub {
     const pr = await this.getReviewInfo()
     const commits = await this.api.getPullRequestCommits()
     const reviews = await this.api.getReviews()
-    const requestedReviewers = await this.api.getReviewerRequests()
+    const requested_reviewers = await this.api.getReviewerRequests()
 
     return {
       issue,
       pr,
       commits,
       reviews,
-      requested_reviewers: requestedReviewers
+      requested_reviewers
     }
   }
 
@@ -138,7 +135,10 @@ export class GitHub {
    */
   async deleteMainComment(): Promise<boolean> {
     const commentID = await this.api.getDangerCommentID()
-    if (commentID) { await this.api.deleteCommentWithID(commentID) }
+    if (commentID) {
+      await this.api.deleteCommentWithID(commentID)
+    }
+
     return commentID !== null
   }
 

--- a/source/platforms/_tests/GitHub.test.ts
+++ b/source/platforms/_tests/GitHub.test.ts
@@ -14,7 +14,7 @@ const EOL = os.EOL
 const mockGitHubWithGetForPath = (expectedPath): GitHub => {
   const mockSource = new FakeCI({})
 
-  const api = new GitHubAPI("token", mockSource)
+  const api = new GitHubAPI(mockSource)
   const github = new GitHub(api)
 
   api.get = (path: string, headers: any = {}, body: any = {}, method: string = "GET"): Promise<any> => {
@@ -50,7 +50,7 @@ export const requestWithFixturedContent = async (path: string): Promise<any> => 
 describe("with fixtured data", () => {
   it("returns the correct github data", async () => {
     const mockSource = new FakeCI({})
-    const api = new GitHubAPI("token", mockSource)
+    const api = new GitHubAPI(mockSource)
     const github = new GitHub(api)
     api.getPullRequestInfo = await requestWithFixturedJSON("github_pr.json")
     api.getPullRequestCommits = await requestWithFixturedJSON("github_commits.json")
@@ -62,11 +62,13 @@ describe("with fixtured data", () => {
   describe("the dangerfile gitDSL", async () => {
     let github: GitHub = {} as any
     beforeEach(async () => {
-      const api = new GitHubAPI("token", new FakeCI({}))
+      const api = new GitHubAPI(new FakeCI({}))
       github = new GitHub(api)
 
-      api.getPullRequestDiff = await requestWithFixturedContent("github_diff.diff")
-      api.getPullRequestCommits = await requestWithFixturedJSON("github_commits.json")
+      const res = await requestWithFixturedContent("github_diff.diff")
+      api.getPullRequestDiff = res().text
+      const jsonFixtures = await requestWithFixturedJSON("github_commits.json")
+      api.getPullRequestCommits = jsonFixtures().json
     })
 
     it("sets the modified/created/deleted", async () => {

--- a/source/platforms/_tests/fixtures/static_file.json
+++ b/source/platforms/_tests/fixtures/static_file.json
@@ -1,0 +1,3 @@
+{
+  "content": "VGhlIEFsbC1EZWZlY3RvciBpcyBhIHB1cnBvcnRlZCBnbGl0Y2ggaW4gdGhlIERpbGVtbWEgUHJpc29uIHRoYXQgYXBwZWFycyB0byBwcmlzb25lcnMgYXMgdGhlbXNlbHZlcy4gVGhpcyBnb2dvbCBhbHdheXMgZGVmZWN0cywgaGVuY2UgdGhlIG5hbWUu"
+}

--- a/source/platforms/_tests/fixtures/static_file.md
+++ b/source/platforms/_tests/fixtures/static_file.md
@@ -1,1 +1,0 @@
-The All-Defector is a purported glitch in the Dilemma Prison that appears to prisoners as themselves. This gogol always defects, hence the name. 

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -162,7 +162,7 @@ export class GitHubAPI {
     const prID = this.ciSource.pullRequestID
     const res = await this.get(`repos/${repo}/issues/${prID}`)
 
-    return res.ok ? res.json() : {}
+    return res.ok ? res.json() : { labels: [] }
   }
 
   // API Helpers

--- a/source/platforms/github/_tests/_GitHubAPI.test.ts
+++ b/source/platforms/github/_tests/_GitHubAPI.test.ts
@@ -1,6 +1,6 @@
 import { GitHubAPI } from "../GitHubAPI"
 import { FakeCI } from "../../../ci_source/providers/Fake"
-import { requestWithFixturedJSON, requestWithFixturedContent } from "../../_tests/GitHub.test"
+import { requestWithFixturedJSON } from "../../_tests/GitHub.test"
 
 const fetchJSON = (api, params): Promise<any> => {
   return Promise.resolve({
@@ -22,10 +22,8 @@ it("fileContents expects to grab PR JSON and pull out a file API call", async ()
   const mockSource = new FakeCI({})
   const api = new GitHubAPI(mockSource, "token")
 
-  const requestFixture = await requestWithFixturedJSON("github_pr.json")
-  api.getPullRequestInfo = requestFixture().json
-  const fileContentFixture = await requestWithFixturedJSON("static_file.json")
-  api.getFileContents = fileContentFixture().json
+  api.getPullRequestInfo = await requestWithFixturedJSON("github_pr.json")
+  api.getFileContents = await requestWithFixturedJSON("static_file.json")
 
   const info = await api.fileContents("my_path.md")
   expect(info).toEqual("The All-Defector is a purported glitch in the Dilemma Prison that appears to prisoners as themselves. This gogol always defects, hence the name.")//tslint:disable-line:max-line-length

--- a/source/platforms/platform.ts
+++ b/source/platforms/platform.ts
@@ -71,7 +71,7 @@ export function getPlatformForEnv(env: Env, source: CISource): Platform {
     throw new Error("Cannot use authenticated API requests.")
   }
 
-  const api = new GitHubAPI(token, source)
+  const api = new GitHubAPI(source, token)
   const github = new GitHub(api)
   return github
 }


### PR DESCRIPTION
This PR improve consistency in `GithubAPI.ts` and avoid throwing error on fetch but only log a warning if something failed.

Fix: https://github.com/danger/danger-js/issues/170
Fix: https://github.com/danger/danger-js/issues/163