### PR TITLE
[CHANGE] Use dangerID instead of "Danger"

### DIFF
--- a/source/platforms/github/comms/checks/resultsToCheck.ts
+++ b/source/platforms/github/comms/checks/resultsToCheck.ts
@@ -90,7 +90,7 @@ export const resultsToCheck = async (
     !results.fails.length && !results.markdowns.length && !results.warnings.length && !results.messages.length
 
   return {
-    name: "Danger",
+    name: options.dangerID,
     status: "completed",
     completed_at: new Date().toISOString(),
 


### PR DESCRIPTION
Enable danger to switch check-run by provided ID.