### PR TITLE
Babel 7 error with sourceFileName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 ## Master
 
+* Fixed Babel 7 breaking because of sourceFileName being defined wrong.
+
+  [@happylinks][]
+
 ## 3.3.0
 
 * Fix `committer` field issue - missing in Stash API by using commit author instead. [@zdenektopic][]
@@ -973,4 +977,5 @@ Not usable for others, only stubs of classes etc. - [@orta][]
 [@azz]: https://github.com/azz
 [@mifi]: https://github.com/ionutmiftode
 [@mxstbr]: https://github.com/mxstbr
+[@happylinks]: https://github.com/happylinks
 [ref]: http://danger.systems/js/reference.html

--- a/source/runner/runners/utils/transpiler.ts
+++ b/source/runner/runners/utils/transpiler.ts
@@ -87,8 +87,8 @@ export const babelify = (content: string, filename: string, extraPlugins: string
     filename,
     filenameRelative: filename,
     sourceMap: false,
-    sourceFileName: null,
-    sourceMapTarget: null,
+    sourceFileName: undefined,
+    sourceMapTarget: undefined,
     sourceType: "module",
     plugins: [...extraPlugins, ...options.plugins],
   }


### PR DESCRIPTION
Babel 7 returns errors for sourceFileName and sourceMapTarget because they are specified as null instead of as undefined.

```
Error:  Error: .sourceMapTarget must be a string, or undefined
    at assertString (/Users/michielwesterbeek/projects/bynder-spa-frontend/node_modules/@babel/core/lib/config/validation/option-assertions.js:51:11)
    at /Users/michielwesterbeek/projects/bynder-spa-frontend/node_modules/@babel/core/lib/config/validation/options.js:83:20
    at Array.forEach (<anonymous>)
    at validate (/Users/michielwesterbeek/projects/bynder-spa-frontend/node_modules/@babel/core/lib/config/validation/options.js:61:21)
    at loadConfig (/Users/michielwesterbeek/projects/bynder-spa-frontend/node_modules/@babel/core/lib/config/index.js:37:48)
    at transformSync (/Users/michielwesterbeek/projects/bynder-spa-frontend/node_modules/@babel/core/lib/transform-sync.js:13:36)
    at Object.transform (/Users/michielwesterbeek/projects/bynder-spa-frontend/node_modules/@babel/core/lib/transform.js:20:65)
    at Object.exports.babelify (/Users/michielwesterbeek/projects/bynder-spa-frontend/node_modules/danger/distribution/runner/runners/utils/transpiler.js:86:24)
    at Object.exports.default (/Users/michielwesterbeek/projects/bynder-spa-frontend/node_modules/danger/distribution/runner/runners/utils/transpiler.js:106:26)
    at Object.<anonymous> (/Users/michielwesterbeek/projects/bynder-spa-frontend/node_modules/danger/distribution/runner/runners/inline.js:90:52)
```

Fixed this by updating it to undefined.