### PR TITLE
Passes through non-zero child process exit codes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 // I'm adding it without a version number since I don't know what version it'll be if/when this is merged <_<
 
 - Improve CircleCI PR detection
+- Passes through non-zero exit codes from `danger process` runs - ashfurrow
 
 ### 2.0.0-alpha.16
 

--- a/source/commands/utils/runDangerSubprocess.ts
+++ b/source/commands/utils/runDangerSubprocess.ts
@@ -40,7 +40,8 @@ const runDangerSubprocess = (subprocessName: string, dslJSONString: string, exec
   child.on("close", async code => {
     console.log(`child process exited with code ${code}`)
     // Submit an error back to the PR
-    if (process.exitCode) {
+    if (code) {
+      process.exitCode = code
       const results = resultsWithFailure(`${subprocessName}\` failed.`, "### Log\n\n" + markdownCode(allLogs))
       await exec.handleResults(results)
     }


### PR DESCRIPTION
Fixes ##363. I didn't see a straightforward way to test this, but I'm open to suggestions/pairing.

The root of the issue was checking for the `process.exitCode` instead of the `code` returned from the child process. Since the `DangerResults` have no way of inferring the code, I also set the `process.exitCode` to `code`. 