### PR TITLE
chore(greenkeeper): add support for greenkeeper-lockfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,14 @@ cache:
 matrix:
   include:
   - node_js: node
+    before_install:
+    - yarn global add greenkeeper-lockfile@1
     before_script:
+    - greenkeeper-lockfile-update
     - yarn run link
     - danger
+    after_script:
+    - greenkeeper-lockfile-upload
   - node_js: '6'
   - node_js: '7'
 


### PR DESCRIPTION
https://github.com/greenkeeperio/greenkeeper-lockfile

Now, greenkeeper will also update the `yarn.lock` file when opening dependency update PRs! 🎉 I followed [these instructions](https://github.com/greenkeeperio/greenkeeper-lockfile#yarn) to update `.travis.yml`.