### PR TITLE
Fix: error thrown undefined comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add logic for "DANGER_DISABLE_TRANSPILATION" env[@markelog][]
 - Jenkins: Respect `CHANGE_URL`/`CHANGE_ID` for GitHub and BitBucket Server [@azz][]
 - Docs: Guides - Update link to apollo-client dangerfile.ts example [@andykenward][]
+- Fix crash that may occur when no message is set on generic event [@flovilmart][]
 
 # 4.4.0
 

--- a/source/runner/Executor.ts
+++ b/source/runner/Executor.ts
@@ -217,7 +217,9 @@ export class Executor {
       await this.platform.deleteMainComment(dangerID)
       const previousComments = await this.platform.getInlineComments(dangerID)
       for (const comment of previousComments) {
-        await this.deleteInlineComment(comment)
+        if (comment) {
+          await this.deleteInlineComment(comment)
+        }
       }
     } else {
       if (fails.length > 0) {


### PR DESCRIPTION
It can occur that the comment is passed as undefined and the method `deleteInlineComment` throws an exception attempting to read `.id` on undefined.

This patch ensure this doesn't happen but I haven't found the root cause. I seems to occur when not responding any message on an issue event.