### PR TITLE
Adds a generated project for testing non-babel + babel projects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,18 +18,30 @@ matrix:
     - greenkeeper-lockfile-upload
   - node_js: '6'
 
-  - node_js: '8'
-    before_script:
+  - node_js: '7'
+    script:
       - yarn build
       - mkdir danger_blank_test
       - cd danger_blank_test
       - yarn init --yes
       - yarn add file:..
-      - echo "" > dangerfile.js
-      - echo "Testing a blank Dangerfile on a fresh project"
+      - echo "warn('I warned you')" > dangerfile.js
+      - echo "Testing a blank Dangerfile on an empty project"
       - yarn danger -- run --text-only
       - cd ..
       - rm -rf danger_blank_test
+
+      - npm install -g create-react-app
+      - create-react-app danger_babel_test
+      - cd danger_babel_test
+      - yarn add file:..
+      - echo "warn('Expect 2 warnings'); const a = async () => {warn('the other');}; schedule(a)" > dangerfile.js
+      - echo "Testing a blank Dangerfile on a babel CRA project"
+      - yarn danger -- run --text-only
+      - cd ..
+      - rm -rf danger_babel_test
+
+  - node_js: '8'
 
 script:
 - yarn lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,19 @@ matrix:
     after_script:
     - greenkeeper-lockfile-upload
   - node_js: '6'
+
   - node_js: '8'
+    before_script:
+      - yarn build
+      - mkdir danger_blank_test
+      - cd danger_blank_test
+      - yarn init --yes
+      - yarn add file:..
+      - echo "" > dangerfile.js
+      - echo "Testing a blank Dangerfile on a fresh project"
+      - yarn danger -- run --text-only
+      - cd ..
+      - rm -rf danger_blank_test
 
 script:
 - yarn lint

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### Master
 
+- Adds a blank project generated in travis 8 to test no-babel or TS integration - orta
 ### 2.0.0-alpha.13
 
 - Improve the error handling around the babel API - #357 - orta


### PR DESCRIPTION
I'd like something to ensure that a project without babel or typescript works, it's looking like it's going to be hard to test that in the form of unit tests, so I've moved it up to integration tests.

This creates a new project, adds Danger, then runs it with no babel/typescript.