### PR TITLE
Closes #675: Remove suggestion to display token in travis build log.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 -->
 
 ## Master
+- Remove suggestion from docs and init tool to display GitHub API token in travis build logs [@mcomella][]
 
 # 4.0.1
 
@@ -1245,3 +1246,4 @@ Not usable for others, only stubs of classes etc. - [@orta][]
 [@cwright017]: https://github.com/Cwright017
 [@adamnoakes]: https://github.com/adamnoakes
 [@johansteffner]: https://github.com/johansteffner
+[@mcomella]: https://github.com/mcomella/

--- a/source/ci_source/providers/Travis.ts
+++ b/source/ci_source/providers/Travis.ts
@@ -19,8 +19,6 @@ import { ensureEnvKeysExist, ensureEnvKeysAreInt } from "../ci_source_helpers"
  *
  *  You need to add the `DANGER_GITHUB_API_TOKEN` environment variable, to do this,
  *  go to your repo's settings, which should look like: `https://travis-ci.org/[user]/[repo]/settings`.
- *
- *  If you have an open source project, you should ensure "Display value in build log" enabled, so that PRs from forks work.
  */
 export class Travis implements CISource {
   constructor(private readonly env: Env) {}

--- a/source/commands/init/add-to-ci.ts
+++ b/source/commands/init/add-to-ci.ts
@@ -20,9 +20,6 @@ export const travis = async (ui: InitUI, state: InitState) => {
       highlight("DANGER_GITHUB_API_TOKEN") +
       " and the value is the GitHub Personal Access Token you just created."
   )
-  if (state.isAnOSSRepo) {
-    ui.say('As you have an OSS repo - make sure to have "Display value in build log" enabled.')
-  }
 
   ui.say("Next, you need to edit your `.travis.yml` to include `yarn danger ci`. If you already have")
   ui.say(


### PR DESCRIPTION
It's insecure to post API tokens to public build logs and most open
source repositories have public build logs. However, I do not
understand the effects not enabling this option would have on users of
danger.