### PR TITLE
Replace preview media type of github pull request reviews api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## Master
 
 * Catch the github api error thrown from @octokit/rest [@Teamop][]
+* Replace preview media type of github pull request reviews api [@Teamop][]
 
 # 3.6.0
 

--- a/source/platforms/_tests/fixtures/readme.md
+++ b/source/platforms/_tests/fixtures/readme.md
@@ -3,7 +3,7 @@ Here's an example CURL request to add a new fixture
 ```sh
 curl \
 -H "Authorization: token <GITHUB_OAUTH_TOKEN>" \
--H "Accept: application/vnd.github.black-cat-preview+json" \
+-H "Accept: application/vnd.github.v3+json" \
 --request GET https://api.github.com/repos/artsy/emission/pulls/327/requested_reviewers \
 > source/platforms/_tests/fixtures/requested_reviewers.json
 ```

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -309,7 +309,7 @@ export class GitHubAPI {
     const repo = this.repoMetadata.repoSlug
     const prID = this.repoMetadata.pullRequestID
     const res = await this.get(`repos/${repo}/pulls/${prID}/requested_reviewers`, {
-      Accept: "application/vnd.github.black-cat-preview+json",
+      Accept: "application/vnd.github.v3+json",
     })
 
     return res.ok ? res.json() : []
@@ -319,7 +319,7 @@ export class GitHubAPI {
     const repo = this.repoMetadata.repoSlug
     const prID = this.repoMetadata.pullRequestID
     const res = await this.get(`repos/${repo}/pulls/${prID}/reviews`, {
-      Accept: "application/vnd.github.black-cat-preview+json",
+      Accept: "application/vnd.github.v3+json",
     })
 
     return res.ok ? res.json() : []


### PR DESCRIPTION
Based on the [blog](https://developer.github.com/changes/2017-05-09-end-black-cat-preview/), preview media type is no longer needed
