### PR TITLE
Adds a note about how the danger import is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 // ### Master
 
+- Adds a warning when you try to import Danger when you're not in a Dangerfole - [@orta][]
+
 ### 2.0.1
 
 - Potential fixes for CLI sub-commands not running when packaging danger - [@orta][]

--- a/source/danger.ts
+++ b/source/danger.ts
@@ -1,2 +1,15 @@
 // This file represents the module that is exposed as the danger API
-import "babel-polyfill"
+
+throw `
+Hey there, it looks like you're trying to import the danger module. Turns out
+that the code you write in a Dangerfile.js is actually a bit of a sneaky hack. 
+
+When running Danger, the import or require for Danger is removed before the code
+is evaluated. Instead all of the imports are added to the global runtime, so if
+you are importing Danger to use one of it's functions - you should instead just
+use the global object for the root DSL elements.
+
+There is a spectrum thread for discussion here:
+  - https://spectrum.chat/?t=0a005b56-31ec-4919-9a28-ced623949d4d
+
+`


### PR DESCRIPTION
Re: #425 - throws a warning, with docs and a link for support when you import Danger in a non-dangerfile.