### PR TITLE
fix(github): use HTTP for status check URL

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### Master
 
+-   Use HTTP for the GitHub status check target URL - macklinu
+
 ### 0.21.0
 
 -   Posts status reports for passing/failing builds, if the account for danger has access - orta

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -213,7 +213,7 @@ export class GitHubAPI {
       {
         state: passed ? "success" : "failure",
         context: "Danger",
-        target_url: "https://danger.systems/js",
+        target_url: "http://danger.systems/js",
         description: message,
       }
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1163,13 +1163,13 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-date-fns@^1.27.2, date-fns@^1.28.3:
-  version "1.28.3"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.3.tgz#145d87adc3f5a82c6bda668de97eee1132c97ea1"
-
-date-fns@^1.28.5:
+date-fns@^1.27.2, date-fns@^1.28.5:
   version "1.28.5"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.5.tgz#257cfc45d322df45ef5658665967ee841cd73faf"
+
+date-fns@^1.28.3:
+  version "1.28.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.3.tgz#145d87adc3f5a82c6bda668de97eee1132c97ea1"
 
 debug@2, debug@^2.1.1, debug@^2.2.0, debug@^2.6.0, debug@^2.6.3:
   version "2.6.3"


### PR DESCRIPTION
When I click the **Details** link in the GitHub status checks of a pull request:

![image](https://user-images.githubusercontent.com/2344137/27229334-2edb422c-5279-11e7-82dd-62af114c7795.png)

I am taken to https://danger.systems/js - however, I see this **Your connection is not private** message:

![image](https://user-images.githubusercontent.com/2344137/27229338-34c0f0ba-5279-11e7-8988-55ea6327cd4c.png)

I've updated the danger.systems URL to use HTTP, which seems consistent with the rest of the codebase. 👍 

![image](https://user-images.githubusercontent.com/2344137/27230112-2e16bc9c-527c-11e7-9ad9-af2f6406ee58.png)

Also, running `yarn` updated the yarn lockfile.