### PR TITLE
Allow repository name parsing to have extra valid characters

### DIFF
--- a/source/platforms/_tests/_pull_request_parser.test.ts
+++ b/source/platforms/_tests/_pull_request_parser.test.ts
@@ -40,4 +40,13 @@ describe("parsing urls", () => {
       repo: "projects/PROJ/repos/super-repo",
     })
   })
+
+  it("handles bitbucket server PRs (overview) with dashes in name", () => {
+    expect(
+      pullRequestParser("http://localhost:7990/projects/PROJ/repos/super-strong.repo_name/pull-requests/1/overview")
+    ).toEqual({
+      pullRequestNumber: "1",
+      repo: "projects/PROJ/repos/super-strong.repo_name",
+    })
+  })
 })

--- a/source/platforms/pullRequestParser.ts
+++ b/source/platforms/pullRequestParser.ts
@@ -11,7 +11,7 @@ export function pullRequestParser(address: string): PullRequestParts | null {
 
   if (components && components.path) {
     // shape: http://localhost:7990/projects/PROJ/repos/repo/pull-requests/1/overview
-    const parts = components.path.match(/(projects\/\w+\/repos\/[\w-]+)\/pull-requests\/(\d+)/)
+    const parts = components.path.match(/(projects\/\w+\/repos\/[\w-_.]+)\/pull-requests\/(\d+)/)
     if (parts) {
       return {
         repo: parts[1],


### PR DESCRIPTION
While setting up the danger environment to use bitbucket server Ive notice that url like 
https://someserver.com/projects/PRJ/repos/com.somewhere.library/pull-requests/10/overview
where not parsed. 
The regex for the repo name, in this case com.somewhere.library, was only allowing \w+ and -.

This PR extends to allow _ and .

Tests and linters are all green