### PR TITLE
Use the peril bot ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 ## Master
 
+# 3.8.2
+
+- Use the Peril Bot ID for the comment lookup checks - [@orta][]
+
 # 3.8.1
 
 - Adds additional logging to handleResultsPostingToPlatform - [@ashfurrow][]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danger",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "description": "Unit tests for Team Culture",
   "main": "distribution/danger.js",
   "typings": "distribution/danger.d.ts",

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -91,14 +91,10 @@ export class GitHubAPI {
     this.d(`User ID: ${userID}`)
     this.d(`Looking at ${allComments.length} comments for ${dangerIDMessage}`)
     return allComments
-      .filter(comment => v.includes(comment.body, dangerIDMessage))
-      .filter(
-        comment =>
-          // When running as a GitHub App, the user ID is not accessible so we skip the check.
-          userID === undefined || comment.user.id === userID
-      )
-      .filter(comment => v.includes(comment.body, dangerSignaturePostfix))
-      .map(comment => comment.id)
+      .filter(comment => v.includes(comment.body, dangerIDMessage)) // does it contain the right danger ID?
+      .filter(comment => comment.user.id === userID) // Does it have the right user ID?
+      .filter(comment => v.includes(comment.body, dangerSignaturePostfix)) // Does it look like a danger message?
+      .map(comment => comment.id) // only return IDs
   }
 
   updateCommentWithID = async (id: number, comment: string): Promise<any> => {
@@ -131,9 +127,11 @@ export class GitHubAPI {
   }
 
   getUserID = async (): Promise<number | undefined> => {
-    if (process.env["DANGER_GITHUB_APP"]) {
-      return
+    const perilID = process.env["PERIL_BOT_USER_ID"]
+    if (perilID) {
+      return parseInt(perilID)
     }
+
     const info = await this.getUserInfo()
     return info.id
   }

--- a/source/platforms/github/_tests/_github_api.test.ts
+++ b/source/platforms/github/_tests/_github_api.test.ts
@@ -198,17 +198,18 @@ describe("Peril", () => {
     )
   })
 
-  describe("Allows setting DANGER_GITHUB_APP env variable", () => {
+  describe("Allows setting PERIL_BOT_USER_ID env variable", () => {
     beforeEach(() => {
-      process.env.DANGER_GITHUB_APP = "1"
+      process.env.PERIL_BOT_USER_ID = "1"
     })
 
     afterEach(() => {
-      delete process.env.DANGER_GITHUB_APP
+      delete process.env.PERIL_BOT_USER_ID
     })
 
     it("Makes getUserId return undefined", async () => {
-      expect(await api.getUserID()).toBeUndefined()
+      const userID = await api.getUserID()
+      expect(userID).toBe(1)
     })
   })
 })


### PR DESCRIPTION
This might fix #642 

Think I was hesitant to have danger know about peril too much when I first built this, but we're pretty far from that now.