### PR TITLE
Only run the default runner when there are no args (e.g. no calls to the subcommands)

### DIFF
--- a/source/commands/danger.ts
+++ b/source/commands/danger.ts
@@ -29,4 +29,6 @@ program
 setSharedArgs(program).parse(process.argv)
 
 const app = (program as any) as SharedCLI
-runRunner(app)
+if (app.args.length === 0) {
+  runRunner(app)
+}


### PR DESCRIPTION
I think Danger is always being ran, on every run because it's happening for `danger` and for `danger pr` for example.