### PR TITLE
Add `reset-status` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ## Master
 
-* []
+* Add `reset-status` command [@mxstbr][]
 
 ## 3.2.0
 
@@ -963,4 +963,5 @@ Not usable for others, only stubs of classes etc. - [@orta][]
 [@peterjgrainger]: https://github.com/peterjgrainger
 [@azz]: https://github.com/azz
 [@mifi]: https://github.com/ionutmiftode
+[@mxstbr]: https://github.com/mxstbr
 [ref]: http://danger.systems/js/reference.html

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "danger-process": "distribution/commands/danger-process.js",
     "danger-ci": "distribution/commands/danger-ci.js",
     "danger-init": "distribution/commands/danger-init.js",
-    "danger-local": "distribution/commands/danger-local.js"
+    "danger-local": "distribution/commands/danger-local.js",
+    "danger-reset-status": "distribution/commands/danger-reset-status.js"
   },
   "jest": {
     "transform": {

--- a/source/commands/ci/reset-status.ts
+++ b/source/commands/ci/reset-status.ts
@@ -1,0 +1,36 @@
+import chalk from "chalk"
+import * as debug from "debug"
+
+import { getPlatformForEnv } from "../../platforms/platform"
+import { SharedCLI } from "../utils/sharedDangerfileArgs"
+import getRuntimeCISource from "../utils/getRuntimeCISource"
+
+import { RunnerConfig } from "./runner"
+
+const d = debug("danger:reset-status")
+
+export const runRunner = async (app: SharedCLI, config?: RunnerConfig) => {
+  d(`Starting sub-process run with ${app.args}`)
+  const source = (config && config.source) || (await getRuntimeCISource(app))
+
+  // This does not set a failing exit code
+  if (source && !source.isPR) {
+    console.log("Skipping Danger due to this run not executing on a PR.")
+  }
+
+  // The optimal path
+  if (source && source.isPR) {
+    const platform = (config && config.platform) || getPlatformForEnv(process.env, source)
+    if (!platform) {
+      console.log(chalk.red(`Could not find a source code hosting platform for ${source.name}.`))
+      console.log(
+        `Currently Danger JS only supports GitHub, if you want other platforms, consider the Ruby version or help out.`
+      )
+      process.exitCode = 1
+    }
+
+    if (platform) {
+      await platform.updateStatus("pending", "Danger is waiting for your CI run to complete...")
+    }
+  }
+}

--- a/source/commands/danger-reset-status.ts
+++ b/source/commands/danger-reset-status.ts
@@ -1,0 +1,12 @@
+#! /usr/bin/env node
+
+import * as program from "commander"
+
+import setSharedArgs, { SharedCLI } from "./utils/sharedDangerfileArgs"
+import { runRunner } from "./ci/runner"
+
+program.usage("[options]").description("Reset the status of a GitHub PR to pending.")
+setSharedArgs(program).parse(process.argv)
+
+const app = (program as any) as SharedCLI
+runRunner(app)

--- a/source/commands/danger.ts
+++ b/source/commands/danger.ts
@@ -19,6 +19,7 @@ program
   .command("pr", "Runs your local Dangerfile against an existing GitHub PR. Will not post on the PR")
   .command("runner", "Runs a dangerfile against a DSL passed in via STDIN [You probably don't need this]")
   .command("local", "Runs danger standalone on a repo, useful for git hooks")
+  .command("reset-status", "Set the status of a PR to pending when a new CI run starts")
   .on("--help", () => {
     console.log("\n")
     console.log("  Docs:")

--- a/source/platforms/GitHub.ts
+++ b/source/platforms/GitHub.ts
@@ -44,7 +44,7 @@ export class GitHub implements Platform {
    * then return true.
    */
 
-  updateStatus = async (passed: boolean, message: string, url?: string): Promise<boolean> => {
+  updateStatus = async (passed: boolean | "pending", message: string, url?: string): Promise<boolean> => {
     const ghAPI = this.api.getExternalAPI()
 
     const prJSON = await this.api.getPullRequestInfo()

--- a/source/platforms/platform.ts
+++ b/source/platforms/platform.ts
@@ -46,7 +46,7 @@ export interface Platform {
   /** Replace the main Danger comment */
   updateOrCreateComment: (dangerID: string, newComment: string) => Promise<any>
   /** Sets the current PR's status */
-  updateStatus: (passed: boolean, message: string, url?: string) => Promise<boolean>
+  updateStatus: (passed: boolean | "pending", message: string, url?: string) => Promise<boolean>
   /** Get the contents of a file at a path */
   getFileContents: (path: string, slug?: string, ref?: string) => Promise<string>
 }


### PR DESCRIPTION
Adds a new command to set the PR status to "pending" at the beginning of a CI run.

Note: This is completely untested as I have no clue how I'd even start testing this, any hints appreciated. At least the code compiles I guess...