### PR TITLE
Check that the danger invocation isn't straight `danger`

### DIFF
--- a/source/commands/danger.ts
+++ b/source/commands/danger.ts
@@ -34,6 +34,7 @@ program
 
 program.parse(process.argv)
 
-if (process.env.CI) {
+const showUpgradeNotice = process.env.CI && ['init', 'ci', 'process', 'pr', '--help'].some(cmd => process.argv.includes(cmd))
+if (showUpgradeNotice) {
   console.error("You may have updated from Danger 2.x -> 3.x without updating from `danger` to `danger ci`.")
 }


### PR DESCRIPTION
Addresses https://github.com/danger/danger-js/issues/470

Checks that the `danger` command was invoked by way of some subcommand.