### PR TITLE
file-utils now looks for capitalized Dangerfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 <!--
 
-// Please add your own contribution below inside the Master section, no need to 
+// Please add your own contribution below inside the Master section, no need to
 // set a version number, that happens during a deploy.
 //
 // These docs are aimed at users rather than danger developers, so please limit technical
@@ -11,8 +11,8 @@
 ## Master
 
 * Fix --base options for danger local. [@peterjgrainger][]
-
 * Fix a minor typo in Semaphore CI setup. [@hongrich][]
+* Fix for capitalized Dangerfiles in CI environment. [@wizardishungry][]
 
 ## 3.1.4
 

--- a/source/commands/utils/file-utils.ts
+++ b/source/commands/utils/file-utils.ts
@@ -19,5 +19,13 @@ export function dangerfilePath(program: any): string {
     return "dangerfile.js"
   }
 
+  if (existsSync("Dangerfile.ts")) {
+    return "Dangerfile.ts"
+  }
+
+  if (existsSync("Dangerfile.js")) {
+    return "Dangerfile.js"
+  }
+
   throw new Error("Could not find a `dangerfile.js` or `dangerfile.ts` in the current working directory.")
 }


### PR DESCRIPTION
`yarn danger init` generates a file with the name `Dangerfile.js`. When [running danger in a ci environment](https://travis-ci.org/WIZARDISHUNGRY/community/builds/338555869), danger complains about not being able to find the Dangerfile.