### PR TITLE
BBS docs, and DSL changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@
     activities: BitBucketServerPRActivity[]
   ```
 
+  You can see more in the docs for [Danger + BitBucket Server](http://danger.systems/js/usage/bitbucket_server.html).
+
   * [@azz][]
 
 * Don't check for same user ID on comment when running as a GitHub App. [@tibdex][]

--- a/source/danger.d.ts
+++ b/source/danger.d.ts
@@ -418,6 +418,10 @@ declare module "danger" {
      *  GitHub user identities and some useful utility functions
      *  for displaying links to files.
      *
+     * Strictly speaking, `github` is a nullable type, if you are not using
+     * GitHub then it will be undefined. For the DSL convience sake though, it
+     * is classed as non-nullable
+     *
      *  Provides an authenticated API so you can work directly
      *  with the GitHub API. This is an instance of the "@ocktokit/rest" npm
      *  module.
@@ -426,14 +430,18 @@ declare module "danger" {
      *  this is the full JSON from the webhook. [github-webhook-event-types](https://github.com/orta/github-webhook-event-types) has the full
      *  typings for those webhooks.
      */
-    readonly github?: GitHubDSL
+    readonly github: GitHubDSL
 
     /**
      *  The BitBucket Server metadata. This covers things like PR info,
      *  comments and reviews on the PR, related issues, commits, comments
      *  and activities.
+     *
+     *  Strictly speaking, `bitbucket_server` is a nullable type, if you are using
+     *  GitHub then it will be undefined. For the DSL convience sake though, it
+     *  is classed as non-nullable
      */
-    readonly bitbucket_server?: BitBucketServerDSL
+    readonly bitbucket_server: BitBucketServerDSL
 
     /**
      * Functions which are globally useful in most Dangerfiles. Right

--- a/source/dsl/DangerDSL.ts
+++ b/source/dsl/DangerDSL.ts
@@ -98,6 +98,10 @@ export interface DangerDSLType {
    *  GitHub user identities and some useful utility functions
    *  for displaying links to files.
    *
+   * Strictly speaking, `github` is a nullable type, if you are not using
+   * GitHub then it will be undefined. For the DSL convience sake though, it
+   * is classed as non-nullable
+   *
    *  Provides an authenticated API so you can work directly
    *  with the GitHub API. This is an instance of the "@ocktokit/rest" npm
    *  module.
@@ -106,14 +110,18 @@ export interface DangerDSLType {
    *  this is the full JSON from the webhook. [github-webhook-event-types](https://github.com/orta/github-webhook-event-types) has the full
    *  typings for those webhooks.
    */
-  readonly github?: GitHubDSL
+  readonly github: GitHubDSL
 
   /**
    *  The BitBucket Server metadata. This covers things like PR info,
    *  comments and reviews on the PR, related issues, commits, comments
    *  and activities.
+   *
+   *  Strictly speaking, `bitbucket_server` is a nullable type, if you are using
+   *  GitHub then it will be undefined. For the DSL convience sake though, it
+   *  is classed as non-nullable
    */
-  readonly bitbucket_server?: BitBucketServerDSL
+  readonly bitbucket_server: BitBucketServerDSL
 
   /**
    * Functions which are globally useful in most Dangerfiles. Right

--- a/source/runner/jsonToDSL.ts
+++ b/source/runner/jsonToDSL.ts
@@ -31,8 +31,11 @@ export const jsonToDSL = async (dsl: DangerDSLJSONType): Promise<DangerDSLType> 
 
   return {
     git,
-    github,
-    bitbucket_server,
+    // Strictly speaking, this is a lie. Only one of these will _ever_ exist, but
+    // otherwise everyone would need to have a check for GitHub/BBS in every Dangerfile
+    // which just doesn't feel right.
+    github: github!,
+    bitbucket_server: bitbucket_server!,
     utils: {
       sentence,
       href,


### PR DESCRIPTION
@azz quite reasonably made the `github` and `bitbucket_server` attributes nullable, I think that's the right choice for Danger's internals, but I think a user of Danger will know whether they're using bitbucket or GitHub and will just not use the other one. So for users of danger I've made both types not null. 

Plus, it's now not a major semver change. 

Also improves the docs a bit more, I got the full docs pipeline working and felt like it was a bit unfinished. 