### PR TITLE
Check windows support

### DIFF
--- a/source/runner/DangerfileRunner.ts
+++ b/source/runner/DangerfileRunner.ts
@@ -31,11 +31,14 @@ export async function createDangerfileRuntimeEnvironment(dangerfileContext: Dang
   }
 
   // Setup a runtime environment
-  const hasteConfig = { automock: false, maxWorkers: 1, resetCache: false }
+  const hasteConfig = { maxWorkers: 4, resetCache: false, watch: false, watchman: false }
+  console.log(0)
   const hasteMap = await Runtime.createHasteMap(config, hasteConfig).build()
+  console.log(1)
   const resolver = Runtime.createResolver(config, hasteMap.moduleMap)
+  console.log(2)
   const runtime = new Runtime(config, environment, resolver)
-
+  console.log(3)
   return {
     context,
     environment,
@@ -57,9 +60,11 @@ export async function dangerJestConfig() {
   // then it's pretty likely that Danger can do it too.
   const jestConfig =  await readConfig([], process.cwd())
   return {
+    automock: false,
     cacheDirectory: os.tmpdir(),
     setupFiles: [],
     name: "danger",
+    expand: false,
     testEnvironment: "node",
     haste: {
       defaultPlatform: "danger-js"
@@ -72,7 +77,9 @@ export async function dangerJestConfig() {
     cache: null,
     testRegex: "",
     testPathDirs: [process.cwd()],
-    transformIgnorePatterns: [ "/node_modules/" ]
+    transformIgnorePatterns: [ "/node_modules/" ],
+    watchman: false,
+    watch: false
   }
 }
 
@@ -88,8 +95,11 @@ export async function runDangerfileEnvironment(filename: Path, environment: Dang
   const runtime = environment.runtime
   // Require our dangerfile
 
+  console.log(4)
   ensureCleanDangerfile(filename, () => {
+    console.log(5)
     runtime.requireModule(filename)
+    console.log(6)
   })
 
   const results = environment.context.results

--- a/source/runner/DangerfileRunner.ts
+++ b/source/runner/DangerfileRunner.ts
@@ -31,14 +31,19 @@ export async function createDangerfileRuntimeEnvironment(dangerfileContext: Dang
   }
 
   // Setup a runtime environment
-  const hasteConfig = { maxWorkers: 4, resetCache: false, watch: false, watchman: false }
-  console.log(0)
-  const hasteMap = await Runtime.createHasteMap(config, hasteConfig).build()
-  console.log(1)
-  const resolver = Runtime.createResolver(config, hasteMap.moduleMap)
-  console.log(2)
-  const runtime = new Runtime(config, environment, resolver)
-  console.log(3)
+  // const hasteConfig = { maxWorkers: 4, resetCache: false, watch: false, watchman: false }
+  // console.log(0)
+  // const hasteMap = await Runtime.createHasteMap(config, hasteConfig).build()
+  // console.log(1)
+  // const resolver = Runtime.createResolver(config, hasteMap.moduleMap)
+  // console.log(2)
+  // const runtime = new Runtime(config, environment, resolver)
+  // console.log(3)
+  const hasteMap = await Runtime.createContext(config, {
+    maxWorkers: os.cpus().length - 1,
+  })
+  const runtime = new Runtime(config, environment, hasteMap.resolver)
+
   return {
     context,
     environment,

--- a/source/runner/_tests/__snapshots__/_danger_runner.test.ts.snap
+++ b/source/runner/_tests/__snapshots__/_danger_runner.test.ts.snap
@@ -2,8 +2,10 @@
 
 exports[`creates a working jest config 1`] = `
 Object {
+  "automock": false,
   "cache": null,
   "cacheDirectory": "[cache]",
+  "expand": false,
   "haste": Object {
     "defaultPlatform": "danger-js",
   },
@@ -42,5 +44,7 @@ Object {
   "transformIgnorePatterns": Array [
     "/node_modules/",
   ],
+  "watch": false,
+  "watchman": false,
 }
 `;

--- a/source/runner/_tests/_danger_runner.test.ts
+++ b/source/runner/_tests/_danger_runner.test.ts
@@ -7,9 +7,9 @@ import {
   dangerJestConfig
 } from "../DangerfileRunner"
 
-import {FakeCI} from "../../ci_source/providers/Fake"
-import {FakePlatform} from "../../platforms/FakePlatform"
-import {Executor} from "../Executor"
+import { FakeCI } from "../../ci_source/providers/Fake"
+import { FakePlatform } from "../../platforms/FakePlatform"
+import { Executor } from "../Executor"
 
 import * as os from "os"
 import * as fs from "fs"
@@ -37,113 +37,113 @@ async function setupDangerfileContext() {
   return contextForDanger(dsl)
 }
 
-if (process.platform !== "win32") {
-  describe("with fixtures", () => {
-    it("handles a blank Dangerfile", async () => {
-      const context = await setupDangerfileContext()
-      const runtime = await createDangerfileRuntimeEnvironment(context)
-      const results = await runDangerfileEnvironment(resolve(fixtures, "__DangerfileEmpty.js"), runtime)
-
-      expect(results).toEqual({
-        fails: [],
-        markdowns: [],
-        messages: [],
-        warnings: []
-      })
+describe("with fixtures", () => {
+  it("handles a blank Dangerfile", async () => {
+    console.log(8)
+    const context = await setupDangerfileContext()
+    console.log(9)
+    const runtime = await createDangerfileRuntimeEnvironment(context)
+    console.log(10)
+    const results = await runDangerfileEnvironment(resolve(fixtures, "__DangerfileEmpty.js"), runtime)
+    console.log(11)
+    expect(results).toEqual({
+      fails: [],
+      markdowns: [],
+      messages: [],
+      warnings: []
     })
-
-    it("handles a full set of messages", async () => {
-      const context = await setupDangerfileContext()
-      const runtime = await createDangerfileRuntimeEnvironment(context)
-      const results = await runDangerfileEnvironment(resolve(fixtures, "__DangerfileFullMessages.js"), runtime)
-
-      expect(results).toEqual({
-        fails: [{"message": "this is a failure"}],
-        markdowns: ["this is a *markdown*"],
-        messages: [{"message": "this is a message"}],
-        warnings: [{"message": "this is a warning"}]
-      })
-    })
-
-    it("handles a failing dangerfile", async () => {
-      const context = await setupDangerfileContext()
-      const runtime = await createDangerfileRuntimeEnvironment(context)
-
-      try {
-        await runDangerfileEnvironment(resolve(fixtures, "__DangerfileBadSyntax.js"), runtime)
-        throw new Error("Do not get to this")
-      }
-      catch (e) {
-        // expect(e.message === ("Do not get to this")).toBeFalsy()
-        expect(e.message).toEqual("hello is not defined")
-      }
-    })
-
-    it("handles relative imports correctly", async () => {
-      const context = await setupDangerfileContext()
-      const runtime = await createDangerfileRuntimeEnvironment(context)
-      await runDangerfileEnvironment(resolve(fixtures, "__DangerfileImportRelative.js"), runtime)
-    })
-
-    it("handles scheduled (async) code", async () => {
-      const context = await setupDangerfileContext()
-      const runtime = await createDangerfileRuntimeEnvironment(context)
-      const results = await runDangerfileEnvironment(resolve(fixtures, "__DangerfileScheduled.js"), runtime)
-      expect(results).toEqual({
-        fails: [],
-        messages: [],
-        markdowns: [],
-        warnings: [{ message: "Asynchronous Warning" }],
-      })
-    })
-
-    it("handles multiple scheduled statements and all message types", async () => {
-      const context = await setupDangerfileContext()
-      const runtime = await createDangerfileRuntimeEnvironment(context)
-      const results = await runDangerfileEnvironment(resolve(fixtures, "__DangerfileMultiScheduled.js"), runtime)
-      expect(results).toEqual({
-        fails: [{ message: "Asynchronous Failure" }],
-        messages: [{ message: "Asynchronous Message" }],
-        markdowns: ["Asynchronous Markdown"],
-        warnings: [{ message: "Asynchronous Warning" }],
-      })
-    })
-
-    // This adds > 6 seconds to the tests! Only orta should be forced into that.
-    if (process.env["USER"] === "orta") {
-      it("can execute async/await scheduled functions", async () => {
-        // this test takes *forever* because of babel-polyfill being required
-        const context = await setupDangerfileContext()
-        const runtime = await createDangerfileRuntimeEnvironment(context)
-        const results = await runDangerfileEnvironment(resolve(fixtures, "__DangerfileAsync.js"), runtime)
-        expect(results.warnings).toEqual([{
-          message: "Async Function"
-        }, {
-          message: "After Async Function"
-        }])
-      })
-    }
-
-    it("can schedule callback-based promised", async () => {
-      const context = await setupDangerfileContext()
-      const runtime = await createDangerfileRuntimeEnvironment(context)
-      const results = await runDangerfileEnvironment(resolve(fixtures, "__DangerfileCallback.js"), runtime)
-      expect(results.warnings).toEqual([{
-        message: "Scheduled a callback",
-      }])
-    })
-
-    it("can handle TypeScript based Dangerfiles", async () => {
-      const context = await setupDangerfileContext()
-      const runtime = await createDangerfileRuntimeEnvironment(context)
-      const results = await runDangerfileEnvironment(resolve(fixtures, "__DangerfileTypeScript.ts"), runtime)
-      expect(results.messages).toEqual([{
-        message: "Honey, we got Types",
-      }])
-    })
-
   })
-}
+
+  it("handles a full set of messages", async () => {
+    const context = await setupDangerfileContext()
+    const runtime = await createDangerfileRuntimeEnvironment(context)
+    const results = await runDangerfileEnvironment(resolve(fixtures, "__DangerfileFullMessages.js"), runtime)
+
+    expect(results).toEqual({
+      fails: [{ "message": "this is a failure" }],
+      markdowns: ["this is a *markdown*"],
+      messages: [{ "message": "this is a message" }],
+      warnings: [{ "message": "this is a warning" }]
+    })
+  })
+
+  it("handles a failing dangerfile", async () => {
+    const context = await setupDangerfileContext()
+    const runtime = await createDangerfileRuntimeEnvironment(context)
+
+    try {
+      await runDangerfileEnvironment(resolve(fixtures, "__DangerfileBadSyntax.js"), runtime)
+      throw new Error("Do not get to this")
+    }
+    catch (e) {
+      // expect(e.message === ("Do not get to this")).toBeFalsy()
+      expect(e.message).toEqual("hello is not defined")
+    }
+  })
+
+  it("handles relative imports correctly", async () => {
+    const context = await setupDangerfileContext()
+    const runtime = await createDangerfileRuntimeEnvironment(context)
+    await runDangerfileEnvironment(resolve(fixtures, "__DangerfileImportRelative.js"), runtime)
+  })
+
+  it("handles scheduled (async) code", async () => {
+    const context = await setupDangerfileContext()
+    const runtime = await createDangerfileRuntimeEnvironment(context)
+    const results = await runDangerfileEnvironment(resolve(fixtures, "__DangerfileScheduled.js"), runtime)
+    expect(results).toEqual({
+      fails: [],
+      messages: [],
+      markdowns: [],
+      warnings: [{ message: "Asynchronous Warning" }],
+    })
+  })
+
+  it("handles multiple scheduled statements and all message types", async () => {
+    const context = await setupDangerfileContext()
+    const runtime = await createDangerfileRuntimeEnvironment(context)
+    const results = await runDangerfileEnvironment(resolve(fixtures, "__DangerfileMultiScheduled.js"), runtime)
+    expect(results).toEqual({
+      fails: [{ message: "Asynchronous Failure" }],
+      messages: [{ message: "Asynchronous Message" }],
+      markdowns: ["Asynchronous Markdown"],
+      warnings: [{ message: "Asynchronous Warning" }],
+    })
+  })
+
+  // This adds > 6 seconds to the tests! Only orta should be forced into that.
+  if (process.env["USER"] === "orta") {
+    it("can execute async/await scheduled functions", async () => {
+      // this test takes *forever* because of babel-polyfill being required
+      const context = await setupDangerfileContext()
+      const runtime = await createDangerfileRuntimeEnvironment(context)
+      const results = await runDangerfileEnvironment(resolve(fixtures, "__DangerfileAsync.js"), runtime)
+      expect(results.warnings).toEqual([{
+        message: "Async Function"
+      }, {
+        message: "After Async Function"
+      }])
+    })
+  }
+
+  it("can schedule callback-based promised", async () => {
+    const context = await setupDangerfileContext()
+    const runtime = await createDangerfileRuntimeEnvironment(context)
+    const results = await runDangerfileEnvironment(resolve(fixtures, "__DangerfileCallback.js"), runtime)
+    expect(results.warnings).toEqual([{
+      message: "Scheduled a callback",
+    }])
+  })
+
+  it("can handle TypeScript based Dangerfiles", async () => {
+    const context = await setupDangerfileContext()
+    const runtime = await createDangerfileRuntimeEnvironment(context)
+    const results = await runDangerfileEnvironment(resolve(fixtures, "__DangerfileTypeScript.ts"), runtime)
+    expect(results.messages).toEqual([{
+      message: "Honey, we got Types",
+    }])
+  })
+})
 
 describe("cleaning Dangerfiles", () => {
   it("Supports removing the danger import", () => {
@@ -174,7 +174,7 @@ import danger from 'danger';
   })
 
   it("also handles require style imports", () => {
-        const before = `
+    const before = `
 const { danger, warn, fail, message } = require('danger')
 var { danger, warn, fail, message } = require("danger")
 let { danger, warn, fail, message } = require('danger');
@@ -198,7 +198,7 @@ it("creates a working jest config", async () => {
 
   const cwd = process.cwd()
   config.transform = config.transform.map(([files, transformer]) => {
-    const trans = transformer.includes("ts-jest")  ? "[ts-jest-transformer]" : transformer
+    const trans = transformer.includes("ts-jest") ? "[ts-jest-transformer]" : transformer
     return [files, trans]
   })
 


### PR DESCRIPTION
This runs the formatter on `source/runner/_tests/_danger_runner.test.ts` as well as undoing the Windows check for the danger eval tests.