### PR TITLE
fix(Dangerfile): report errors when evaluating Dangerfile

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 // TODO
 
+* Handle exceptions in Dangerfile and report them as failures in Danger results - macklinu
+
 ### 2.0.0-alpha.6-7
 
 * Expose a Promise object to the external GitHub API - orta

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "node-fetch": "^1.6.3",
     "parse-diff": "^0.4.0",
     "parse-link-header": "^1.0.1",
+    "pinpoint": "^1.1.0",
     "rfc6902": "^1.3.0",
     "vm2": "patriksimek/vm2",
     "voca": "^1.2.0"

--- a/source/ambient.d.ts
+++ b/source/ambient.d.ts
@@ -11,6 +11,7 @@ declare module "voca"
 declare module "jsome"
 declare module "jsonpointer"
 declare module "parse-link-header"
+declare module "pinpoint"
 
 declare module "*/package.json"
 

--- a/source/runner/DangerfileRunner.ts
+++ b/source/runner/DangerfileRunner.ts
@@ -114,15 +114,26 @@ export async function runDangerfileEnvironment(
       messages: results.messages,
       markdowns: results.markdowns,
     }
-  } catch (e) {
+  } catch (error) {
     console.error("Unable to evaluate the Dangerfile")
-    return {
-      fails: [{ message: `\`\`\`\n${e.stack}\n\`\`\`` }],
-      warnings: [],
-      messages: [],
-      markdowns: [],
-    }
+    return resultsForCaughtError(filename, content, error)
   }
+}
+
+/** Returns Markdown results to post if an exception is raised during the danger run */
+const resultsForCaughtError = (file: string, contents: string, error: Error): DangerResults => {
+  const failure = `Danger failed to run \`${file}\`.`
+  const errorMD = `## Error ${error.name}
+\`\`\`
+${error.message}
+${error.stack}
+\`\`\`
+### Dangerfile
+\`\`\`
+${contents}
+\`\`\`
+  `
+  return { fails: [{ message: failure }], warnings: [], markdowns: [errorMD], messages: [] }
 }
 
 // https://regex101.com/r/dUq4yB/1

