### PR TITLE
Update TS definitions to work correctly on 3rd party repos

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 //  Add your own contribution below
 
-### 0.14.0
+### 0.14.0 - 0.14.1
 
 * TypeScript Dangerfiles are now support in Danger - orta
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danger",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Unit tests for Team Culture",
   "main": "distribution/danger.js",
   "typings": "distribution/danger.d.ts",

--- a/scripts/danger-dts.ts
+++ b/scripts/danger-dts.ts
@@ -26,15 +26,12 @@ const createDTS = () => {
   // we need to add either `declare function` or `declare var` to the interface
   const context = moduleContext.split("\n").map((line: string) => {
     if ((line.length === 0) || (line.includes("*"))) { return line }
-    if (line.includes("(")) { return "  function " + line.trim() }
-    if (line.includes(":")) { return "  const " + line.trim() }
+    if (line.includes("(")) { return "declare function " + line.trim() }
+    if (line.includes(":")) { return "declare const " + line.trim() }
     return ""
   }).join("\n")
 
-  fileOutput += `declare namespace danger {
-  ${context}
-}
-`// last extra line is EOF
+  fileOutput += context
 
   // Remove all JS-y bits
   fileOutput = fileOutput.split("\n").filter((line) => {

--- a/source/danger.d.ts
+++ b/source/danger.d.ts
@@ -147,17 +147,17 @@ export interface GitDSL {
   /**
    * Filepaths with changes relative to the git root
    */
-  readonly modified_files: Readonly<Array<string>>
+  readonly modified_files: Array<string>
 
   /**
    * Newly created filepaths relative to the git root
    */
-  readonly created_files: Readonly<Array<string>>
+  readonly created_files: Array<string>
 
   /**
    * Removed filepaths relative to the git root
    */
-  readonly deleted_files: Readonly<Array<string>>
+  readonly deleted_files: Array<string>
 
   /** Offers the diff for a specific file */
   diffForFile(filename: string): string | null,
@@ -193,7 +193,7 @@ export interface GitDSL {
   JSONDiffForFile(filename: string): Promise<any>,
 
   /** The Git commit metadata */
-  readonly commits: Readonly<Array<GitCommit>>
+  readonly commits: Array<GitCommit>
 }
 // This is `danger.github`
 
@@ -548,54 +548,51 @@ export interface Violation {
    */
   message: string
 }
-
-declare namespace danger {
   /**
    * Contains asynchronous code to be run after the application has booted.
    *
    * @param {Function} asyncFunction the function to run asynchronously
    */
-  function schedule(asyncFunction: (p: Promise<any>) => void): void
+declare function schedule(asyncFunction: (p: Promise<any>) => void): void
 
   /**
    * Fails a build, outputting a specific reason for failing
    *
    * @param {MarkdownString} message the String to output
    */
-  function fail(message: MarkdownString): void
+declare function fail(message: MarkdownString): void
 
   /**
    * Highlights low-priority issues, does not fail the build
    *
    * @param {MarkdownString} message the String to output
    */
-  function warn(message: MarkdownString): void
+declare function warn(message: MarkdownString): void
 
   /**
    * Puts a message inside the Danger table
    *
    * @param {MarkdownString} message the String to output
    */
-  function message(message: MarkdownString): void
+declare function message(message: MarkdownString): void
 
   /**
    * Puts a message inside the Danger table
    *
    * @param {MarkdownString} message the String to output
    */
-  function markdown(message: MarkdownString): void
+declare function markdown(message: MarkdownString): void
 
   /** Typical console */
-  const console: Console
+declare const console: Console
 
   /**
    * The Danger object to work with
    *
    */
-  const danger: DangerDSLType
+declare const danger: DangerDSLType
   /**
    * Results of a Danger run
    *
    */
-  const results: DangerRuntimeContainer
-}
+declare const results: DangerRuntimeContainer

--- a/source/dsl/GitDSL.ts
+++ b/source/dsl/GitDSL.ts
@@ -40,19 +40,19 @@ export interface GitDSL {
    * Filepaths with changes relative to the git root
    * @type {string[]}
    */
-  readonly modified_files: Readonly<Array<string>>
+  readonly modified_files: Array<string>
 
   /**
    * Newly created filepaths relative to the git root
    * @type {string[]}
    */
-  readonly created_files: Readonly<Array<string>>
+  readonly created_files: Array<string>
 
   /**
    * Removed filepaths relative to the git root
    * @type {string[]}
    */
-  readonly deleted_files: Readonly<Array<string>>
+  readonly deleted_files: Array<string>
 
   /** Offers the diff for a specific file */
   diffForFile(filename: string): string | null,
@@ -88,5 +88,5 @@ export interface GitDSL {
   JSONDiffForFile(filename: string): Promise<any>,
 
   /** The Git commit metadata */
-  readonly commits: Readonly<Array<GitCommit>>
+  readonly commits: Array<GitCommit>
 }

--- a/source/runner/Executor.ts
+++ b/source/runner/Executor.ts
@@ -131,7 +131,6 @@ export class Executor {
     const failureCount = [...fails, ...warnings].length
     const messageCount = [...messages, ...markdowns].length
 
-    console.log(this)
     this.d(results)
 
     if (failureCount + messageCount === 0) {


### PR DESCRIPTION
I was seeing errors around `Readonly`, and it looks like the `declare module` part isn't needed for TypeScript.