### PR TITLE
Use the diff url from the PR API instead of a version header to work with Peril

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@
 
 // TODO
 
+### 2.0.0-alpha.7
+
+* Uses the GitHub `diff_url` instead of the `diff` version header, as it conflicted with Peril - orta
+
 ### 2.0.0-alpha.6-7
 
 * Expose a Promise object to the external GitHub API - orta

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danger",
-  "version": "2.0.0-alpha.7",
+  "version": "2.0.0-alpha.8",
   "description": "Unit tests for Team Culture",
   "main": "distribution/danger.js",
   "typings": "distribution/danger.d.ts",

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -207,11 +207,9 @@ export class GitHubAPI {
   }
 
   async getPullRequestDiff(): Promise<string> {
-    const repo = this.repoMetadata.repoSlug
-    const prID = this.repoMetadata.pullRequestID
-    const res = await this.get(`repos/${repo}/pulls/${prID}`, {
-      accept: "application/vnd.github.v3.diff",
-    })
+    const prJSON = await this.getPullRequestInfo()
+    const diffURL = prJSON["diff_url"]
+    const res = await this.get(diffURL)
 
     return res.ok ? res.text() : ""
   }
@@ -282,8 +280,11 @@ export class GitHubAPI {
       headers["Authorization"] = `token ${this.token}`
     }
 
+    const containsBase = path.startsWith("http")
     const baseUrl = process.env["DANGER_GITHUB_API_BASE_URL"] || "https://api.github.com"
-    return this.fetch(`${baseUrl}/${path}`, {
+    const url = containsBase ? path : `${baseUrl}/${path}`
+
+    return this.fetch(url, {
       method: method,
       body: body,
       headers: {

--- a/source/platforms/github/GitHubGit.ts
+++ b/source/platforms/github/GitHubGit.ts
@@ -42,7 +42,6 @@ export default async function gitDSLForGitHub(api: GitHubAPI): Promise<GitDSL> {
 
   const pr = await api.getPullRequestInfo()
   const diff = await api.getPullRequestDiff()
-  const getCommits = await api.getPullRequestCommits()
 
   const fileDiffs: any[] = parseDiff(diff)
 
@@ -166,6 +165,7 @@ export default async function gitDSLForGitHub(api: GitHubAPI): Promise<GitDSL> {
     }
   }
 
+  const getCommits = await api.getPullRequestCommits()
   return {
     modified_files: modifiedDiffs.map(d => d.to),
     created_files: addedDiffs.map(d => d.to),


### PR DESCRIPTION
This should fix https://github.com/danger/peril/issues/121