### PR TITLE
Improve peril checks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,5 +23,5 @@
   "spellchecker.ignoreFileExtensions": [],
   "spellchecker.checkInterval": 5000,
   "editor.formatOnSave": true,
-  "cSpell.words": ["PRDSL", "bitbucket"]
+  "cSpell.words": ["APIPR", "Commenter", "PRDSL", "bitbucket"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 ## Master
 
+# 3.7.2
+
+* Debugging when using the GitHub OctoKit - orta
+
 # 3.7.1
 
 * Improve checks support for Danger - orta

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -34,10 +34,6 @@ const checkREADME = async () => {
 }
 checkREADME()
 
-warn("a warning", "dangerfile.ts", 3)
-
-warn("another warning", "source/runner/runners/vm2.ts", 3)
-
 import yarn, { message } from "danger-plugin-yarn"
 yarn()
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danger",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "Unit tests for Team Culture",
   "main": "distribution/danger.js",
   "typings": "distribution/danger.d.ts",

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -44,12 +44,14 @@ export class GitHubAPI {
    */
   getExternalAPI = (JWTForGithubApp?: string): GitHubNodeAPI => {
     const host = process.env["DANGER_GITHUB_API_BASE_URL"] || undefined
-    const api = new GitHubNodeAPI({
+    const options: GitHubNodeAPI.Options & { debug: boolean } = {
+      debug: !!process.env.LOG_FETCH_REQUESTS,
       baseUrl: host,
       headers: {
         ...this.additionalHeaders,
       },
-    })
+    }
+    const api = new GitHubNodeAPI(options)
 
     if (JWTForGithubApp) {
       // I sent a PR for this: https://github.com/octokit/rest.js/pull/873


### PR DESCRIPTION
Let's `process.env.LOG_FETCH_REQUESTS` include octokit info, so  I can verify https://github.com/octokit/rest.js/pull/878