### PR TITLE
Resolve test failure by lacks of jest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
 
 script:
 - yarn lint
+- yarn add jest
 - yarn test -- --coverage --no-cache && rm ./coverage/coverage-final.json
 - yarn docs
 - if [[ $TRAVIS_NODE_VERSION == "7" ]]; then yarn add dtslint; yarn dts-lint; fi


### PR DESCRIPTION
There seems super odd things on certain node.js configuration, `jest` is not fully installed there. This may be related with some of jest runtime under `dependencies`, cause I could observe something like below.

```
npm WARN gentlyRm not removing /home/travis/build/kwonoj/danger-js/node_modules/.bin/jest as it wasn't installed by /home/travis/build/kwonoj/danger-js/node_modules/jest-cli
```

For a workaround, I made to explicitly install jest after build is done - feel freely to close PR without check in, this is more like fyi. 