### PR TITLE
Fix handling of 'pending' status for BitBucket's updateStatus()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+- Fix handling a `"pending"` status update properly using Bitbucket API - [@sgtcoolguy][]
+
 # 5.0.1, err. 6.0.0
 
 - Hah, my computer ran out opf power mid-deploy, and now I have to ship another build to make sure the brew versions of

--- a/source/platforms/BitBucketServer.ts
+++ b/source/platforms/BitBucketServer.ts
@@ -42,9 +42,13 @@ export class BitBucketServer implements Platform {
   updateStatus = async (passed: boolean | "pending", message: string, url?: string): Promise<boolean> => {
     const pr = await this.api.getPullRequestInfo()
     const { latestCommit } = pr.fromRef
+    let state = passed ? "SUCCESSFUL" : "FAILED"
+    if (passed === "pending") {
+      state = "INPROGRESS"
+    }
     try {
       await this.api.postBuildStatus(latestCommit, {
-        state: passed ? "SUCCESSFUL" : "FAILED",
+        state: state,
         key: "danger.systems",
         name: process.env["PERIL_INTEGRATION_ID"] ? "Peril" : "Danger",
         url: url || "http://danger.systems/js",


### PR DESCRIPTION
While the API declared the status as a boolean or `"pending"`, it didn't actually handle it properly and forward to the API state of `"INPROGRESS"`

(The fix for Github is in #704)