### PR TITLE
Improve status updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
     - yarn docs
     - yarn add dtslint@0.1.2
     - yarn dts-lint
+    - echo "--Shell Export Lists START--" ; export -p; echo "--Shell Export Lists STOP--"
 
   # Checks every example dangerfile can run in `danger runner`.
   - node_js: '8.4'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ matrix:
     - yarn docs
     - yarn add dtslint@0.1.2
     - yarn dts-lint
-    - echo "--Shell Export Lists START--" ; export -p; echo "--Shell Export Lists STOP--"
 
   # Checks every example dangerfile can run in `danger runner`.
   - node_js: '8.4'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ developers, so please limit technical // terminology to in here.
 // ### Master
 
 * Updates dependencies - orta
+* Link to the build URL if Danger can find it in the CI env - orta
+* Removes the "couldn't post a status" message - orta
 
 ### 2.1.5
 

--- a/source/ci_source/ci_source.ts
+++ b/source/ci_source/ci_source.ts
@@ -31,4 +31,7 @@ export interface CISource {
 
   /** allows the source to do some setup */
   setup?(): Promise<any>
+
+  /** Optional URL for the CI run, for a status update link */
+  readonly ciRunURL?: string
 }

--- a/source/ci_source/providers/Buildkite.ts
+++ b/source/ci_source/providers/Buildkite.ts
@@ -46,10 +46,16 @@ export class Buildkite implements CISource {
   get pullRequestID(): string {
     return this.env.BUILDKITE_PULL_REQUEST
   }
+
   get repoSlug(): string {
     return this._parseRepoURL()
   }
+
   get supportedPlatforms(): string[] {
     return ["github"]
+  }
+
+  get ciRunURL() {
+    return process.env.BUILDKITE_BUILD_URL
   }
 }

--- a/source/ci_source/providers/Circle.ts
+++ b/source/ci_source/providers/Circle.ts
@@ -71,7 +71,12 @@ export class Circle implements CISource {
   get repoURL(): string {
     return this.env.CIRCLE_REPOSITORY_URL
   }
+
   get supportedPlatforms(): string[] {
     return ["github"]
+  }
+
+  get ciRunURL() {
+    return this.env["CIRCLE_BUILD_URL"]
   }
 }

--- a/source/ci_source/providers/Codeship.ts
+++ b/source/ci_source/providers/Codeship.ts
@@ -1,6 +1,8 @@
 import { Env, CISource } from "../ci_source"
 import { ensureEnvKeysExist, getPullRequestIDForBranch } from "../ci_source_helpers"
 
