### PR TITLE
Fail when any types dependency is shipped to library consumers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,16 @@
 
 //  Add your own contribution below
 
-### 0.14.0 - 0.14.1
+### 0.14.2
+
+* Moved `@types/chalk` from dependencies to devDependencies - orta
+
+### 0.14.1
+
+* Killed some stray console logs - orta
+* Updated the danger.d.ts - orta
+
+### 0.14.0
 
 * TypeScript Dangerfiles are now support in Danger - orta
 

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -85,6 +85,18 @@ const checkForLockfileDiff = (packageDiff) => {
   }
 }
 
+// Don't ship @types dependencies to consumers of Danger
+const checkForTypesInDeps = (packageDiff) => {
+  if (packageDiff.dependencies) {
+    const typesDeps = packageDiff.dependencies.added.filter((dep: string) => dep.startsWith("@types"))
+    if (typesDeps.length) {
+      const message = `@types dependencies were added to package.json, as a dependency for others.`
+      const idea = `You need to move ${sentence(typesDeps)} into "devDependencies"?`
+      fail(`${message}<br/><i>${idea}</i>`)
+    }
+  }
+}
+
 // As `JSONDiffForFile` is an async function, we want to add it to Danger's scheduler
 // then it can continue after eval has taken place.
 
@@ -93,6 +105,7 @@ schedule(async () => {
   checkForRelease(packageDiff)
   checkForNewDependencies(packageDiff)
   checkForLockfileDiff(packageDiff)
+  checkForTypesInDeps(packageDiff)
 })
 
 // Some good old-fashioned maintainance upkeep

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   },
   "homepage": "https://github.com/danger/danger-js#readme",
   "devDependencies": {
+    "@types/chalk": "^0.4.31",
     "@types/commander": "^2.3.31",
     "@types/debug": "0.0.29",
     "@types/jest": "^19.2.1",
@@ -95,7 +96,6 @@
     "typescript": "2.2.1"
   },
   "dependencies": {
-    "@types/chalk": "^0.4.31",
     "babel-polyfill": "^6.20.0",
     "chalk": "^1.1.1",
     "commander": "^2.9.0",


### PR DESCRIPTION
Accidentally shipped `@types/chalk` with the last release. Not critical, but not good.

Let's ensure it doesn't happen again in the future.