### PR TITLE
Fix a minor typo in Semaphore CI setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## Master
 
+* Fix a minor typo in Semaphore CI setup. [@hongrich][]
+
 ## 3.1.4
 
 * Register danger-runner as a package binary. [@urkle][]

--- a/source/ci_source/providers/Semaphore.ts
+++ b/source/ci_source/providers/Semaphore.ts
@@ -4,7 +4,7 @@ import { ensureEnvKeysExist, ensureEnvKeysAreInt } from "../ci_source_helpers"
 /**
  *  ### CI Setup
  *
- *  For Semaphor you will want to go to the settings page of the project. Inside "Build Settings"
+ *  For Semaphore you will want to go to the settings page of the project. Inside "Build Settings"
  *  you should add `yarn danger ci` to the Setup thread. Note that Semaphore only provides
  *  the build environment variables necessary for Danger on PRs across forks.
  *


### PR DESCRIPTION
http://danger.systems/js/guides/getting_started.html#setting-up-danger-to-run-on-your-ci