### PR TITLE
fix codeship - actually return the json from api.getPullRequests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ developers, so please limit technical // terminology to in here.
 
 // ### Master
 
+### 2.1.7
+
+* Fix Codeship integration - [#caffodian][]
+
 ### 2.1.6
 
 * Updates dependencies - [@orta][]

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -227,7 +227,7 @@ export class GitHubAPI {
     const repo = this.repoMetadata.repoSlug
     const res = await this.get(`repos/${repo}/pulls`)
 
-    return res.ok ? res.json : []
+    return res.ok ? res.json() : []
   }
 
   async getReviewerRequests(): Promise<any> {


### PR DESCRIPTION
#120 

This PR may not be quite ready, for several reasons, but help is welcome:

Firstly, I'm not sure if there's any nice way to test this.  This code doesn't look used outside of Codeship.  Due to the issues below, I'm also unable to build danger-js. :/  

I'm not a typescript user in my day to day. Doing a straight up "yarn install", the pre-commit and prepush hooks are both broken in different ways. For some reason, prettier never actually finishes running in the pre-commit, even though this change is just to 1 file. 

The prepush hook  to `yarn run build` fails with the following:

```
yarn run v0.27.5
$ shx rm -rf ./distribution && tsc -p tsconfig.production.json && madge ./distribution --circular

503     interface Mock<T = {}> extends Function, MockInstance<T> {
                         ~

node_modules/@types/jest/index.d.ts(503,22): error TS1005: ',' expected.


503     interface Mock<T = {}> extends Function, MockInstance<T> {
                           ~

node_modules/@types/jest/index.d.ts(503,24): error TS1005: '>' expected.


503     interface Mock<T = {}> extends Function, MockInstance<T> {
                             ~

node_modules/@types/jest/index.d.ts(503,26): error TS1109: Expression expected.


503     interface Mock<T = {}> extends Function, MockInstance<T> {
                               ~~~~~~~

node_modules/@types/jest/index.d.ts(503,28): error TS1109: Expression expected.


505         (...args: any[]): any;
            ~

node_modules/@types/jest/index.d.ts(505,9): error TS1005: ',' expected.


505         (...args: any[]): any;
                    ~

node_modules/@types/jest/index.d.ts(505,17): error TS1005: ',' expected.


505         (...args: any[]): any;
                            ~

node_modules/@types/jest/index.d.ts(505,25): error TS1005: ';' expected.


508     interface SpyInstance<T = {}> extends MockInstance<T> {
                                ~

node_modules/@types/jest/index.d.ts(508,29): error TS1005: ',' expected.


508     interface SpyInstance<T = {}> extends MockInstance<T> {
                                  ~

node_modules/@types/jest/index.d.ts(508,31): error TS1005: '>' expected.


508     interface SpyInstance<T = {}> extends MockInstance<T> {
                                    ~

node_modules/@types/jest/index.d.ts(508,33): error TS1109: Expression expected.


508     interface SpyInstance<T = {}> extends MockInstance<T> {
                                      ~~~~~~~

node_modules/@types/jest/index.d.ts(508,35): error TS1109: Expression expected.


541 }
    ~

node_modules/@types/jest/index.d.ts(541,1): error TS1128: Declaration or statement expected.

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

I've attempted to bump the @types/jest version, but doesn't fix it. Typescript looks up to date too.  



