### PR TITLE
Look for more CircleCI PR environment variables

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ### Master
 
+// I'm adding it without a version number since I don't know what version it'll be if/when this is merged <_<
+
+- Improve CircleCI PR detection
+
 ### 2.0.0-alpha.16
 
 Some UX fixes:

--- a/source/ci_source/providers/Circle.ts
+++ b/source/ci_source/providers/Circle.ts
@@ -41,7 +41,7 @@ export class Circle implements CISource {
   }
 
   get isPR(): boolean {
-    if (ensureEnvKeysExist(this.env, ["CI_PULL_REQUEST"])) {
+    if (ensureEnvKeysExist(this.env, ["CI_PULL_REQUEST"]) || ensureEnvKeysExist(this.env, ["CIRCLE_PULL_REQUEST"])) {
       return true
     }
 
@@ -50,7 +50,7 @@ export class Circle implements CISource {
   }
 
   private _prParseURL(): { owner?: string; reponame?: string; id?: string } {
-    const prUrl = this.env.CI_PULL_REQUEST || ""
+    const prUrl = this.env.CI_PULL_REQUEST || this.env.CIRCLE_PULL_REQUEST || ""
     const splitSlug = prUrl.split("/")
     if (splitSlug.length === 7) {
       const owner = splitSlug[3]

--- a/source/ci_source/providers/_tests/_circle.test.ts
+++ b/source/ci_source/providers/_tests/_circle.test.ts
@@ -7,6 +7,7 @@ const correctEnv = {
   CIRCLE_PROJECT_REPONAME: "someproject",
   CIRCLE_BUILD_NUM: "1501",
   CIRCLE_PR_NUMBER: "800",
+  CIRCLE_PULL_REQUEST: "https://github.com/artsy/eigen/pull/800",
   CI_PULL_REQUEST: "https://github.com/artsy/eigen/pull/800",
 }
 
@@ -48,6 +49,7 @@ describe(".isPR", () => {
       CIRCLE_PROJECT_REPONAME: "someproject",
       CIRCLE_BUILD_NUM: "1501",
       CIRCLE_PR_NUMBER: "800",
+      CIRCLE_PULL_REQUEST: "https://github.com/artsy/eigen/pull/800",
       CI_PULL_REQUEST: "https://github.com/artsy/eigen/pull/800",
     }
     env[key] = null
@@ -68,7 +70,7 @@ describe(".isPR", () => {
   })
 })
 
-describe(".pullReuestID", () => {
+describe(".pullRequestID", () => {
   it("pulls it out of the env", () => {
     const circle = new Circle({ CIRCLE_PR_NUMBER: "800" })
     expect(circle.pullRequestID).toEqual("800")
@@ -77,6 +79,7 @@ describe(".pullReuestID", () => {
   it("can derive it from PR Url", () => {
     let env = {
       CI_PULL_REQUEST: "https://github.com/artsy/eigen/pull/23",
+      CIRCLE_PULL_REQUEST: "https://github.com/artsy/eigen/pull/23",
     }
     const circle = new Circle(env)
     expect(circle.pullRequestID).toEqual("23")

--- a/source/ci_source/providers/_tests/_circle.test.ts
+++ b/source/ci_source/providers/_tests/_circle.test.ts
@@ -79,10 +79,15 @@ describe(".pullRequestID", () => {
   it("can derive it from PR Url", () => {
     let env = {
       CI_PULL_REQUEST: "https://github.com/artsy/eigen/pull/23",
+    }
+    let env2 = {
       CIRCLE_PULL_REQUEST: "https://github.com/artsy/eigen/pull/23",
     }
     const circle = new Circle(env)
     expect(circle.pullRequestID).toEqual("23")
+
+    const circle2 = new Circle(env2)
+    expect(circle2.pullRequestID).toEqual("23")
   })
 })
 


### PR DESCRIPTION
Related issues: #326

Circle sometimes does _not_ export a `CI_PULL_REQUEST` environment variable, but seems to _always_ export a `CIRCLE_PULL_REQUEST` environment variable. They are always exactly the same value.

Take a look at these two screenshots. The top one, danger didn't run, the bottom, it did.

![image](https://user-images.githubusercontent.com/1108160/31021051-ae5d6c9c-a502-11e7-8133-19bbacf0c81d.png)
![image](https://user-images.githubusercontent.com/1108160/31021066-b8b51488-a502-11e7-8712-d3eb56ddd61b.png)

This PR adds support for the `CIRCLE_PULL_REQUEST` env var.