### PR TITLE
Add a note about setting up a token in danger pr

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,7 +9,7 @@ docs
 .editorconfig
 .babelrc
 scripts
-dangerfile.js
+dangerfile.ts
 env
 jsconfig.json
 coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+<!--
+
 // Please add your own contribution below inside the Master section
 // These docs are aimed at users rather than danger developers, so please limit technical
 // terminology to in here.
 
-// ### Master
+-->
+
+## Master
+
+* Add a note in `danger pr` if you don't have a token set up - [@orta][]
 
 ### 2.1.7
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danger",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "Unit tests for Team Culture",
   "main": "distribution/danger.js",
   "typings": "distribution/danger.d.ts",

--- a/source/commands/danger-pr.ts
+++ b/source/commands/danger-pr.ts
@@ -50,10 +50,16 @@ if (program.args.length === 0) {
     // TODO: Use custom `fetch` in GitHub that stores and uses local cache if PR is closed, these PRs
     //       shouldn't change often and there is a limit on API calls per hour.
 
+    const token = process.env["DANGER_GITHUB_API_TOKEN"]
+    if (!token) {
+      console.log("You don't have a DANGER_GITHUB_API_TOKEN set up, this is optional, but TBH, you want to do this")
+      console.log("Check out: http://danger.systems/js/guides/the_dangerfile.html#working-on-your-dangerfile")
+    }
+
     if (validateDangerfileExists(dangerFile)) {
       d(`executing dangerfile at ${dangerFile}`)
       const source = new FakeCI({ DANGER_TEST_REPO: pr.repo, DANGER_TEST_PR: pr.pullRequestNumber })
-      const api = new GitHubAPI(source, process.env["DANGER_GITHUB_API_TOKEN"])
+      const api = new GitHubAPI(source, token)
       const platform = new GitHub(api)
       if (app.json || app.js) {
         runHalfProcessJSON(platform)

--- a/source/runner/Executor.ts
+++ b/source/runner/Executor.ts
@@ -1,4 +1,4 @@
-import { contextForDanger, DangerContext } from "../runner/Dangerfile"
+import { contextForDanger, DangerContext } from "./Dangerfile"
 import { DangerDSL } from "../dsl/DangerDSL"
 import { CISource } from "../ci_source/ci_source"
 import { Platform } from "../platforms/platform"


### PR DESCRIPTION
* also fixes release bug where the npmignore would ignore a file called `dangerfile.ts` that was nested deep, I guess at some point the ignore was improved in npm and I updated
