### PR TITLE
Don't check for same user ID on comment when running as a GitHub App

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## Master
 
 * Update the PR DSL to include bots. [@orta][]
+* Don't check for same user ID on comment when running as a GitHub App. [@tibdex][]
 
 ## 3.1.7
 

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -83,7 +83,11 @@ export class GitHubAPI {
 
     return allComments
       .filter(comment => v.includes(comment.body, dangerIDMessage))
-      .filter(comment => userID || comment.user.id === userID)
+      .filter(
+        comment =>
+          // When running as a GitHub App, the user ID is not accessible so we skip the check.
+          userID === undefined || comment.user.id === userID
+      )
       .filter(comment => v.includes(comment.body, dangerSignaturePostfix))
       .map(comment => comment.id)
   }


### PR DESCRIPTION
I think the line was wrongly changed [here](https://github.com/danger/danger-js/commit/a3befe7cef72ce6e3d2d3907f126b47c0a413d3c#diff-b77e13a15617a77791367e0df9de18c7R82).
The consequence is that when running as a GitHub App, Danger will keep creating new comments instead of updating the existing one.