### PR TITLE
Adds an overwrite for the TS module system when transpiling our TS code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ developers, so please limit technical // terminology to in here.
 
 // ### Master
 
+### 2.1.5
+
+* The TS compiler will force a module type of commonjs when transpiling the Dangerfile - [@orta][]
+
 ### 2.1.4
 
 * Adds a CLI option for a unique Danger ID per run to `danger` and `danger process`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danger",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Unit tests for Team Culture",
   "main": "distribution/danger.js",
   "typings": "distribution/danger.d.ts",

--- a/source/runner/runners/utils/_tests/_transpiler.test.ts
+++ b/source/runner/runners/utils/_tests/_transpiler.test.ts
@@ -1,0 +1,22 @@
+jest.mock("fs", () => ({
+  readFileSync: jest.fn(),
+}))
+
+import { typescriptify } from "../transpiler"
+import * as fs from "fs"
+
+describe("typescriptify", () => {
+  it("removes the module option in a tsconfig ", () => {
+    const dangerfile = `import {a} from 'lodash'; a()`
+    const fakeTSConfig = {
+      compilerOptions: {
+        target: "es5",
+        module: "es2015",
+      },
+    }
+    const fsMock = fs.readFileSync as any
+    fsMock.mockImplementationOnce(() => JSON.stringify(fakeTSConfig))
+
+    expect(typescriptify(dangerfile)).not.toContain("import")
+  })
+})


### PR DESCRIPTION
Looking at https://github.com/apollographql/react-apollo/pull/1402 I spotted that the TSC compilation process was generating code that wouldn't run on vanilla node. This ensures all that code works today.