### PR TITLE
Add filter per type to gitdiff

### DIFF
--- a/source/danger.d.ts
+++ b/source/danger.d.ts
@@ -165,7 +165,7 @@ export interface GitDSL {
   readonly deleted_files: Array<string>
 
   /** Offers the diff for a specific file */
-  diffForFile(filename: string): string | null,
+  diffForFile(filename: string, diffTypes?: string[]): string | null,
 
   /**
    * Provides a JSON patch (rfc6902) between the two versions of a JSON file,

--- a/source/dsl/GitDSL.ts
+++ b/source/dsl/GitDSL.ts
@@ -60,7 +60,7 @@ export interface GitDSL {
   readonly deleted_files: Array<string>
 
   /** Offers the diff for a specific file */
-  diffForFile(filename: string): string | null,
+  diffForFile(filename: string, diffTypes?: string[]): string | null,
 
   /**
    * Provides a JSON patch (rfc6902) between the two versions of a JSON file,

--- a/source/platforms/github/GitHubGit.ts
+++ b/source/platforms/github/GitHubGit.ts
@@ -139,12 +139,18 @@ export default async function gitDSLForGitHub(api: GitHubAPI): Promise<GitDSL> {
  *
  * @param name File path for the diff
  */
-  const diffForFile = (name: string) => {
+  const diffForFile = (name: string, diffTypes?: string[]) => {
     const diff = find(fileDiffs, (diff: any) => diff.from === name || diff.to === name)
     if (!diff) { return null }
 
-    const changes = diff.chunks.map((c: any) => c.changes)
-                               .reduce((a: any, b: any) => a.concat(b), [])
+    let changes = diff.chunks.map((c: any) => c.changes)
+                             .reduce((a: any, b: any) => a.concat(b), [])
+
+    // Filter the diffs by type
+    if (diffTypes && diffTypes.length > 0) {
+      changes = changes.filter((c: any) => diffTypes.indexOf(c.type) !== -1)
+    }
+
     const lines = changes.map((c: any) => c.content)
     return lines.join(os.EOL)
   }

--- a/source/platforms/github/_tests/_github_git.test.ts
+++ b/source/platforms/github/_tests/_github_git.test.ts
@@ -48,6 +48,13 @@ describe("the dangerfile gitDSL", async () => {
     expect(gitDSL.diffForFile("CHANGELOG.md")).toEqual(expected)
   })
 
+  it("should show only diff of specified type", async () => {
+    const expected = "+- GeneVC now shows about information, and trending artists - orta"
+    const gitDSL = await github.getPlatformGitRepresentation()
+
+    expect(gitDSL.diffForFile("CHANGELOG.md", ["add"])).toEqual(expected)
+  })
+
   it("sets up commit data correctly", async () => {
     const exampleCommit: GitCommit = {
       "author": {


### PR DESCRIPTION
On my project I only want to check for the changes that have been added to the project, this support any kind of specified type (normal, add, delete)