+// https://documentation.codeship.com/pro/builds-and-configuration/environment-variables/
+
 /**
  * ### CI Setup
  *

--- a/source/ci_source/providers/Jenkins.ts
+++ b/source/ci_source/providers/Jenkins.ts
@@ -2,6 +2,7 @@ import { Env, CISource } from "../ci_source"
 import { ensureEnvKeysExist, ensureEnvKeysAreInt } from "../ci_source_helpers"
 
 // https://jenkins.io/
+// https://wiki.jenkins.io/display/JENKINS/Building+a+software+project#Buildingasoftwareproject-belowJenkinsSetEnvironmentVariables
 
 /**
  * ### CI Setup
@@ -52,5 +53,9 @@ export class Jenkins implements CISource {
 
   get supportedPlatforms(): string[] {
     return ["github"]
+  }
+
+  get ciRunURL() {
+    return process.env.BUILD_URL
   }
 }

--- a/source/ci_source/providers/Travis.ts
+++ b/source/ci_source/providers/Travis.ts
@@ -42,10 +42,16 @@ export class Travis implements CISource {
   get pullRequestID(): string {
     return this.env.TRAVIS_PULL_REQUEST
   }
+
   get repoSlug(): string {
     return this.env.TRAVIS_REPO_SLUG
   }
-  get supportedPlatforms(): string[] {
+
+  get ciRunURL() {
+    return this.env["CIRCLE_BUILD_URL"]
+  }
+
+  get supportedPlatforms() {
     return ["github"]
   }
 }

--- a/source/ci_source/providers/Travis.ts
+++ b/source/ci_source/providers/Travis.ts
@@ -48,10 +48,45 @@ export class Travis implements CISource {
   }
 
   get ciRunURL() {
-    return this.env["CIRCLE_BUILD_URL"]
+    // TODO: This only supports travis.org
+    return `https://travis-ci.org/${this.env.TRAVIS_REPO_SLUG}/jobs/${this.env.TRAVIS_JOB_ID}`
   }
 
   get supportedPlatforms() {
     return ["github"]
   }
 }
+
+// See end of https://travis-ci.org/danger/danger-js/jobs/317790046
+//
+//  TRAVIS="true"
+//  TRAVIS_ALLOW_FAILURE="false"
+//  TRAVIS_BRANCH="env_improve"
+//  TRAVIS_BUILD_DIR="/home/travis/build/danger/danger-js"
+//  TRAVIS_BUILD_ID="317790044"
+//  TRAVIS_BUILD_NUMBER="1840"
+//  TRAVIS_COMMIT="b8a4f70062810274ee8ae155b2bbe4d0b4e0ddf4"
+//  TRAVIS_COMMIT_MESSAGE="[Env] Start work on improving the status message"
+//  TRAVIS_COMMIT_RANGE="1469195a5f86...b8a4f7006281"
+//  TRAVIS_EVENT_TYPE="push"
+//  TRAVIS_JOB_ID="317790046"
+//  TRAVIS_JOB_NUMBER="1840.2"
+//  TRAVIS_LANGUAGE="node_js"
+//  TRAVIS_NODE_VERSION="8"
+//  TRAVIS_OS_NAME="linux"
+//  TRAVIS_PRE_CHEF_BOOTSTRAP_TIME="2017-12-05T19:33:30"
+//  TRAVIS_PULL_REQUEST="false"
+//  TRAVIS_PULL_REQUEST_BRANCH=""
+//  TRAVIS_PULL_REQUEST_SHA=""
+//  TRAVIS_PULL_REQUEST_SLUG=""
+//  TRAVIS_REPO_SLUG="danger/danger-js"
+//  TRAVIS_SECURE_ENV_VARS="false"
+//  TRAVIS_STACK_FEATURES="basic cassandra chromium couchdb disabled-ipv6 docker docker-compose elasticsearch firefox go-toolchain google-chrome jdk //  neo4j nodejs_interpreter perl_interpreter perlbrew phantomjs postgresql python_interpreter rabbitmq redis riak ruby_interpreter sqlite //  TRAVIS_STACK_JOB_BOARD_REGISTER="/.job-board-register.yml"
+//  TRAVIS_STACK_LANGUAGES="__garnet__ c c++ clojure cplusplus cpp default go groovy java node_js php pure_java python ruby scala"
+//  TRAVIS_STACK_NAME="garnet"
+//  TRAVIS_STACK_NODE_ATTRIBUTES="/.node-attributes.yml"
+//  TRAVIS_STACK_TIMESTAMP="2017-12-05 19:33:46 UTC"
+//  TRAVIS_SUDO="false"
+//  TRAVIS_TAG=""
+//  TRAVIS_TEST_RESULT="0"
+//  TRAVIS_UID="2000"

--- a/source/ci_source/providers/_tests/_travis.test.ts
+++ b/source/ci_source/providers/_tests/_travis.test.ts
@@ -5,6 +5,7 @@ const correctEnv = {
   HAS_JOSH_K_SEAL_OF_APPROVAL: "true",
   TRAVIS_PULL_REQUEST: "800",
   TRAVIS_REPO_SLUG: "artsy/eigen",
+  TRAVIS_JOB_ID: "317790046",
 }
 
 describe("being found when looking for CI", () => {
@@ -74,5 +75,12 @@ describe(".repoSlug", () => {
   it("pulls it out of the env", () => {
     const travis = new Travis(correctEnv)
     expect(travis.repoSlug).toEqual("artsy/eigen")
+  })
+})
+
+describe(".ciRunURL", () => {
+  it("pulls it out of the env", () => {
+    const travis = new Travis(correctEnv)
+    expect(travis.ciRunURL).toEqual("https://travis-ci.org/artsy/eigen/jobs/317790046")
   })
 })

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -258,7 +258,7 @@ export class GitHubAPI {
     return res.ok ? res.json() : { labels: [] }
   }
 
-  async updateStatus(passed: boolean, message: string): Promise<any> {
+  async updateStatus(passed: boolean, message: string, url?: string): Promise<any> {
     const repo = this.repoMetadata.repoSlug
 
     const prJSON = await this.getPullRequestInfo()
@@ -269,7 +269,7 @@ export class GitHubAPI {
       {
         state: passed ? "success" : "failure",
         context: process.env["PERIL_INTEGRATION_ID"] ? "Peril" : "Danger",
-        target_url: "http://danger.systems/js",
+        target_url: url || "http://danger.systems/js",
         description: message,
       }
     )

--- a/source/platforms/platform.ts
+++ b/source/platforms/platform.ts
@@ -42,7 +42,7 @@ export interface Platform {
   /** Replace the main Danger comment */
   updateOrCreateComment: (dangerID: string, newComment: string) => Promise<any>
   /** Sets the current PR's status */
