### PR TITLE
Catch github api error thrown from @octokit/rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+* Catch the github api error thrown from @octokit/rest [@Teamop][]
+
 # 3.6.0
 
 * A Dangerfile can return a default export, and then Danger will handle the execution of that code [@orta][]

--- a/source/platforms/github/GitHubUtils.ts
+++ b/source/platforms/github/GitHubUtils.ts
@@ -41,11 +41,15 @@ const utils = (pr: GitHubPRDSL, api: GitHub): GitHubUtilsDSL => {
         repo: repoSlug.split("/")[1],
         owner: repoSlug.split("/")[0],
       }
-      const response = await api.repos.getContent(opts)
-      if (response && response.data && response.data.type === "file") {
-        const buffer = new Buffer(response.data.content, response.data.encoding)
-        return buffer.toString()
-      } else {
+      try {
+        const response = await api.repos.getContent(opts)
+        if (response && response.data && response.data.type === "file") {
+          const buffer = new Buffer(response.data.content, response.data.encoding)
+          return buffer.toString()
+        } else {
+          return ""
+        }
+      } catch {
         return ""
       }
     },


### PR DESCRIPTION
Fix #532
For the newly created files, `api.repos.getContent(opts)` will get a `HttpError` thrown by `@octokit/rest`, so here just `try/catch` them to catch the issue so that `diffForFile` can work well for these files