### PR TITLE
Allows any args on the runner command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 ## Master
 
+## 3.1.1
+
+* Allows `danger runner` (the hidden command which runs the process) to accept
+  unknown command flags (such as ones passed to it via `danger local`.) - [@adam-moss][]/[@orta][]
+
 ## 3.1.0
 
 * Adds a new command `danger local`.
@@ -867,3 +872,4 @@ Not usable for others, only stubs of classes etc. - [@orta][]
 [@caffodian]: https://github.com/caffodian
 [@fbartho]: https://github.com/fbartho
 [@tychota]: https://github.com/tychota
+[@adam-moss]: https://github.com/adam-moss

--- a/source/commands/danger-runner.ts
+++ b/source/commands/danger-runner.ts
@@ -19,6 +19,7 @@ const d = debug("danger:runner")
 // Given the nature of this command, it can be tricky to test, so I use a command like this:
 //
 // tslint:disable-next-line:max-line-length
+//
 // yarn build; cat source/_tests/fixtures/danger-js-pr-395.json | env DANGER_FAKE_CI="YEP" DANGER_TEST_REPO='danger/danger-js' DANGER_TEST_PR='395' node distribution/commands/danger-runner.js --text-only
 //
 // Which will build danger, then run just the dangerfile runner with a fixtured version of the JSON
@@ -28,6 +29,9 @@ program
   .description(
     "Handles running the Dangerfile, expects a DSL from STDIN, which should be passed from `danger` or danger run`. You probably don't need to use this command."
   )
+  // Because other calls will trigger this one,
+  // and we don't want to keep a white/blacklist
+  .allowUnknownOption(true)
 
 const argvClone = process.argv.slice(0)
 setSharedArgs(program).parse(argvClone)


### PR DESCRIPTION
Makes it possible to use the `base` argument in `danger local`. Will ship a release right after this.