### PR TITLE
add missing danger-runner bin to package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## Master
 
+* Register danger-runner as a package binary. [@urkle][]
+
 ## 3.1.2-3.1.3
 
 * Peril typings to the Danger DSL. [@orta][]

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "bin": {
     "danger": "distribution/commands/danger.js",
     "danger-pr": "distribution/commands/danger-pr.js",
+    "danger-runner": "distribution/commands/danger-runner.js",
     "danger-process": "distribution/commands/danger-process.js",
     "danger-ci": "distribution/commands/danger-ci.js",
     "danger-init": "distribution/commands/danger-init.js",


### PR DESCRIPTION
without this danger-pr fails to run as it can't find danger-runner in the node_modules/.bin folder