### PR TITLE
Merge accept requests 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,10 @@
 
 ### Master
 
-- Fixed #348 invalid json response body error - felipesabino
+### 2.0.0-alpha.12
+
+- Fixed #348 invalid json response body error on generating a diff - felipesabino
+- Potential fix for ^ that works with Peril also - orta
 
 ### 2.0.0-alpha.11
 

--- a/changelog.md
+++ b/changelog.md
@@ -40,7 +40,7 @@
 
   Which is basically Ruby Danger in ~10LOC. Lols.
 
-  This is the first release of the command, it's pretty untested, but it is usable IMO. - orta
+  This is the first release of the command, it's pretty untested, but [it does work][swift-first-pr]. - orta
 
 [danger-swift]: https://github.com/danger/danger-swift
 [swift-json]: https://github.com/danger/danger-swift/blob/master/fixtures/eidolon_609.json
@@ -48,6 +48,7 @@
 [swift-eval]: https://github.com/danger/danger-swift/blob/1576e336e41698861456533463c8821675427258/Sources/Runner/main.swift#L23-L40
 [swift-dangerfile]: https://github.com/danger/danger-swift/blob/1576e336e41698861456533463c8821675427258/Dangerfile.swift
 [swift-stdout]: https://github.com/danger/danger-swift/blob/1576e336e41698861456533463c8821675427258/Sources/Runner/main.swift#L48-L50
+[swift-first-pr]: https://github.com/danger/danger-swift/pull/12
 
 ### 2.0.0-alpha.9
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danger",
-  "version": "2.0.0-alpha.11",
+  "version": "2.0.0-alpha.12",
   "description": "Unit tests for Team Culture",
   "main": "distribution/danger.js",
   "typings": "distribution/danger.d.ts",

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -211,7 +211,7 @@ export class GitHubAPI {
     const prJSON = await this.getPullRequestInfo()
     const diffURL = prJSON["diff_url"]
     const res = await this.get(diffURL, {
-      accept: "application/vnd.github.v3.diff",
+      Accept: "application/vnd.github.v3.diff",
     })
 
     return res.ok ? res.text() : ""
@@ -287,6 +287,12 @@ export class GitHubAPI {
     const baseUrl = process.env["DANGER_GITHUB_API_BASE_URL"] || "https://api.github.com"
     const url = containsBase ? path : `${baseUrl}/${path}`
 
+    let customAccept = {}
+    if (headers.Accept && this.additionalHeaders.Accept) {
+      // We need to merge the accepts which are comma separated according to the HTML spec
+      // e.g. https://gist.github.com/LTe/5270348
+      customAccept = { Accept: `${this.additionalHeaders.Accept}, ${headers.Accept}` }
+    }
     return this.fetch(url, {
       method: method,
       body: body,
@@ -294,6 +300,7 @@ export class GitHubAPI {
         "Content-Type": "application/json",
         ...headers,
         ...this.additionalHeaders,
+        ...customAccept,
       },
     })
   }

--- a/source/platforms/github/_tests/_github_api.test.ts
+++ b/source/platforms/github/_tests/_github_api.test.ts
@@ -80,7 +80,7 @@ describe("API testing", () => {
       api: "https://github.com/artsy/emission/pull/327.diff",
       headers: {
         Authorization: "token ABCDE",
-        accept: "application/vnd.github.v3.diff",
+        Accept: "application/vnd.github.v3.diff",
         "Content-Type": "application/json",
       },
     })
@@ -104,6 +104,24 @@ describe("Peril", () => {
       headers: {
         Authorization: "token ABCDE",
         CUSTOM: "HEADER",
+        "Content-Type": "application/json",
+      },
+      method: "GET",
+    })
+  })
+
+  it("Merges two Accept headers", async () => {
+    api.additionalHeaders = { Accept: "application/vnd.github.machine-man-preview+json" }
+
+    const request = await api.get("user", {
+      Accept: "application/vnd.github.v3.diff",
+    })
+
+    expect(api.fetch).toHaveBeenCalledWith("https://api.github.com/user", {
+      body: {},
+      headers: {
+        Accept: "application/vnd.github.machine-man-preview+json, application/vnd.github.v3.diff",
+        Authorization: "token ABCDE",
         "Content-Type": "application/json",
       },
       method: "GET",


### PR DESCRIPTION
This expands on #348 and adds support [for merging accept headers](https://developer.github.com/v3/media/). The docs on the github API don't actually say what they'll expect, so I'm kinda hoping this'll just work given the spec and the ordering.

Converts "accept" to "Accept" as that's what's in the docs too.