### PR TITLE
Use `pullRequestParser` in TeamCity provider

### DIFF
--- a/source/ci_source/providers/TeamCity.ts
+++ b/source/ci_source/providers/TeamCity.ts
@@ -1,5 +1,6 @@
 import { Env, CISource } from "../ci_source"
 import { ensureEnvKeysExist } from "../ci_source_helpers"
+import { pullRequestParser } from "../../platforms/pullRequestParser"
 
 /**
  *
@@ -35,25 +36,23 @@ export class TeamCity implements CISource {
     return ensureEnvKeysExist(this.env, mustHave)
   }
 
-  private _prParseURL(): { owner?: string; reponame?: string; id?: string } {
-    const prUrl = this.env.PULL_REQUEST_URL || ""
-    const splitSlug = prUrl.split("/")
-    if (splitSlug.length === 7) {
-      const owner = splitSlug[3]
-      const reponame = splitSlug[4]
-      const id = splitSlug[6]
-      return { owner, reponame, id }
-    }
-    return {}
-  }
-
   get pullRequestID(): string {
-    const { id } = this._prParseURL()
-    return id || ""
+    const parts = pullRequestParser(this.env.PULL_REQUEST_URL || "")
+
+    if (parts === null) {
+      return ""
+    }
+
+    return parts.pullRequestNumber
   }
 
   get repoSlug(): string {
-    const { owner, reponame } = this._prParseURL()
-    return owner && reponame ? `${owner}/${reponame}` : ""
+    const parts = pullRequestParser(this.env.PULL_REQUEST_URL || "")
+
+    if (parts === null) {
+      return ""
+    }
+
+    return parts.repo
   }
 }

--- a/source/ci_source/providers/_tests/_teamcity.test.ts
+++ b/source/ci_source/providers/_tests/_teamcity.test.ts
@@ -58,11 +58,27 @@ describe(".pullRequestID", () => {
     })
     expect(teamcity.pullRequestID).toEqual("541")
   })
+
+  it("pulls it out of the env for Bitbucket Server", () => {
+    const teamcity = new TeamCity({
+      PULL_REQUEST_URL: "https://stash.test.com/projects/POR/repos/project/pull-requests/32304/overview",
+    })
+
+    expect(teamcity.pullRequestID).toEqual("32304")
+  })
 })
 
 describe(".repoSlug", () => {
   it("derives it from the PR Url", () => {
     const teamcity = new TeamCity(correctEnv)
     expect(teamcity.repoSlug).toEqual("danger/danger-js")
+  })
+
+  it("derives it from the PR Url for Bitbucket Server", () => {
+    const teamcity = new TeamCity({
+      PULL_REQUEST_URL: "https://stash.test.com/projects/POR/repos/project/pull-requests/32304/overview",
+    })
+
+    expect(teamcity.repoSlug).toEqual("projects/POR/repos/project")
   })
 })

--- a/source/platforms/_tests/_pull_request_parser.test.ts
+++ b/source/platforms/_tests/_pull_request_parser.test.ts
@@ -33,4 +33,11 @@ describe("parsing urls", () => {
       repo: "projects/PROJ/repos/repo",
     })
   })
+
+  it("handles bitbucket server PRs (overview) with dashes in name", () => {
+    expect(pullRequestParser("http://localhost:7990/projects/PROJ/repos/super-repo/pull-requests/1/overview")).toEqual({
+      pullRequestNumber: "1",
+      repo: "projects/PROJ/repos/super-repo",
+    })
+  })
 })

--- a/source/platforms/pullRequestParser.ts
+++ b/source/platforms/pullRequestParser.ts
@@ -8,9 +8,10 @@ export interface PullRequestParts {
 
 export function pullRequestParser(address: string): PullRequestParts | null {
   const components = url.parse(address, false)
+
   if (components && components.path) {
     // shape: http://localhost:7990/projects/PROJ/repos/repo/pull-requests/1/overview
-    const parts = components.path.match(/(projects\/\w+\/repos\/\w+)\/pull-requests\/(\d+)/)
+    const parts = components.path.match(/(projects\/\w+\/repos\/[\w-]+)\/pull-requests\/(\d+)/)
     if (parts) {
       return {
         repo: parts[1],


### PR DESCRIPTION
If one uses Bitbucket Server + TeamCity, parsing of the
PULL_REQUEST_URL environment variable will be incorrect.

It seems `pullRequestParser` module already does a pretty good
job in figuring out what's what, so use it in TeamCity provider implementation