### PR TITLE
Fix missing PR status bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+- Fixed a bug where Danger would fail to update status when there are no failures or messages [@johansteffner][]
+
 # 4.0.1
 
 - Fixed a bug where Danger was throwing an error when removing any existing messages [@stefanbuck][]
@@ -1240,3 +1242,4 @@ Not usable for others, only stubs of classes etc. - [@orta][]
 [@joshacheson]: https://github.com/joshacheson
 [@cwright017]: https://github.com/Cwright017
 [@adamnoakes]: https://github.com/adamnoakes
+[@johansteffner]: https://github.com/johansteffner

--- a/source/runner/Executor.ts
+++ b/source/runner/Executor.ts
@@ -210,6 +210,8 @@ export class Executor {
     const dangerID = this.options.dangerID
     const failed = fails.length > 0
 
+    let issueURL = undefined
+
     if (failureCount + messageCount === 0) {
       console.log("No issues or messages were sent. Removing any existing messages.")
       await this.platform.deleteMainComment(dangerID)
@@ -234,7 +236,6 @@ export class Executor {
       const regular = regularResults(results)
       const mergedResults = sortResults(mergeResults(regular, inlineLeftovers))
 
-      let issueURL = undefined
       // If danger have no comments other than inline to update. Just delete previous main comment.
       if (isEmptyResults(mergedResults)) {
         this.platform.deleteMainComment(dangerID)
@@ -246,18 +247,18 @@ export class Executor {
         issueURL = await this.platform.updateOrCreateComment(dangerID, comment)
         console.log(`Feedback: ${issueURL}`)
       }
+    }
 
-      const urlForInfo = issueURL || this.ciSource.ciRunURL
-      const successPosting = await this.platform.updateStatus(!failed, messageForResults(results), urlForInfo)
-      if (!successPosting && this.options.verbose) {
-        console.log("Could not add a commit status, the GitHub token for Danger does not have access rights.")
-        console.log("If the build fails, then danger will use a failing exit code.")
-      }
+    const urlForInfo = issueURL || this.ciSource.ciRunURL
+    const successPosting = await this.platform.updateStatus(!failed, messageForResults(results), urlForInfo)
+    if (!successPosting && this.options.verbose) {
+      console.log("Could not add a commit status, the GitHub token for Danger does not have access rights.")
+      console.log("If the build fails, then danger will use a failing exit code.")
+    }
 
-      if (!successPosting && failed) {
-        this.d("Failing the build due to handleResultsPostingToPlatform not successfully setting a commit status")
-        process.exitCode = 1
-      }
+    if (!successPosting && failed) {
+      this.d("Failing the build due to handleResultsPostingToPlatform not successfully setting a commit status")
+      process.exitCode = 1
     }
 
     // More info, is more info.

--- a/source/runner/_tests/_executor.test.ts
+++ b/source/runner/_tests/_executor.test.ts
@@ -269,6 +269,17 @@ describe("setup", () => {
     expect(platform.deleteInlineComment).toHaveBeenCalledTimes(2)
   })
 
+  it("Updates the status with success for a passed empty results", async () => {
+    const platform = new FakePlatform()
+    const exec = new Executor(new FakeCI({}), platform, inlineRunner, defaultConfig)
+    const dsl = await defaultDsl(platform)
+    platform.updateOrCreateComment = jest.fn()
+    platform.updateStatus = jest.fn()
+
+    await exec.handleResults(emptyResults, dsl.git)
+    expect(platform.updateStatus).toBeCalledWith(true, jasmine.any(String), undefined)
+  })
+
   it("Updates the status with success for a passed results", async () => {
     const platform = new FakePlatform()
     const exec = new Executor(new FakeCI({}), platform, inlineRunner, defaultConfig)


### PR DESCRIPTION
Since v3.6.0 danger doesn't post a updated status if there are no failures or messages. This has broken our build pipeline since we have Danger set as a required step in our repositories.

This update should fix that issue by moving the update status call outside of `failureCount + messageCount === 0` again.