### PR TITLE
Creates inline docs for all providers (help requested)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### Master
 
+-  Adds inline docs for all CI providers - orta
+
 ### 0.21.1
 
 -   Use HTTP for the GitHub status check target URL - macklinu

--- a/source/ci_source/providers/BuddyBuild.ts
+++ b/source/ci_source/providers/BuddyBuild.ts
@@ -1,6 +1,20 @@
 import { Env, CISource } from "../ci_source"
 import { ensureEnvKeysExist, ensureEnvKeysAreInt } from "../ci_source_helpers"
 
+/**
+ * ### CI Setup
+ *
+ * Buddybuild has an integration for Danger JS already built-in.
+ *
+ * ### Token Setup
+ *
+ * Login to buddybuild and select your app. Go to your *App Settings* and
+ * in the *Build Settings* menu on the left, choose *Environment Variables*.
+ *
+ * #### GitHub
+ * Add the `DANGER_GITHUB_API_TOKEN` to your build user's ENV.
+ *
+ */
 export class BuddyBuild implements CISource {
   constructor(private readonly env: Env) {}
 

--- a/source/ci_source/providers/Buildkite.ts
+++ b/source/ci_source/providers/Buildkite.ts
@@ -1,6 +1,24 @@
 import { Env, CISource } from "../ci_source"
 import { ensureEnvKeysExist, ensureEnvKeysAreInt } from "../ci_source_helpers"
 
+/**
+ * ### CI Setup
+ *
+ * With BuildKite you run the server yourself, so you will want to run  it as a part of your build process.
+ * It is common to have build steps, so we would recommend adding this to your scrip:
+ *
+ *  ``` shell
+ *   echo "--- Running Danger"
+ *   bundle exec danger
+ *  ```
+ *
+ * ### Token Setup
+ *
+ * #### GitHub
+ *
+ * As this is self-hosted, you will need to add the `DANGER_GITHUB_API_TOKEN` to your build user's ENV. The  alternative
+ * is to pass in the token as a prefix to the command `DANGER_GITHUB_API_TOKEN="123" bundle exec danger`.
+ */
 export class Buildkite implements CISource {
   constructor(private readonly env: Env) {}
 

--- a/source/ci_source/providers/Codeship.ts
+++ b/source/ci_source/providers/Codeship.ts
@@ -2,8 +2,31 @@ import { Env, CISource } from "../ci_source"
 import { ensureEnvKeysExist, getPullRequestIDForBranch } from "../ci_source_helpers"
 
 /**
- * Docs: TODO
+ * ### CI Setup
+ *
+ * To make Danger run, add a new steo to the `codeship-steps.yml` file:
+ *
+ * ```
+ * - type: parallel:
+ *   ...
+ *    - name: danger
+ *      service: web
+ *      command: yarn danger
+ * ```
+ *
+ * ### Token Setup
+ *
+ * You'll want to edit your `codeship-services.yml` file to include a reference
+ * to the Danger authentication token: `DANGER_GITHUB_API_TOKEN`.
+ *
+ * ```
+ * project_name:
+ *   ...
+ *   environment:
+ *     - DANGER_GITHUB_API_TOKEN=[my_token]
+ * ```
  */
+
 export class Codeship implements CISource {
   private default = { prID: "0" }
   constructor(private readonly env: Env) {}

--- a/source/ci_source/providers/Codeship.ts
+++ b/source/ci_source/providers/Codeship.ts
@@ -4,7 +4,7 @@ import { ensureEnvKeysExist, getPullRequestIDForBranch } from "../ci_source_help
 /**
  * ### CI Setup
  *
- * To make Danger run, add a new steo to the `codeship-steps.yml` file:
+ * To make Danger run, add a new step to the `codeship-steps.yml` file:
  *
  * ```
  * - type: parallel:
@@ -13,6 +13,8 @@ import { ensureEnvKeysExist, getPullRequestIDForBranch } from "../ci_source_help
  *      service: web
  *      command: yarn danger
  * ```
+ *
+ * If you're using Codeship Classic, add `yarn danger` to your 'Test Commands'
  *
  * ### Token Setup
  *
@@ -25,6 +27,9 @@ import { ensureEnvKeysExist, getPullRequestIDForBranch } from "../ci_source_help
  *   environment:
  *     - DANGER_GITHUB_API_TOKEN=[my_token]
  * ```
+ *
+ * If you're using Codeship Classic, add `DANGER_GITHUB_API_TOKEN` to your
+ * 'Environment' settings.
  */
 
 export class Codeship implements CISource {

--- a/source/ci_source/providers/DockerCloud.ts
+++ b/source/ci_source/providers/DockerCloud.ts
@@ -2,8 +2,33 @@ import { Env, CISource } from "../ci_source"
 import { ensureEnvKeysExist } from "../ci_source_helpers"
 
 /**
- * Docs: TODO
+ *
+ * ### CI Setup
+ *
+ * You'll want to add danger to your existing `Dockerfile.test` (or whatever you
+ * have choosen as your `sut` Dockerfile.)
+ *
+ * ```sh
+ * ...
+ *
+ * CMD ["yarn", "danger"]
+ * ```
+ *
+ * ### Token Setup
+ *
+ * #### GitHub
+ *
+ * Your `DANGER_GITHUB_API_TOKEN` will need to be exposed to the `sut` part of your
+ * `docker-compose.yml`.  This looks similar to:
+ *
+ * ```
+ * sut:
+ *   ...
+ *   environment:
+ *     - DANGER_GITHUB_API_TOKEN=[my_token]
+ * ```
  */
+
 export class DockerCloud implements CISource {
   constructor(private readonly env: Env) {}
 

--- a/source/ci_source/providers/Jenkins.ts
+++ b/source/ci_source/providers/Jenkins.ts
@@ -1,8 +1,9 @@
 import { Env, CISource } from "../ci_source"
 import { ensureEnvKeysExist, ensureEnvKeysAreInt } from "../ci_source_helpers"
+
+//  https://jenkins-ci.org
+
 /**
- *  https://jenkins-ci.org
- *
  *  ### CI Setup
  *  Ah Jenkins, so many memories. So, if you're using Jenkins, you're hosting your own  environment.
  *

--- a/source/ci_source/providers/Jenkins.ts
+++ b/source/ci_source/providers/Jenkins.ts
@@ -1,29 +1,29 @@
 import { Env, CISource } from "../ci_source"
 import { ensureEnvKeysExist, ensureEnvKeysAreInt } from "../ci_source_helpers"
 
-//  https://jenkins-ci.org
+// https://jenkins.io/
 
 /**
- *  ### CI Setup
- *  Ah Jenkins, so many memories. So, if you're using Jenkins, you're hosting your own  environment.
+ * ### CI Setup
+ * Ah Jenkins, so many memories. So, if you're using Jenkins, you're hosting your own environment.
  *
- *  ### GitHub
- *  You will want to be using the
- *  [GitHub pull request builder plugin](https://wiki.jenkins-ci.org/display/JENKINS/GitHub+pull+request+builder+plugin)
- *  in order to ensure that you have the build environment set up for PR integration.
+ * ### GitHub
+ * You will want to be using the
+ * [GitHub pull request builder plugin](https://wiki.jenkins.io/display/JENKINS/GitHub+pull+request+builder+plugin)
+ * in order to ensure that you have the build environment set up for PR integration.
  *
- *  With that set up, you can edit your job to add `yarn danger` at the build action.
+ * With that set up, you can edit your job to add `yarn danger` at the build action.
  *
- *  ### Pipeline
+ * ### Pipeline
  * If you're using [pipelines](https://jenkins.io/solutions/pipeline/) you should be using the
- * [GitHub branch source plugin](https://wiki.jenkins-ci.org/display/JENKINS/GitHub+Branch+Source+Plugin) for easy setup and handling of PRs.
+ * [GitHub branch source plugin](https://wiki.jenkins.io/display/JENKINS/GitHub+Branch+Source+Plugin) for easy setup and handling of PRs.
  *
- *  After you've set up the plugin, add a `sh 'yarn danger'` line in your pipeline  script and make sure that build PRs is enabled.
+ * After you've set up the plugin, add a `sh 'yarn danger'` line in your pipeline script and make sure that build PRs is enabled.
  *
- *  ## Token Setup
+ * ## Token Setup
  *
- *  ### GitHub
- *  As you own the machine, it's up to you to add the environment variable for the  `DANGER_GITHUB_API_TOKEN`.
+ * ### GitHub
+ * As you own the machine, it's up to you to add the environment variable for the `DANGER_GITHUB_API_TOKEN`.
  */
 export class Jenkins implements CISource {
   constructor(private readonly env: Env) {}


### PR DESCRIPTION
Sorry to ask specifically, but there are some CI provides I have never used on this list, so:

- @benkraus - can you confirm that the BuddyBuild docs look 👍? 
- @deecewan - can you confirm the CodeShip one?
- @camacho - can you confirm the DockerCloud?


This will mean that they show up on the getting started guide:

![screen shot 2017-06-26 at 22 04 09](https://user-images.githubusercontent.com/49038/27585055-9968b772-5b08-11e7-91da-be76e671df2a.png)
http://danger.systems/js/guides/getting_started.html