### PR TITLE
Improve Github dsl test

### DIFF
--- a/source/platforms/GitHub.ts
+++ b/source/platforms/GitHub.ts
@@ -44,6 +44,7 @@ export class GitHub {
     if (!issue) {
       return { labels: [] }
     }
+
     const labels = issue.labels.map((label: any): GitHubIssueLabel => ({
       id: label.id,
       url: label.url,

--- a/source/platforms/_tests/_github.test.ts
+++ b/source/platforms/_tests/_github.test.ts
@@ -47,7 +47,6 @@ describe("getPlatformDSLRepresentation", () => {
 
   it("should get the issue label", async() => {
     const issue = await github.getIssue()
-    console.log(issue)
     expect(issue.labels[0].name).toEqual("bug")
   })
 

--- a/source/platforms/_tests/fixtures/github_issue.json
+++ b/source/platforms/_tests/fixtures/github_issue.json
@@ -28,7 +28,13 @@
     "site_admin": false
   },
   "labels": [
-
+    {
+      "id": 208045946,
+      "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
+      "name": "bug",
+      "color": "f29513",
+      "default": true
+    }
   ],
   "state": "closed",
   "locked": false,


### PR DESCRIPTION
This PR improve the way `GitHub.ts` is tested by mocking `GithubAPI` class so that it is using mock data instead of doing call to API.

What do you think about it ? If the approach seems good for you I can write the missing tests, it should be straightforward now to add any test on top of this.