### PR TITLE
Fix tsconfig read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ developers, so please limit technical // terminology to in here.
 * Updates documentation dependencies - [@orta][]
 * Fixes to running `danger` with params - [@orta][]
 * Fixes for `danger pr` not acting like `danger` WRT async code - [@orta][]
+* Fixes `tsconfig.json` parse to be JSON5 friendly - [@gantman][]
 
 ### 2.1.6
 

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "github": "^13.0.1",
     "hyperlinker": "^1.0.0",
     "jsome": "^2.3.25",
+    "json5": "^0.5.1",
     "jsonpointer": "^4.0.1",
     "lodash.find": "^4.6.0",
     "lodash.includes": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@types/debug": "0.0.30",
     "@types/get-stdin": "^5.0.1",
     "@types/jest": "^21.1.9",
+    "@types/json5": "^0.0.29",
     "@types/lodash.includes": "^4.3.3",
     "@types/node-fetch": "^1.6.6",
     "@types/readline-sync": "^1.4.2",

--- a/source/runner/runners/utils/transpiler.ts
+++ b/source/runner/runners/utils/transpiler.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs"
 import * as path from "path"
+import JSON5 from "json5"
 
 let hasNativeTypeScript = false
 let hasBabel = false
@@ -33,7 +34,7 @@ try {
 
 export const typescriptify = (content: string): string => {
   const ts = require("typescript") // tslint:disable-line
-  const compilerOptions = JSON.parse(fs.readFileSync("tsconfig.json", "utf8"))
+  const compilerOptions = JSON5.parse(fs.readFileSync("tsconfig.json", "utf8"))
   let result = ts.transpileModule(content, sanitizeTSConfig(compilerOptions))
   return result.outputText
 }

--- a/source/runner/runners/utils/transpiler.ts
+++ b/source/runner/runners/utils/transpiler.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs"
 import * as path from "path"
-import JSON5 from "json5"
+import * as JSON5 from "json5"
 
 let hasNativeTypeScript = false
 let hasBabel = false

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,6 +38,10 @@
   version "21.1.9"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-21.1.9.tgz#a913d6224e9d8a1f24908af536f65b5bf4d489bc"
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+
 "@types/lodash.includes@^4.3.3":
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/@types/lodash.includes/-/lodash.includes-4.3.3.tgz#c823cc87ef331577fb5e9f5afd103d8b03cece79"


### PR DESCRIPTION
tsconfig.json now read in as JSON5 format.
* Types included.  
* Couldn't think of a test that doesn't just test that JSON5 works, so no tests added.

----
Fixes #454