### PR TITLE
Perform DELETE requests to GitHub API without body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   **Breaking:** 3.9.0 was the last version to support inline transpilation via Babel 6. Danger doesn't specify babel in
   its dependencies, so this warning won't show anywhere else.
 
+- Fixed a bug where Danger was throwing an error when removing any existing messages [@stefanbuck][]
+
 # 3.9.0
 
 - Adds CI integration for Concourse - [@cwright017][]

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -112,7 +112,7 @@ export class GitHubAPI {
 
   deleteCommentWithID = async (id: number): Promise<boolean> => {
     const repo = this.repoMetadata.repoSlug
-    const res = await this.api(`repos/${repo}/issues/comments/${id}`, {}, {}, "DELETE")
+    const res = await this.api(`repos/${repo}/issues/comments/${id}`, {}, null, "DELETE")
 
     //https://developer.github.com/v3/issues/comments/#response-5
     return Promise.resolve(res.status === 204)
@@ -120,7 +120,7 @@ export class GitHubAPI {
 
   deleteInlineCommentWithID = async (id: string): Promise<boolean> => {
     const repo = this.repoMetadata.repoSlug
-    const res = await this.api(`repos/${repo}/pulls/comments/${id}`, {}, {}, "DELETE", false)
+    const res = await this.api(`repos/${repo}/pulls/comments/${id}`, {}, null, "DELETE", false)
 
     //https://developer.github.com/v3/pulls/comments/#response-5
     return Promise.resolve(res.status === 204)

--- a/source/platforms/github/_tests/_github_api.test.ts
+++ b/source/platforms/github/_tests/_github_api.test.ts
@@ -147,6 +147,42 @@ describe("API testing", () => {
     expect.assertions(1)
     await expect(api.postInlinePRComment("", "", "", 0)).rejects.toEqual(expectedJSON)
   })
+
+  it("deleteCommentWithID", async () => {
+    api.fetch = jest.fn().mockReturnValue({ status: 204 })
+    await api.deleteCommentWithID(123)
+
+    expect(api.fetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/artsy/emission/issues/comments/123",
+      {
+        body: null,
+        headers: {
+          Authorization: "token ABCDE",
+          "Content-Type": "application/json",
+        },
+        method: "DELETE",
+      },
+      undefined
+    )
+  })
+
+  it("deleteInlineCommentWithID", async () => {
+    api.fetch = jest.fn().mockReturnValue({ status: 204 })
+    await api.deleteInlineCommentWithID("123")
+
+    expect(api.fetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/artsy/emission/pulls/comments/123",
+      {
+        body: null,
+        headers: {
+          Authorization: "token ABCDE",
+          "Content-Type": "application/json",
+        },
+        method: "DELETE",
+      },
+      false
+    )
+  })
 })
 
 describe("Peril", () => {


### PR DESCRIPTION
Fixed a bug where Danger was throwing an error when removing any existing messages. Fixes #659 

Looks like the GitHub API does not allow a DELETE request to have a body anymore.
If I set body to `null` instead of `{}` it works.