--- a/source/runner/DangerfileRunner.ts
+++ b/source/runner/DangerfileRunner.ts
@@ -92,26 +92,36 @@ export async function runDangerfileEnvironment(
   //   return originalRequire.apply(this, arguments)
   // }
 
-  vm.run(content, filename)
+  try {
+    vm.run(content, filename)
 
-  const results = environment.sandbox!.results!
-  await Promise.all(
-    results.scheduled.map((fnOrPromise: any) => {
-      if (fnOrPromise instanceof Promise) {
-        return fnOrPromise
-      }
-      if (fnOrPromise.length === 1) {
-        // callback-based function
-        return new Promise(res => fnOrPromise(res))
-      }
-      return fnOrPromise()
-    })
-  )
-  return {
-    fails: results.fails,
-    warnings: results.warnings,
-    messages: results.messages,
-    markdowns: results.markdowns,
+    const results = environment.sandbox!.results!
+    await Promise.all(
+      results.scheduled.map((fnOrPromise: any) => {
+        if (fnOrPromise instanceof Promise) {
+          return fnOrPromise
+        }
+        if (fnOrPromise.length === 1) {
+          // callback-based function
+          return new Promise(res => fnOrPromise(res))
+        }
+        return fnOrPromise()
+      })
+    )
+    return {
+      fails: results.fails,
+      warnings: results.warnings,
+      messages: results.messages,
+      markdowns: results.markdowns,
+    }
+  } catch (e) {
+    console.error("Unable to evaluate the Dangerfile")
+    return {
+      fails: [{ message: `\`\`\`\n${e.stack}\n\`\`\`` }],
+      warnings: [],
+      messages: [],
+      markdowns: [],
+    }
   }
 }
 

--- a/source/runner/_tests/_danger_runner.test.ts
+++ b/source/runner/_tests/_danger_runner.test.ts
@@ -65,6 +65,7 @@ describe("with fixtures", () => {
 
     expect(results.fails[0].message).toContain("Danger failed to run")
     expect(results.markdowns[0]).toContain("hello is not defined")
+    console.log(results.markdowns)
   })
 
   it.skip("handles relative imports correctly in Babel", async () => {
@@ -182,6 +183,7 @@ describe("with fixtures", () => {
 
     expect(results.fails[0].message).toContain("Danger failed to run")
     expect(results.markdowns[0]).toContain("Error: failure")
+    console.log(results)
   })
 })
 

--- a/source/runner/_tests/_danger_runner.test.ts
+++ b/source/runner/_tests/_danger_runner.test.ts
@@ -65,7 +65,6 @@ describe("with fixtures", () => {
 
     expect(results.fails[0].message).toContain("Danger failed to run")
     expect(results.markdowns[0]).toContain("hello is not defined")
-    console.log(results.markdowns)
   })
 
   it.skip("handles relative imports correctly in Babel", async () => {
@@ -183,7 +182,6 @@ describe("with fixtures", () => {
 
     expect(results.fails[0].message).toContain("Danger failed to run")
     expect(results.markdowns[0]).toContain("Error: failure")
-    console.log(results)
   })
 })
 

--- a/source/runner/_tests/_danger_runner.test.ts
+++ b/source/runner/_tests/_danger_runner.test.ts
@@ -61,14 +61,9 @@ describe("with fixtures", () => {
   it("handles a failing dangerfile", async () => {
     const context = await setupDangerfileContext()
     const runtime = await createDangerfileRuntimeEnvironment(context)
+    const results = await runDangerfileEnvironment(resolve(fixtures, "__DangerfileBadSyntax.js"), undefined, runtime)
 
-    try {
-      await runDangerfileEnvironment(resolve(fixtures, "__DangerfileBadSyntax.js"), undefined, runtime)
-      throw new Error("Do not get to this")
-    } catch (e) {
-      // expect(e.message === ("Do not get to this")).toBeFalsy()
-      expect(e.message).toEqual("hello is not defined")
-    }
+    expect(results.fails[0].message).toContain("hello is not defined")
   })
 
   it.skip("handles relative imports correctly in Babel", async () => {
@@ -177,6 +172,14 @@ describe("with fixtures", () => {
     const results = await runDangerfileEnvironment(resolve(fixtures, "__DangerfilePlugin.js"), undefined, runtime)
 
     expect(results.fails[0].message).toContain("@types dependencies were added to package.json")
+  })
+
+  it("does not swallow errors thrown in Dangerfile", async () => {
+    const context = await setupDangerfileContext()
+    const runtime = await createDangerfileRuntimeEnvironment(context)
+    const results = await runDangerfileEnvironment(resolve(fixtures, "__DangerfileThrows.js"), undefined, runtime)
+
+    expect(results.fails[0].message).toContain("Error: failure")
   })
 })
 

--- a/source/runner/_tests/_danger_runner.test.ts
+++ b/source/runner/_tests/_danger_runner.test.ts
@@ -63,7 +63,8 @@ describe("with fixtures", () => {
     const runtime = await createDangerfileRuntimeEnvironment(context)
     const results = await runDangerfileEnvironment(resolve(fixtures, "__DangerfileBadSyntax.js"), undefined, runtime)
 
-    expect(results.fails[0].message).toContain("hello is not defined")
+    expect(results.fails[0].message).toContain("Danger failed to run")
+    expect(results.markdowns[0]).toContain("hello is not defined")
   })
 
   it.skip("handles relative imports correctly in Babel", async () => {
@@ -179,7 +180,8 @@ describe("with fixtures", () => {
     const runtime = await createDangerfileRuntimeEnvironment(context)
     const results = await runDangerfileEnvironment(resolve(fixtures, "__DangerfileThrows.js"), undefined, runtime)
 
-    expect(results.fails[0].message).toContain("Error: failure")
+    expect(results.fails[0].message).toContain("Danger failed to run")
+    expect(results.markdowns[0]).toContain("Error: failure")
   })
 })
 

--- a/source/runner/_tests/fixtures/__DangerfileThrows.js
+++ b/source/runner/_tests/fixtures/__DangerfileThrows.js
@@ -1,0 +1,1 @@
+throw new Error("failure")

--- a/yarn.lock
+++ b/yarn.lock
@@ -3328,6 +3328,10 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+pinpoint@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pinpoint/-/pinpoint-1.1.0.tgz#0cf7757a6977f1bf7f6a32207b709e377388e874"
+
 pkg-dir@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"


### PR DESCRIPTION
resolves #250 

This wraps our dangerfile evaluation in a try/catch (as suggested in [vm2's docs](https://github.com/patriksimek/vm2#error-handling)). I opted to report a failure to evaluate the dangerfile as a failure, so Danger will post the error's stack in the Danger results table. Thoughts on this?

Running `danger pr` locally:

```
ts-node source/commands/danger-pr.ts https://github.com/danger/danger-js/pull/336
Unable to evaluate the Dangerfile
{
  fails: [
    {
      message: "```
Error: failure
    at Object.<anonymous> (/Users/macklinu/dev/danger/danger-js/dangerfile.ts:6:7)
    at NodeVM.run (/Users/macklinu/dev/danger/danger-js/node_modules/vm2/lib/main.js:424:27)
    at Object.<anonymous> (/Users/macklinu/dev/danger/danger-js/source/runner/DangerfileRunner.ts:123:24)
    at step (/Users/macklinu/dev/danger/danger-js/source/runner/DangerfileRunner.ts:40:23)
    at Object.next (/Users/macklinu/dev/danger/danger-js/source/runner/DangerfileRunner.ts:21:53)
    at /Users/macklinu/dev/danger/danger-js/source/runner/DangerfileRunner.ts:15:71
    at __awaiter (/Users/macklinu/dev/danger/danger-js/source/runner/DangerfileRunner.ts:11:12)
    at Object.runDangerfileEnvironment (/Users/macklinu/dev/danger/danger-js/source/runner/DangerfileRunner.ts:111:12)
    at /Users/macklinu/dev/danger/danger-js/source/commands/danger-pr.ts:108:61
    at step (/Users/macklinu/dev/danger/danger-js/source/commands/danger-pr.ts:32:23)
```"
    }
  ],
  warnings: [],
  messages: [],
  markdowns: []
}
```

Lemme know what you think about this solution, I think this addresses the issue mentioned in #250.