### PR TITLE
Run yarn and yarn declarations #trivial

### DIFF
--- a/source/danger.d.ts
+++ b/source/danger.d.ts
@@ -1,6 +1,6 @@
 export type MarkdownString = string
 
-/** A platform agnostic refernce to a Git commit */
+/** A platform agnostic reference to a Git commit */
 export interface GitCommit {
   /** The SHA for the commit */
   sha: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,7 +94,7 @@ ansi-styles@^3.0.0:
   dependencies:
     color-convert "^1.0.0"
 
-any-promise@^1.0.0, any-promise@^1.3.0:
+any-promise@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
 
@@ -3271,7 +3271,7 @@ pinkie-promise@^2.0.0:
   dependencies:
     pinkie "^2.0.0"
 
-pinkie@^2.0.0, pinkie@^2.0.4:
+pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
@@ -3814,7 +3814,7 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   dependencies:
     ansi-regex "^2.0.0"
 
-strip-bom@3.0.0:
+strip-bom@3.0.0, strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
@@ -3994,9 +3994,9 @@ ts-jest@^19.0.0:
     source-map-support "^0.4.4"
     yargs "^6.1.1"
 
-ts-node@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-2.1.0.tgz#aa2bf4b2e25c5fb6a7c54701edc3666d3a9db25d"
+ts-node@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-3.0.2.tgz#cfc9516c831b920d7efbe16005915062b1294f8c"
   dependencies:
     arrify "^1.0.0"
     chalk "^1.1.1"
@@ -4004,20 +4004,16 @@ ts-node@^2.1.0:
     make-error "^1.1.1"
     minimist "^1.2.0"
     mkdirp "^0.5.1"
-    pinkie "^2.0.4"
     source-map-support "^0.4.0"
-    tsconfig "^5.0.2"
+    tsconfig "^6.0.0"
     v8flags "^2.0.11"
-    xtend "^4.0.0"
     yn "^1.2.0"
 
-tsconfig@^5.0.2:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/tsconfig/-/tsconfig-5.0.3.tgz#5f4278e701800967a8fc383fd19648878f2a6e3a"
+tsconfig@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/tsconfig/-/tsconfig-6.0.0.tgz#6b0e8376003d7af1864f8df8f89dd0059ffcd032"
   dependencies:
-    any-promise "^1.3.0"
-    parse-json "^2.2.0"
-    strip-bom "^2.0.0"
+    strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
 
 tslint@^4.4.0:


### PR DESCRIPTION
I ran `yarn declarations` to update the `danger.d.ts` file with the typo fix from https://github.com/danger/danger-js/pull/195. Greenkeeper PRs like https://github.com/danger/danger-js/pull/202 are "failing" because of the `yarn declarations` check in our dangerfile. (I also think https://github.com/danger/danger-js/issues/200 relates to this.)

Also, when I just ran `yarn` on master, it updated the `yarn.lock` file, which I think more appropriately reflects our `package.json` (for example, `yarn.lock` now shows ts-node 3.x, which is also present in our `package.json`).

Once this is merged, I can merge master back into #201, #202, and #203 to get them passing. 👍 