### PR TITLE
Fix GitHub Checks API payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix handling a `"pending"` status update properly using Bitbucket API - [@sgtcoolguy][]
 - Fix #614 - Posting status updates to Github using issue workflow broken - [@sgtcoolguy][]
 - Fix vertical alignment in GitHub issue template - [@patrickkempff][]
+- Fix GitHub checks API payload - [@pveyes][]
 
 # 5.0.1, err. 6.0.0
 

--- a/source/platforms/github/comms/checks/resultsToCheck.ts
+++ b/source/platforms/github/comms/checks/resultsToCheck.ts
@@ -149,7 +149,13 @@ const inlineResultsToAnnotations = async (
       })
     })
 
-    // ignore perFileResults.markdown because it's not supported by Checks API
+    perFileResults.markdowns.forEach(message => {
+      annotations.push({
+        ...fileAnnotation,
+        annotation_level: "notice",
+        message: message,
+      })
+    })
   }
 
   return annotations


### PR DESCRIPTION
This fixes issue because of GitHub Checks API uses different fields (`filename` -> `path`, and `warning_level` -> `annotation_level`) https://developer.github.com/v3/checks/runs/#create-a-check-run

I also separate how danger create annotations. Previously danger use 1 annotation for one file/line, but in our cases we found out that it's possible to have different `annotation_level` in the same file and same line (for example 2 different lint rules). With this change, every `fails`, `warnings`, `messages`, and `markdowns` will have its own annotation.

~The last thing that I found out is that markdown is not supported in `annotation.message` so I just ignore `result.markdowns` (maybe we can put it inside `annotation.raw_message`?)~

If you want to test it you can change your `danger` dependency to `https://github.com/pveyes/danger-js.git#40f6b1acd165bd8953ab6862e1f9c260081eee10` 