### PR TITLE
Bugfix - FetchError: invalid json response body

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ### Master
 
-// TODO
+- Fixed #348 invalid json response body error - felipesabino
 
 ### 2.0.0-alpha.9
 

--- a/source/api/_tests/fetch.test.ts
+++ b/source/api/_tests/fetch.test.ts
@@ -1,0 +1,90 @@
+// import * as jest from 'jest';
+import * as http from "http"
+
+import { api } from "../fetch"
+
+interface ResponseMock {
+  body?: any
+  statusCode?: number
+  contentType?: string
+}
+
+class TestServer {
+  private port = 30001
+  private hostname = "localhost"
+  private response: ResponseMock = null
+  private router = (req, res) => {
+    res.statusCode = this.response && this.response.statusCode ? this.response.statusCode : 200
+    res.setHeader(
+      "Content-Type",
+      this.response && this.response.contentType ? this.response.contentType : "application/json"
+    )
+    res.end(this.response ? this.response.body : null)
+  }
+  private server = http.createServer(this.router)
+
+  start = async (response: ResponseMock): Promise<void> => {
+    this.response = response
+    return new Promise<void>((resolve, reject) => {
+      this.server.listen(this.port, this.hostname, err => (err ? reject(err) : resolve()))
+    })
+  }
+  stop = async (): Promise<void> => {
+    this.response = null
+    return new Promise<void>((resolve, reject) => {
+      this.server.close(err => (err ? reject(err) : resolve()))
+    })
+  }
+}
+
+describe("fetch", () => {
+  let url: string
+  let server = new TestServer()
+
+  beforeEach(() => {
+    url = "http://localhost:30001/"
+  })
+
+  afterEach(async () => {
+    await server.stop()
+  })
+
+  it("handles json success", async () => {
+    let body = { key: "valid json" }
+    await server.start({
+      body: JSON.stringify(body),
+    })
+
+    let response = await api(url, {})
+    expect(response.ok).toBe(true)
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject(body)
+  })
+
+  it("handles json error", async () => {
+    let body = { key: "valid json" }
+    await server.start({
+      body: JSON.stringify(body),
+      statusCode: 500,
+    })
+
+    let response = await api(url, {})
+    expect(response.ok).toBe(false)
+    expect(response.status).toBe(500)
+    expect(await response.json()).toMatchObject(body)
+  })
+
+  it("handles plain text error", async () => {
+    let body = "any plain text response"
+    await server.start({
+      body: body,
+      statusCode: 500,
+      contentType: "text/plain",
+    })
+
+    let response = await api(url, {})
+    expect(response.ok).toBe(false)
+    expect(response.status).toBe(500)
+    expect(await response.text()).toBe(body)
+  })
+})

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -1,14 +1,15 @@
-import { api as fetch } from "../../api/fetch"
-import { RepoMetaData } from "../../ci_source/ci_source"
-import { GitHubPRDSL, GitHubUser } from "../../dsl/GitHubDSL"
-import * as find from "lodash.find"
-import * as v from "voca"
-import * as parse from "parse-link-header"
-
-import * as node_fetch from "node-fetch"
 import * as GitHubNodeAPI from "github"
 import * as debug from "debug"
+import * as find from "lodash.find"
+import * as node_fetch from "node-fetch"
+import * as parse from "parse-link-header"
+import * as v from "voca"
+
+import { GitHubPRDSL, GitHubUser } from "../../dsl/GitHubDSL"
+
+import { RepoMetaData } from "../../ci_source/ci_source"
 import { dangerSignaturePostfix } from "../../runner/templates/githubIssueTemplate"
+import { api as fetch } from "../../api/fetch"
 
 // The Handle the API specific parts of the github
 
@@ -209,7 +210,9 @@ export class GitHubAPI {
   async getPullRequestDiff(): Promise<string> {
     const prJSON = await this.getPullRequestInfo()
     const diffURL = prJSON["diff_url"]
-    const res = await this.get(diffURL)
+    const res = await this.get(diffURL, {
+      accept: "application/vnd.github.v3.diff",
+    })
 
     return res.ok ? res.text() : ""
   }

--- a/source/platforms/github/_tests/_github_api.test.ts
+++ b/source/platforms/github/_tests/_github_api.test.ts
@@ -1,5 +1,5 @@
-import { GitHubAPI } from "../GitHubAPI"
 import { FakeCI } from "../../../ci_source/providers/Fake"
+import { GitHubAPI } from "../GitHubAPI"
 import { requestWithFixturedJSON } from "../../_tests/_github.test"
 
 const fetchJSON = (api, params): Promise<any> => {
@@ -9,6 +9,19 @@ const fetchJSON = (api, params): Promise<any> => {
         api,
         ...params,
       }),
+  })
+}
+
+const fetchText = (api, params): Promise<any> => {
+  return Promise.resolve({
+    ok: true,
+    text: () =>
+      Promise.resolve(
+        JSON.stringify({
+          api,
+          ...params,
+        })
+      ),
   })
 }
 
@@ -57,6 +70,20 @@ describe("API testing", () => {
     await api.updateCommentWithID(123, "Hello!")
 
     expect(api.patch).toHaveBeenCalledWith("repos/artsy/emission/issues/comments/123", {}, { body: "Hello!" })
+  })
+
+  it("getPullRequestDiff", async () => {
+    api.getPullRequestInfo = await requestWithFixturedJSON("github_pr.json")
+    api.fetch = fetchText
+    let text = await api.getPullRequestDiff()
+    expect(JSON.parse(text)).toMatchObject({
+      api: "https://github.com/artsy/emission/pull/327.diff",
+      headers: {
+        Authorization: "token ABCDE",
+        accept: "application/vnd.github.v3.diff",
+        "Content-Type": "application/json",
+      },
+    })
   })
 })
 


### PR DESCRIPTION
Issue: #348

A lot of uncertainties on my part here, so please review carefully 😬 

It seems that the main reason the problem was occurring was that the `api` function tried to always parse the response as `JSON`, even when the error response wasn't a valid JSON string.

I did not want to change too much on how dependencies are being handled and as `fetch.ts` file directly imports `node-fetch`, the only way I could think of testing it was to create a mock http server. It is not the most elegant solution and I guess I could use `jest` mock to do so, I tried that route a bit but it got so complex that I just gave up for now. Anyway, having the http server allowed testing without changing all dependency management for now and it should be versatile if future improvement on tests are needed.

Something else I stumbled upon was that calling either `.text()` or `.json()` on `node-fetch` are not idempotent actions, so in order to not mess with future usages of the response instance I cloned the object before messing with the object to retrieve the body for logging 😬 

I wasn't very sure either how to automatically test `getPullRequestDiff`, so for now I just added a test to make sure the correct headers are actually being sent. They were removed recently and I wasn't sure if it was on purpose, let me know if I need to rollback this change 🤔

