### PR TITLE
Add support for a flow definition file based on the TSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### 2.0.0-beta.2
 
 - Fixes a bug with `danger.github.utils` in that it didn't work as of b1, and now it does :+1: - [@orta][]
+- Ships a `danger.js.flow` in the root of the project, this may be enough to support flow typing, thanks to [@joarwilk][] 
+  and [flowgen](https://github.com/joarwilk/flowgen) - [@orta][]
 
 ### 2.0.0-beta.1
 
@@ -697,3 +699,4 @@ Not usable for others, only stubs of classes etc. - [@orta][]
 [danger-go]: https://github.com/bdotdub/danger-go
 [@orta]: https://github.com/orta
 [@ashfurrow]: https://github.com/ashfurrow
+[@joarwilk]: https://github.com/joarwilk

--- a/package.json
+++ b/package.json
@@ -35,8 +35,10 @@
     "test:watch": "jest --watch",
     "lint": "tslint \"source/**/*.ts\"",
     "lint:fix": "tslint \"source/**/*.ts\" --fix",
-    "prepublishOnly": "yarn run build && yarn declarations",
+    "prepublishOnly": "yarn run build && yarn declarations && yarn build:flow-types",
     "build": "shx rm -rf ./distribution && tsc -p tsconfig.production.json && madge ./distribution --circular",
+    "build:flow-types":
+      "cp source/danger.d.ts source/_danger.d.ts; sed -ie 's/api: GitHub/api: any/g' source/_danger.d.ts; npx flowgen source/_danger.d.ts -o distribution/danger.js.flow; rm source/_danger.d.ts",
     "build:watch": "tsc -w",
     "link": "yarn run build && chmod +x distribution/commands/danger.js && npm link",
     "declarations": "ts-node ./scripts/create-danger-dts.ts",


### PR DESCRIPTION
Fixes https://github.com/danger/danger-js/issues/178

This was surprisingly simple once I found [flowgen](https://github.com/joarwilk/flowgen) - Danger references one external module ( the GH API ) which doesn't work with flown - so for Flow, that can just be an `any` for now.