### PR TITLE
Fix posting status update on Github PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+- Fix #614 - Posting status updates to Github using issue workflow broken - [@sgtcoolguy][]
+
 # 5.0.1, err. 6.0.0
 
 - Hah, my computer ran out opf power mid-deploy, and now I have to ship another build to make sure the brew versions of

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -344,17 +344,21 @@ export class GitHubAPI {
     return res.ok ? res.json() : { labels: [] }
   }
 
-  updateStatus = async (passed: boolean, message: string, url?: string): Promise<any> => {
+  updateStatus = async (passed: boolean | "pending", message: string, url?: string): Promise<any> => {
     const repo = this.repoMetadata.repoSlug
 
     const prJSON = await this.getPullRequestInfo()
     const ref = prJSON.head.sha
+    let state = passed ? "success" : "failure"
+    if (passed === "pending") {
+      state = "pending"
+    }
     const res = await this.post(
       `repos/${repo}/statuses/${ref}`,
       {},
       {
-        state: passed ? "success" : "failure",
-        context: process.env["PERIL_INTEGRATION_ID"] ? "Peril" : "Danger",
+        state: state,
+        context: process.env["PERIL_BOT_USER_ID"] ? "Peril" : "Danger",
         target_url: url || "http://danger.systems/js",
         description: message,
       }

--- a/source/platforms/github/_tests/_github_api.test.ts
+++ b/source/platforms/github/_tests/_github_api.test.ts
@@ -147,6 +147,82 @@ describe("API testing", () => {
     await expect(api.postInlinePRComment("", "", "", 0)).rejects.toEqual(expectedJSON)
   })
 
+  it("updateStatus('pending') success", async () => {
+    api.fetch = jest.fn().mockReturnValue({ ok: true })
+    api.getPullRequestInfo = await requestWithFixturedJSON("github_pr.json")
+
+    await expect(api.updateStatus("pending", "message")).resolves.toEqual(true)
+    expect(api.fetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/artsy/emission/statuses/cfa8fb80d2b65f4c4fa0b54d25352a3a0ff58f75",
+      {
+        headers: {
+          Authorization: "token ABCDE",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+        body: '{"state":"pending","context":"Danger","target_url":"http://danger.systems/js","description":"message"}',
+      },
+      undefined
+    )
+  })
+
+  it("updateStatus(false) success", async () => {
+    api.fetch = jest.fn().mockReturnValue({ ok: true })
+    api.getPullRequestInfo = await requestWithFixturedJSON("github_pr.json")
+
+    await expect(api.updateStatus(false, "message")).resolves.toEqual(true)
+    expect(api.fetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/artsy/emission/statuses/cfa8fb80d2b65f4c4fa0b54d25352a3a0ff58f75",
+      {
+        headers: {
+          Authorization: "token ABCDE",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+        body: '{"state":"failure","context":"Danger","target_url":"http://danger.systems/js","description":"message"}',
+      },
+      undefined
+    )
+  })
+
+  it("updateStatus(true, 'message', 'http://example.org') success", async () => {
+    api.fetch = jest.fn().mockReturnValue({ ok: true })
+    api.getPullRequestInfo = await requestWithFixturedJSON("github_pr.json")
+
+    await expect(api.updateStatus(true, "message", "http://example.org")).resolves.toEqual(true)
+    expect(api.fetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/artsy/emission/statuses/cfa8fb80d2b65f4c4fa0b54d25352a3a0ff58f75",
+      {
+        headers: {
+          Authorization: "token ABCDE",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+        body: '{"state":"success","context":"Danger","target_url":"http://example.org","description":"message"}',
+      },
+      undefined
+    )
+  })
+
+  it("updateStatus(true) failed", async () => {
+    api.fetch = jest.fn().mockReturnValue({ ok: false })
+    api.getPullRequestInfo = await requestWithFixturedJSON("github_pr.json")
+
+    await expect(api.updateStatus(true, "message")).resolves.toEqual(false)
+    expect(api.fetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/artsy/emission/statuses/cfa8fb80d2b65f4c4fa0b54d25352a3a0ff58f75",
+      {
+        headers: {
+          Authorization: "token ABCDE",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+        body: '{"state":"success","context":"Danger","target_url":"http://danger.systems/js","description":"message"}',
+      },
+      undefined
+    )
+  })
+
   it("deleteCommentWithID", async () => {
     api.fetch = jest.fn().mockReturnValue({ status: 204 })
     await api.deleteCommentWithID(123)

--- a/source/platforms/github/comms/issueCommenter.ts
+++ b/source/platforms/github/comms/issueCommenter.ts
@@ -55,31 +55,8 @@ export const GitHubIssueCommenter = (api: GitHubAPI) => {
      * Fails the current build, if status setting succeeds
      * then return true.
      */
-
-    updateStatus: async (passed: boolean | "pending", message: string, url?: string): Promise<boolean> => {
-      const ghAPI = api.getExternalAPI()
-
-      const prJSON = await api.getPullRequestInfo()
-      const ref = prJSON.head
-      try {
-        await ghAPI.repos.createStatus({
-          repo: ref.repo.name,
-          owner: ref.repo.owner.login,
-          sha: ref.sha,
-          state: passed ? "success" : "failure",
-          context: process.env["PERIL_BOT_USER_ID"] ? "Peril" : "Danger",
-          target_url: url || "http://danger.systems/js",
-          description: message,
-        })
-        return true
-      } catch (error) {
-        // @ts-ignore
-        if (global.verbose) {
-          console.log("Got an error with creating a commit status", error)
-        }
-        return false
-      }
-    },
+    updateStatus: async (passed: boolean | "pending", message: string, url?: string): Promise<boolean> =>
+      api.updateStatus(passed, message, url),
 
     /**
      * Gets inline comments for current PR


### PR DESCRIPTION
Fixes #614

- Fix posting status update on Github PRs. 
- Fix handling of 'pending' status on updateStatus(). 
- Add unit tests around GithubAPI's updateStatus() impl

This basically reverts back to delegating to `GithubAPI` to perform the status update on a PR using the issue commenter workflow. (this means that the nice octokit API isn't used, but this does centralize the API operations in the right place, rather than having two implementations - one broken, the other unused).

The underlying issue was that the new implementation in IssueCommenter was using the head she (correct), but also the head repo (should be base). The old impl in GithubAPI was correct here.

Additionally, while the platforms' api states the status could be `"pending"` that was never handled properly here. I'll open a PR to fix that for Bitbucket too.