### PR TITLE
Revert back to older version of the diff API code, now that merging A ccept headers works

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ### Master
 
+### 2.0.0-alpha.13
+
+- Move back to the original URLs for diffs, instead of relying on PR metadata - orta
+
 ### 2.0.0-alpha.12
 
 - Fixed #348 invalid json response body error on generating a diff - felipesabino

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -208,12 +208,11 @@ export class GitHubAPI {
   }
 
   async getPullRequestDiff(): Promise<string> {
-    const prJSON = await this.getPullRequestInfo()
-    const diffURL = prJSON["diff_url"]
-    const res = await this.get(diffURL, {
+    const repo = this.repoMetadata.repoSlug
+    const prID = this.repoMetadata.pullRequestID
+    const res = await this.get(`repos/${repo}/pulls/${prID}`, {
       Accept: "application/vnd.github.v3.diff",
     })
-
     return res.ok ? res.text() : ""
   }
 
@@ -233,7 +232,7 @@ export class GitHubAPI {
     const repo = this.repoMetadata.repoSlug
     const prID = this.repoMetadata.pullRequestID
     const res = await this.get(`repos/${repo}/pulls/${prID}/requested_reviewers`, {
-      accept: "application/vnd.github.black-cat-preview+json",
+      Accept: "application/vnd.github.black-cat-preview+json",
     })
 
     return res.ok ? res.json() : []
@@ -243,7 +242,7 @@ export class GitHubAPI {
     const repo = this.repoMetadata.repoSlug
     const prID = this.repoMetadata.pullRequestID
     const res = await this.get(`repos/${repo}/pulls/${prID}/reviews`, {
-      accept: "application/vnd.github.black-cat-preview+json",
+      Accept: "application/vnd.github.black-cat-preview+json",
     })
 
     return res.ok ? res.json() : []

--- a/source/platforms/github/_tests/_github_api.test.ts
+++ b/source/platforms/github/_tests/_github_api.test.ts
@@ -77,7 +77,7 @@ describe("API testing", () => {
     api.fetch = fetchText
     let text = await api.getPullRequestDiff()
     expect(JSON.parse(text)).toMatchObject({
-      api: "https://github.com/artsy/emission/pull/327.diff",
+      api: "https://api.github.com/repos/artsy/emission/pulls/1",
       headers: {
         Authorization: "token ABCDE",
         Accept: "application/vnd.github.v3.diff",


### PR DESCRIPTION
Brings Danger back to 1.x behaviour, but should work with Peril now. 👍 