### PR TITLE
Add Bitrise as a CI provider

### DIFF
--- a/source/ci_source/providers/Bitrise.ts
+++ b/source/ci_source/providers/Bitrise.ts
@@ -1,0 +1,69 @@
+import { Env, CISource } from "../ci_source"
+import { ensureEnvKeysExist, ensureEnvKeysAreInt } from "../ci_source_helpers"
+/**
+ * ### CI Setup
+ *  You need to edit your `bitrise.yml` (in version control, or directly from UI) to include `yarn danger ci`.
+ *
+ *   You can set "is_always_run: true" to ensure that it reports even if previous steps fails
+ *
+ *   ```yaml
+ *     workflows:
+ *       <your_workflow_name>:
+ *         steps:
+ *         - yarn:
+ *           inputs:
+ *           - args: ci
+ *           - command: danger
+ *           is_always_run: true
+ *   ```
+ *
+ *  Adding this to your `bitrise.yml` allows Danger to fail your build, both on the Bitrise website and within your Pull Request.
+ *  With that set up, you can edit your job to add `yarn danger ci` at the build action.
+ *
+ *  ### Token Setup
+ *
+ *  You need to add the `DANGER_GITHUB_API_TOKEN` environment variable, to do this,
+ *  go to your repo's secrets, which should look like: `https://www.bitrise.io/app/[app_id]#/workflow` and secrets tab.
+ *
+ *  You should check the case "Expose for Pull Requests?".
+ */
+export class Bitrise implements CISource {
+  constructor(private readonly env: Env) {}
+
+  get name(): string {
+    return "Bitrise"
+  }
+
+  get isCI(): boolean {
+    return ensureEnvKeysExist(this.env, ["BITRISE_IO"])
+  }
+
+  get isPR(): boolean {
+    const mustHave = ["GIT_REPOSITORY_URL"]
+    const mustBeInts = ["BITRISE_PULL_REQUEST"]
+    return ensureEnvKeysExist(this.env, mustHave) && ensureEnvKeysAreInt(this.env, mustBeInts)
+  }
+
+  private _parseRepoURL(): string {
+    const repoURL = this.env.GIT_REPOSITORY_URL
+    const regexp = new RegExp("([/:])([^/]+/[^/.]+)(?:.git)?$")
+    const matches = repoURL.match(regexp)
+    return matches ? matches[2] : ""
+  }
+
+  get pullRequestID(): string {
+    return this.env.BITRISE_PULL_REQUEST
+  }
+
+  get repoSlug(): string {
+    return this._parseRepoURL()
+  }
+
+  get supportedPlatforms(): string[] {
+    return ["github"]
+  }
+
+  get ciRunURL() {
+    return process.env.BITRISE_PULL_REQUEST
+  }
+}

--- a/source/ci_source/providers/_tests/_bitrise.test.ts
+++ b/source/ci_source/providers/_tests/_bitrise.test.ts
@@ -1,0 +1,75 @@
+import { Bitrise } from "../Bitrise"
+import { getCISourceForEnv } from "../../get_ci_source"
+
+const correctEnv = {
+  BITRISE_IO: "true",
+  BITRISE_PULL_REQUEST: "800",
+  GIT_REPOSITORY_URL: "https://github.com/artsy/eigen",
+}
+
+describe("being found when looking for CI", () => {
+  it("finds Bitrise with the right ENV", () => {
+    const ci = getCISourceForEnv(correctEnv)
+    expect(ci).toBeInstanceOf(Bitrise)
+  })
+})
+
+describe(".isCI", () => {
+  it("validates when all Bitrise environment vars are set", () => {
+    const bitrise = new Bitrise(correctEnv)
+    expect(bitrise.isCI).toBeTruthy()
+  })
+
+  it("does not validate without env", () => {
+    const bitrise = new Bitrise({})
+    expect(bitrise.isCI).toBeFalsy()
+  })
+})
+
+describe(".isPR", () => {
+  it("validates when all bitrise environment vars are set", () => {
+    const bitrise = new Bitrise(correctEnv)
+    expect(bitrise.isPR).toBeTruthy()
+  })
+
+  it("does not validate outside of bitrise", () => {
+    const bitrise = new Bitrise({})
+    expect(bitrise.isPR).toBeFalsy()
+  })
+
+  const envs = ["BITRISE_PULL_REQUEST", "GIT_REPOSITORY_URL", "BITRISE_IO"]
+  envs.forEach((key: string) => {
+    let env = { ...correctEnv }
+    env[key] = null
+
+    it(`does not validate when ${key} is missing`, () => {
+      const bitrise = new Bitrise(env)
+      expect(bitrise.isCI && bitrise.isPR).toBeFalsy()
+    })
+  })
+})
+
+describe(".pullRequestID", () => {
+  it("pulls it out of the env", () => {
+    const bitrise = new Bitrise({
+      BITRISE_PULL_REQUEST: "800",
+    })
+    expect(bitrise.pullRequestID).toEqual("800")
+  })
+})
+
+describe(".repoSlug", () => {
+  it("derives it from the repo URL", () => {
+    const bitrise = new Bitrise(correctEnv)
+    expect(bitrise.repoSlug).toEqual("artsy/eigen")
+  })
+
+  it("derives it from the repo URL in SSH format", () => {
+    const env = {
+      ...correctEnv,
+      GIT_REPOSITORY_URL: "git@github.com:artsy/eigen.git",
+    }
+    const bitrise = new Bitrise(env)
+    expect(bitrise.repoSlug).toEqual("artsy/eigen")
+  })
+})

--- a/source/ci_source/providers/index.ts
+++ b/source/ci_source/providers/index.ts
@@ -1,3 +1,4 @@
+import { Bitrise } from "./Bitrise"
 import { BuddyBuild } from "./BuddyBuild"
 import { Buildkite } from "./Buildkite"
 import { Circle } from "./Circle"
@@ -26,6 +27,7 @@ const providers = [
   Buildkite,
   BuddyBuild,
   VSTS,
+  Bitrise,
 ]
 
 // Mainly used for Dangerfile linting


### PR DESCRIPTION
Hello and thank for the invitation in the organisation :)

In my current project, the client use bitrise as a CI.

Bitrise is supported in danger-rb (https://github.com/danger/danger/blob/ccd0a83e42b9825761abb56d2870877e3ec6447c/lib/danger/ci_source/bitrise.rb) but not in danger-js

I did adapt buildkite provider, added Tests and make them pass, in regards to the ruby implementation

~~My only uncertainty is https://github.com/danger/danger-js/compare/feature/provider/bitrise?expand=1#diff-57355ea59dd912ef267ff074f7ddf8a4R38 as it is used https://github.com/danger/danger/blob/ccd0a83e42b9825761abb56d2870877e3ec6447c/lib/danger/ci_source/bitrise.rb#L24 but not documented here http://devcenter.bitrise.io/faq/available-environment-variables/.~~

**--EDIT START--**
*They confirm that BITRISE_IO is true when runned on Bitrise https://twitter.com/bitrise/status/953984609531899904*
**--EDIT END--**

If you need any changes feel free add as much stuff as you want on the PR or to ping me on twitter (@tychota).

