### PR TITLE
Fix Netlify integration when repo url includes access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@
 
 ## Master
 
+- Fix Netlify integration when repo url includes an access token - [@imorente][]
+
 # 6.1.0
 
-- Add CI integration for Netlify - imorente
+- Add CI integration for Netlify - [@imorente][]
 
 # 6.0.7
 
@@ -1382,3 +1384,4 @@ Not usable for others, only stubs of classes etc. - [@orta][]
 [@johansteffner]: https://github.com/johansteffner
 [@sgtcoolguy]: https://github.com/sgtcoolguy
 [@patrickkempff]: https://github.com/patrickkempff
+[@imorente]: https://github.com/imorente

--- a/source/ci_source/providers/Netlify.ts
+++ b/source/ci_source/providers/Netlify.ts
@@ -32,6 +32,6 @@ export class Netlify implements CISource {
   }
 
   get repoSlug(): string {
-    return this.env.REPOSITORY_URL.replace(/^https:\/\/github.com\//, "")
+    return this.env.REPOSITORY_URL.replace(/^https:\/\/[^/]+\//, "")
   }
 }

--- a/source/ci_source/providers/_tests/_netlify.test.ts
+++ b/source/ci_source/providers/_tests/_netlify.test.ts
@@ -70,7 +70,7 @@ describe(".pullRequestID", () => {
 
 describe(".repoSlug", () => {
   it("pulls it out of the env", () => {
-    const netlify = new Netlify({ REPOSITORY_URL: "https://github.com/someone/something" })
+    const netlify = new Netlify({ REPOSITORY_URL: "https://x-access-token:v1.9xxx0@github.com/someone/something" })
     expect(netlify.repoSlug).toEqual("someone/something")
   })
 })


### PR DESCRIPTION
(Followup of PR https://github.com/danger/danger-js/pull/760)

Fix Netlify integration for private repositories that include an access token in the URL



