### PR TITLE
Prevent GitHub adding a <p> tag to <td> inside issue comment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+- Fix vertical alignment in GitHub issue template - [@patrickkempff][]
+
 # 5.0.1, err. 6.0.0
 
 - Hah, my computer ran out opf power mid-deploy, and now I have to ship another build to make sure the brew versions of

--- a/source/runner/templates/_tests/__snapshots__/_githubIssueTemplates.test.ts.snap
+++ b/source/runner/templates/_tests/__snapshots__/_githubIssueTemplates.test.ts.snap
@@ -10,7 +10,7 @@ exports[`generating inline messages Shows correct message for multiple inline vi
   DangerID: danger-id-blankID;
   File: File.swift;
   Line: 10;
--->  
+-->
 - :no_entry_sign: Test message
 - :no_entry_sign: Warning message
 - :warning: Test message
@@ -43,18 +43,12 @@ exports[`generating inline messages Shows correct messages for inline/regular vi
   </thead>
   <tbody><tr>
       <td>:warning:</td>
-      <td>
-
-  **File.swift#L10** - Test message
-  </td>
+      <td>**File.swift#L10** - Test message</td>
     </tr>
   
 <tr>
       <td>:warning:</td>
-      <td>
-
-  Warning message
-  </td>
+      <td>Warning message</td>
     </tr>
   </tbody>
 </table>
@@ -86,10 +80,7 @@ exports[`generating messages leaves space between <td>s to allow GitHub to rende
   </thead>
   <tbody><tr>
       <td>:no_entry_sign:</td>
-      <td>
-
-  **Failure:** Something failed!
-  </td>
+      <td>**Failure:** Something failed!</td>
     </tr>
   </tbody>
 </table>
@@ -104,10 +95,7 @@ exports[`generating messages leaves space between <td>s to allow GitHub to rende
   </thead>
   <tbody><tr>
       <td>:warning:</td>
-      <td>
-
-  _Maybe you meant to run \`yarn install\`?_
-  </td>
+      <td>_Maybe you meant to run \`yarn install\`?_</td>
     </tr>
   </tbody>
 </table>
@@ -122,14 +110,11 @@ exports[`generating messages leaves space between <td>s to allow GitHub to rende
   </thead>
   <tbody><tr>
       <td>:book:</td>
-      <td>
-
-  \`\`\`ts
+      <td>\`\`\`ts
 function add(a: number, b: number): number {
   return a + b
 }
-\`\`\`
-  </td>
+\`\`\`</td>
     </tr>
   </tbody>
 </table>

--- a/source/runner/templates/githubIssueTemplate.ts
+++ b/source/runner/templates/githubIssueTemplate.ts
@@ -28,10 +28,7 @@ function table(name: string, emoji: string, violations: Violation[]): string {
       const message = isInline(v) ? `**${v.file!}#L${v.line!}** - ${v.message}` : v.message
       return `<tr>
       <td>:${emoji}:</td>
-      <td>
-
-  ${message}
-  </td>
+      <td>${message}</td>
     </tr>
   `
     })
@@ -103,7 +100,7 @@ export function inlineTemplate(dangerID: string, results: DangerResults, file: s
 <!--
 ${buildSummaryMessage(dangerID, results)}
 ${fileLineToString(file, line)}
--->  
+-->
 ${results.fails.map(printViolation("no_entry_sign")).join("\n")}
 ${results.warnings.map(printViolation("warning")).join("\n")}
 ${results.messages.map(printViolation("book")).join("\n")}


### PR DESCRIPTION
Thanks for this awesome project. It looks awesome! There was one thing that caught my attention; the vertical alignment of content in the table seemed somewhat off. 

Before:
![screen shot 2018-11-05 at 12 44 58](https://user-images.githubusercontent.com/310766/47996776-ee0b5a00-e0f9-11e8-87f1-43848c463c01.png)

After:
![screen shot 2018-11-05 at 12 43 59](https://user-images.githubusercontent.com/310766/47996781-f6fc2b80-e0f9-11e8-83ad-a5f60c11244b.png)

This PR fixes that.

After comparing the implementation and the code that GitHub renders. I found that the GitHub markdown implementation adds an <p> tag inside the <td> when it thinks the text should be a text block (because of the linebreak before and after `${message}`). When it appends a `<p>` the user-agent add the default margin at the bottom of the paragraph. (as an example; chrome adds margin-bottom: 16px;) This messes up the vertical alignment.

I removed the linebreaks and github andeverything seems to render everything correctly.

HTML output by github:

Before:
![screen shot 2018-11-05 at 13 01 01](https://user-images.githubusercontent.com/310766/47997112-0a5bc680-e0fb-11e8-9462-3a45030201de.png)

After:
![screen shot 2018-11-05 at 13 03 22](https://user-images.githubusercontent.com/310766/47997176-3ecf8280-e0fb-11e8-9f22-251aac9cd1ff.png)

**Important:** I also updated the `githubIssueTemplates.test.ts.snap` snapshot reflect the changes.

PS. @orta I am sure this is not the right way but I wanted to thank you and the artsy crew for the inspiring talks @facebookHQ in london last July.

