### PR TITLE
Fixes to github.thisPR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@ developers, so please limit technical // terminology to in here.
 
 // ### Master
 
-<<<<<<< HEAD
-
 ### 2.1.7
 
 * Fix Codeship integration - [@caffodian][]
@@ -12,6 +10,7 @@ developers, so please limit technical // terminology to in here.
 * Fixes to running `danger` with params - [@orta][]
 * Fixes for `danger pr` not acting like `danger` WRT async code - [@orta][]
 * Fixes `tsconfig.json` parse to be JSON5 friendly - [@gantman][]
+* Fixes for `danger.github.thisPR` to use the base metadata for a PR, I'm too used to branch workflows - [@orta][]
 
 ### 2.1.6
 

--- a/source/platforms/GitHub.ts
+++ b/source/platforms/GitHub.ts
@@ -160,8 +160,8 @@ export class GitHub {
   APIMetadataForPR(pr: GitHubPRDSL): GitHubAPIPR {
     return {
       number: pr.number,
-      repo: pr.head.repo.name,
-      owner: pr.head.repo.owner.login,
+      repo: pr.base.repo.name,
+      owner: pr.base.repo.owner.login,
     }
   }
 }

--- a/source/platforms/_tests/_github.test.ts
+++ b/source/platforms/_tests/_github.test.ts
@@ -99,7 +99,7 @@ describe("getPlatformDSLRepresentation", () => {
 
     expect(dsl.thisPR).toEqual({
       number: 327,
-      owner: "orta",
+      owner: "artsy",
       repo: "emission",
     })
   })


### PR DESCRIPTION
Spotted in Peril that the details for `GitHub.thisPR` on this PR #456 were wrong:

<img width="791" alt="screen shot 2017-12-26 at 11 17 28 pm" src="https://user-images.githubusercontent.com/49038/34370560-0808a07e-ea93-11e7-9018-c89346745624.png">

