### PR TITLE
Use absolute urls for the node_modules folder to improve module resolution for Peril

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### Master
 
+-   Use an absolute url for the jest-resolver config moduleDirs option so that Peril can run dangerfiles out of process - orta
+
 ### 0.21.1
 
 -   Use HTTP for the GitHub status check target URL - macklinu

--- a/source/runner/DangerfileRunner.ts
+++ b/source/runner/DangerfileRunner.ts
@@ -4,6 +4,7 @@ import { readConfig } from "jest-config"
 import * as NodeEnvironment from "jest-environment-node"
 import * as os from "os"
 import * as fs from "fs"
+import * as path from "path"
 
 import { DangerResults } from "../dsl/DangerResults"
 import { DangerContext } from "../runner/Dangerfile"
@@ -66,7 +67,7 @@ export async function dangerJestConfig() {
       defaultPlatform: "danger-js",
     },
     moduleNameMapper: [],
-    moduleDirectories: ["node_modules"],
+    moduleDirectories: [path.resolve(process.cwd(), "node_modules")],
     moduleFileExtensions: ["js", ...jestConfig.config.moduleFileExtensions],
     transform: [["js$", "babel-jest"], ...jestConfig.config.transform],
     testPathIgnorePatterns: jestConfig.config.testPathIgnorePatterns,

--- a/source/runner/_tests/__snapshots__/_danger_runner.test.ts.snap
+++ b/source/runner/_tests/__snapshots__/_danger_runner.test.ts.snap
@@ -8,7 +8,7 @@ Object {
     "defaultPlatform": "danger-js",
   },
   "moduleDirectories": Array [
-    "node_modules",
+    "[moduleDirectories]",
   ],
   "moduleFileExtensions": Array [
     "js",

--- a/source/runner/_tests/_danger_runner.test.ts
+++ b/source/runner/_tests/_danger_runner.test.ts
@@ -206,6 +206,7 @@ it("creates a working jest config", async () => {
   config.cacheDirectory = "[cache]"
   config.testPathDirs = ["[testPathDirs]"]
   config.testPathIgnorePatterns = ["[testPathIgnorePatterns]"]
+  config.moduleDirectories = ["[moduleDirectories]"]
 
   const cwd = process.cwd()
   config.transform = config.transform.map(([files, transformer]) => {


### PR DESCRIPTION
I'm seeing issues with parsing typescript files in Peril. Think this should get it.
