### PR TITLE
Remove deprecated babel 7 sourceMapTarget

### DIFF
--- a/source/runner/runners/utils/transpiler.ts
+++ b/source/runner/runners/utils/transpiler.ts
@@ -88,7 +88,6 @@ export const babelify = (content: string, filename: string, extraPlugins: string
     filenameRelative: filename,
     sourceMap: false,
     sourceFileName: undefined,
-    sourceMapTarget: undefined,
     sourceType: "module",
     plugins: [...extraPlugins, ...options.plugins],
   }


### PR DESCRIPTION
This has been deprecated and Babel now throws an error even if this is passed as `undefined`.