### PR TITLE
Fix typo + Make example fixture easier to read

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### Master
 
+* Update internal test fixture generation docs
+
 ### 0.16.0
 
 * Adds a `diffTypes` option to `diffForFile` - alex3165

--- a/source/platforms/_tests/fixtures/readme.md
+++ b/source/platforms/_tests/fixtures/readme.md
@@ -1,5 +1,9 @@
 Here's an example CURL request to add a new fixture
 
 ```sh
-curl -H "Authorization: XXX" curl -H "Accept: application/vnd.github.black-cat-preview+json" --request GET https://api.github.com/repos/artsy/emission/pulls/327/requested_reviewers  > source/platforms/_tests/fixtures/requested_reviewers.json
+curl \
+-H "Authorization: token <GITHUB_OAUTH_TOKEN>" \
+-H "Accept: application/vnd.github.black-cat-preview+json" \
+--request GET https://api.github.com/repos/artsy/emission/pulls/327/requested_reviewers \
+> source/platforms/_tests/fixtures/requested_reviewers.json
 ```


### PR DESCRIPTION
The curl command in `fixtures/readme.md` wasn't working as expected (and had a small typo), but after looking up GitHub's authorization API I realized I forgot to add `token` to the `Authorization` header.

This small change should help contributors add tests. :beers: