### PR TITLE
[Inline mode] Fix a bug when multiple violations of the same type are issued for the same file/line.

### DIFF
--- a/source/runner/_tests/fixtures/ExampleDangerResults.ts
+++ b/source/runner/_tests/fixtures/ExampleDangerResults.ts
@@ -49,6 +49,25 @@ export const inlineRegularResults: DangerResults = {
   markdowns: [],
 }
 
+export const inlineRegularResultsForTheSameLine: DangerResults = {
+  messages: [
+    { message: "Test message", file: "File.swift", line: 10 },
+    { message: "Warning message", file: "File.swift", line: 10 },
+  ],
+  warnings: [
+    { message: "Test message", file: "File.swift", line: 10 },
+    { message: "Warning message", file: "File.swift", line: 10 },
+  ],
+  fails: [
+    { message: "Test message", file: "File.swift", line: 10 },
+    { message: "Warning message", file: "File.swift", line: 10 },
+  ],
+  markdowns: [
+    { message: "Test message", file: "File.swift", line: 10 },
+    { message: "Warning message", file: "File.swift", line: 10 },
+  ],
+}
+
 export const failsResults: DangerResults = {
   fails: [{ message: "Failing message" }],
   warnings: [],

--- a/source/runner/templates/_tests/__snapshots__/_githubIssueTemplates.test.ts.snap
+++ b/source/runner/templates/_tests/__snapshots__/_githubIssueTemplates.test.ts.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`generating inline messages Shows correct message for multiple inline violations for the same file and line 1`] = `
+"
+<!--
+  2 failure:  Test message, Warning message
+  2 warning:  Test message, Warning message
+  2 messages
+  2 markdown notices
+  DangerID: danger-id-blankID;
+  File: File.swift;
+  Line: 10;
+-->  
+- :no_entry_sign: Test message
+- :no_entry_sign: Warning message
+- :warning: Test message
+- :warning: Warning message
+- :book: Test message
+- :book: Warning message
+Test message
+
+Warning message
+  "
+`;
+
 exports[`generating inline messages Shows correct messages for inline/regular violations 1`] = `
 "
 <!--

--- a/source/runner/templates/_tests/_githubIssueTemplates.test.ts
+++ b/source/runner/templates/_tests/_githubIssueTemplates.test.ts
@@ -7,6 +7,7 @@ import {
   messagesResults,
   markdownResults,
   inlineRegularResults,
+  inlineRegularResultsForTheSameLine,
 } from "../../_tests/fixtures/ExampleDangerResults"
 import {
   template as githubResultsTemplate,
@@ -121,6 +122,12 @@ describe("generating inline messages", () => {
 
   it("Shows correct messages for inline/regular violations", () => {
     const issues = githubResultsTemplate("blankID", inlineRegularResults)
+
+    expect(issues).toMatchSnapshot()
+  })
+
+  it("Shows correct message for multiple inline violations for the same file and line", () => {
+    const issues = githubResultsInlineTemplate("blankID", inlineRegularResultsForTheSameLine, "File.swift", 10)
 
     expect(issues).toMatchSnapshot()
   })

--- a/source/runner/templates/bitbucketServerTemplate.ts
+++ b/source/runner/templates/bitbucketServerTemplate.ts
@@ -70,9 +70,9 @@ export function inlineTemplate(results: DangerResults): string {
   }
 
   return `
-${results.fails.map(printViolation("no_entry_sign"))}
-${results.warnings.map(printViolation("warning"))}
-${results.messages.map(printViolation("book"))}
+${results.fails.map(printViolation("no_entry_sign")).join("\n")}
+${results.warnings.map(printViolation("warning")).join("\n")}
+${results.messages.map(printViolation("book")).join("\n")}
 ${results.markdowns.map(v => v.message).join("\n\n")}
   `
 }

--- a/source/runner/templates/githubIssueTemplate.ts
+++ b/source/runner/templates/githubIssueTemplate.ts
@@ -99,9 +99,9 @@ export function inlineTemplate(dangerID: string, results: DangerResults, file: s
 ${buildSummaryMessage(dangerID, results)}
 ${fileLineToString(file, line)}
 -->  
-${results.fails.map(printViolation("no_entry_sign"))}
-${results.warnings.map(printViolation("warning"))}
-${results.messages.map(printViolation("book"))}
+${results.fails.map(printViolation("no_entry_sign")).join("\n")}
+${results.warnings.map(printViolation("warning")).join("\n")}
+${results.messages.map(printViolation("book")).join("\n")}
 ${results.markdowns.map(v => v.message).join("\n\n")}
   `
 }


### PR DESCRIPTION
For instance, if you have 2 warnings for the same file/line, the comment would be:
<img width="645" alt="zrzut ekranu 2018-04-01 o 02 05 35" src="https://user-images.githubusercontent.com/5232779/38168597-3a3c391c-3551-11e8-971c-b7ef6515b944.png">
instead of:
<img width="647" alt="zrzut ekranu 2018-04-01 o 02 05 50" src="https://user-images.githubusercontent.com/5232779/38168599-40b62d16-3551-11e8-9c30-04a3b574abe0.png">

This PR aims to fix it.