-  updateStatus: (passed: boolean, message: string) => Promise<boolean>
+  updateStatus: (passed: boolean, message: string, url?: string) => Promise<boolean>
 }
 
 /**

--- a/source/runner/Executor.ts
+++ b/source/runner/Executor.ts
@@ -168,7 +168,7 @@ export class Executor {
 
     const dangerID = this.options.dangerID
     const failed = fails.length > 0
-    const successPosting = await this.platform.updateStatus(!failed, messageForResults(results))
+    const successPosting = await this.platform.updateStatus(!failed, messageForResults(results), this.ciSource.ciRunURL)
     if (this.options.verbose) {
       console.log("Could not add a commit status, the GitHub token for Danger does not have access rights.")
       console.log("If the build fails, then danger will use a failing exit code.")

--- a/source/runner/_tests/_executor.test.ts
+++ b/source/runner/_tests/_executor.test.ts
@@ -8,6 +8,7 @@ const defaultConfig = {
   stdoutOnly: false,
   verbose: false,
   jsonOnly: false,
+  dangerID: "123",
 }
 
 describe("setup", () => {
@@ -86,11 +87,12 @@ describe("setup", () => {
     await exec.handleResults(warnResults)
     expect(platform.updateStatus).toBeCalledWith(
       true,
-      "⚠️ Danger found some issues. Don't worry, everything is fixable."
+      "⚠️ Danger found some issues. Don't worry, everything is fixable.",
+      undefined
     )
   })
 
-  it("Updates the status with success for a passed results", async () => {
+  it("Updates the status with success for failing results", async () => {
     const platform = new FakePlatform()
     const exec = new Executor(new FakeCI({}), platform, inlineRunner, defaultConfig)
     platform.updateOrCreateComment = jest.fn()
@@ -99,7 +101,21 @@ describe("setup", () => {
     await exec.handleResults(failsResults)
     expect(platform.updateStatus).toBeCalledWith(
       false,
-      "⚠️ Danger found some issues. Don't worry, everything is fixable."
+      "⚠️ Danger found some issues. Don't worry, everything is fixable.",
+      undefined
     )
+  })
+
+  it("Passes the URL from a platform to the updateStatus", async () => {
+    const platform = new FakePlatform()
+    const ci: any = new FakeCI({})
+    ci.ciRunURL = "https://url.com"
+
+    const exec = new Executor(ci, platform, inlineRunner, defaultConfig)
+    platform.updateOrCreateComment = jest.fn()
+    platform.updateStatus = jest.fn()
+
+    await exec.handleResults(failsResults)
+    expect(platform.updateStatus).toBeCalledWith(expect.anything(), expect.anything(), ci.ciRunURL)
   })
 })


### PR DESCRIPTION
* Removes the error log if it fails
* Gives a better URL 

I swear that @keith once mentioned that the status URL could be the CI build URL, but couldn't find the reference. So, I've built that out, as that's useful.

The key is the error messages, that request will fail on most OSS repos, so it shouldn't show a message.