### PR TITLE
Add more error checking around the babel import

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ### Master
 
+- Improve the error handling around the babel API - #357 - orta
+
 ### 2.0.0-alpha.13
 
 - Move back to the original URLs for diffs, instead of relying on PR metadata - orta

--- a/source/runner/DangerfileRunner.ts
+++ b/source/runner/DangerfileRunner.ts
@@ -183,7 +183,11 @@ const typescriptify = (content: string): string => {
 
 const babelify = (content: string, filename: string, extraPlugins: string[]): string => {
   const babel = require("babel-core") // tslint:disable-line
-  const options = babel.loadOptions({})
+  if (!babel.transform) {
+    return content
+  }
+
+  const options = babel.loadOptions ? babel.loadOptions({}) : { plugins: [] }
 
   const fileOpts = {
     filename,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1246,9 +1246,9 @@ cssom@0.3.x, "cssom@>= 0.3.0 < 0.4.0", "cssom@>= 0.3.2 < 0.4.0":
   dependencies:
     cssom "0.3.x"
 
-danger-plugin-yarn@^0.2.9:
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/danger-plugin-yarn/-/danger-plugin-yarn-0.2.9.tgz#89cac101aa98908dcbcb53f32abaa0d9931e5af7"
+danger-plugin-yarn@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/danger-plugin-yarn/-/danger-plugin-yarn-1.1.1.tgz#6ecd03e221ae8b71f51e089150a766e8c8d4b2c3"
   dependencies:
     date-fns "^1.28.5"
     lodash.flatten "^4.4.0"
@@ -1820,9 +1820,9 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-github@^9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/github/-/github-9.2.0.tgz#8a886dc40dd63636707dcaf99df3df26c59f16fc"
+github@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/github/-/github-10.0.0.tgz#701aa610ed6244b35d578d70b005d6b3859d2eff"
   dependencies:
     follow-redirects "0.0.7"
     https-proxy-agent "^1.0.0"


### PR DESCRIPTION
I've added some error handling to make the babel parser a bit more safe between different versions of babel, as Danger doesn't have a marked dependency - we can't write `babel-core > 5` or anything, so just need to play it safer.