### PR TITLE
Add .jest folder to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,3 +13,4 @@ dangerfile.js
 env
 jsconfig.json
 coverage
+.jest


### PR DESCRIPTION
It's around 70mb, and it's currently part of the npm package.

```bash
$ npm init -y
$ npm install danger
$ du -hc -d 2 node_modules/danger
  0B	node_modules/danger/node_modules/.bin
 16K	node_modules/danger/distribution/api
 36K	node_modules/danger/types
100K	node_modules/danger/node_modules
100K	node_modules/danger/node_modules/debug
104K	node_modules/danger/distribution/dsl
144K	node_modules/danger/distribution/platforms
148K	node_modules/danger/distribution/commands
180K	node_modules/danger/distribution/runner
204K	node_modules/danger/distribution/ci_source
848K	node_modules/danger/distribution
 75M	node_modules/danger/.jest
 75M	node_modules/danger/.jest/cache
 76M	node_modules/danger
 76M	total
```

It's ignored by the .gitignore, but IIRC npm ignores the .gitignore completely once you add a .npmignore file.