### PR TITLE
Use Exec instead of spawn in danger local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+* Convert the `exec` in `danger local` to a `spawn` hopefully unblocking large diffs from going through it - [@orta][]
+
 # 3.7.18
 
 * Report the error in a commit status update when in verbose - [@orta][]

--- a/source/commands/danger-local.ts
+++ b/source/commands/danger-local.ts
@@ -16,7 +16,6 @@ interface App extends SharedCLI {
 
 program
   .usage("[options]")
-  .option("-b, --base  [base]", "Choose the base commit to work against.")
   // TODO: this option
   // .option("-s, --staging", "Just use staged changes.")
   .description("Runs danger without PR metadata, useful for git hooks.")

--- a/source/platforms/git/localGetCommits.ts
+++ b/source/platforms/git/localGetCommits.ts
@@ -22,10 +22,9 @@ export const formatJSON = `{ "sha": "${sha}", "parents": "${parents}", ${author}
 
 export const localGetCommits = (base: string, head: string) =>
   new Promise<GitCommit[]>(done => {
-    const call = `git log ${base}...${head} --pretty=format:'${formatJSON}'`
-    d(call)
-    const child = spawn(call)
-
+    const args = ["log", `${base}...${head}`, `--pretty=format:${formatJSON}`]
+    const child = spawn("git", args, { env: process.env })
+    d("> git", args.join(" "))
     child.stdout.on("data", async data => {
       data = data.toString()
 


### PR DESCRIPTION
WIP on  #571 

got a crash though:

```
~/dev/projects/danger/danger-js exec_to_spawn*
❯ yarn tsc -p tsconfig.production.json; node distribution/commands/danger.js local --dangerfile dangerfile.lite.ts --base 7cf25a13730309fe0773c597f2ae0f1e22a1d4ab
yarn run v1.7.0
$ /Users/orta/dev/projects/danger/danger-js/node_modules/.bin/tsc -p tsconfig.production.json
✨  Done in 5.29s.
Error:  { SyntaxError: JSON5: invalid character 'A' at 9:317
    at syntaxError (/Users/orta/dev/projects/danger/danger-js/node_modules/json5/lib/parse.js:1:12963)
    at invalidChar (/Users/orta/dev/projects/danger/danger-js/node_modules/json5/lib/parse.js:1:12177)
    at Object.afterPropertyValue (/Users/orta/dev/projects/danger/danger-js/node_modules/json5/lib/parse.js:1:8133)
    at Object._default [as default] (/Users/orta/dev/projects/danger/danger-js/node_modules/json5/lib/parse.js:1:2255)
    at lex (/Users/orta/dev/projects/danger/danger-js/node_modules/json5/lib/parse.js:1:1680)
    at Object.parse (/Users/orta/dev/projects/danger/danger-js/node_modules/json5/lib/parse.js:1:992)
    at Object.<anonymous> (/Users/orta/dev/projects/danger/danger-js/distribution/platforms/git/localGetCommits.js:73:33)
    at step (/Users/orta/dev/projects/danger/danger-js/distribution/platforms/git/localGetCommits.js:40:23)
    at Object.next (/Users/orta/dev/projects/danger/danger-js/distribution/platforms/git/localGetCommits.js:21:53)
    at /Users/orta/dev/projects/danger/danger-js/distribution/platforms/git/localGetCommits.js:15:71 lineNumber: 9, columnNumber: 317 }
Error:  { SyntaxError: JSON5: invalid character 'A' at 15:317
    at syntaxError (/Users/orta/dev/projects/danger/danger-js/node_modules/json5/lib/parse.js:1:12963)
    at invalidChar (/Users/orta/dev/projects/danger/danger-js/node_modules/json5/lib/parse.js:1:12177)
    at Object.afterPropertyValue (/Users/orta/dev/projects/danger/danger-js/node_modules/json5/lib/parse.js:1:8133)
    at Object._default [as default] (/Users/orta/dev/projects/danger/danger-js/node_modules/json5/lib/parse.js:1:2255)
    at lex (/Users/orta/dev/projects/danger/danger-js/node_modules/json5/lib/parse.js:1:1680)
    at Object.parse (/Users/orta/dev/projects/danger/danger-js/node_modules/json5/lib/parse.js:1:992)
    at Object.<anonymous> (/Users/orta/dev/projects/danger/danger-js/distribution/platforms/git/localGetCommits.js:73:33)
    at step (/Users/orta/dev/projects/danger/danger-js/distribution/platforms/git/localGetCommits.js:40:23)
    at Object.next (/Users/orta/dev/projects/danger/danger-js/distribution/platforms/git/localGetCommits.js:21:53)
    at /Users/orta/dev/projects/danger/danger-js/distribution/platforms/git/localGetCommits.js:15:71 lineNumber: 15, columnNumber: 317 }

Danger: ⅹ Failing the build, there is 1 fail.
```