### PR TITLE
Fix `GitJSONDSL` and `diffForFile` for BitBucket Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ## Master
 
+- Fix `GitJSONDSL` and `diffForFile` for BitBucket Server [@langovoi][]
+
 # 6.1.3
 
 - Add support for personal tokens of BitBucket Server - [@langovoi][]

--- a/source/danger.d.ts
+++ b/source/danger.d.ts
@@ -296,6 +296,30 @@ interface BitBucketServerPRComment {
   }
 }
 
+interface BitBucketServerChanges {
+  nextPageStart: number | null
+  values: BitBucketServerChangesValue[]
+}
+
+interface BitBucketServerChangesValueAddModifyDelete {
+  type: "ADD" | "MODIFY" | "DELETE"
+  path: {
+    toString: string
+  }
+}
+
+interface BitBucketServerChangesValueMove {
+  type: "MOVE"
+  path: {
+    toString: string
+  }
+  srcPath: {
+    toString: string
+  }
+}
+
+type BitBucketServerChangesValue = BitBucketServerChangesValueAddModifyDelete | BitBucketServerChangesValueMove
+
 /** A platform agnostic reference to a Git commit */
 interface GitCommit {
   /** The SHA for the commit */

--- a/source/dsl/BitBucketServerDSL.ts
+++ b/source/dsl/BitBucketServerDSL.ts
@@ -287,3 +287,27 @@ export interface BitBucketServerPRComment {
     id: number
   }
 }
+
+export interface BitBucketServerChanges {
+  nextPageStart: number | null
+  values: BitBucketServerChangesValue[]
+}
+
+export interface BitBucketServerChangesValueAddModifyDelete {
+  type: "ADD" | "MODIFY" | "DELETE"
+  path: {
+    toString: string
+  }
+}
+
+export interface BitBucketServerChangesValueMove {
+  type: "MOVE"
+  path: {
+    toString: string
+  }
+  srcPath: {
+    toString: string
+  }
+}
+
+export type BitBucketServerChangesValue = BitBucketServerChangesValueAddModifyDelete | BitBucketServerChangesValueMove

--- a/source/platforms/_tests/_bitbucket_server.test.ts
+++ b/source/platforms/_tests/_bitbucket_server.test.ts
@@ -24,8 +24,8 @@ class mockBitBucketServerAPI /*tslint:disable-line*/ {
     const fixtures = await requestWithFixturedJSON("bitbucket_server_comments.json")
     return await fixtures()
   }
-  async getPullRequestDiff() {
-    const fixtures = await requestWithFixturedJSON("bitbucket_server_diff.json")
+  async getPullRequestChanges() {
+    const fixtures = await requestWithFixturedJSON("bitbucket_server_changes.json")
     return await fixtures()
   }
   async getPullRequestActivities() {

--- a/source/platforms/_tests/fixtures/bitbucket_server_changes.json
+++ b/source/platforms/_tests/fixtures/bitbucket_server_changes.json
@@ -1,0 +1,29 @@
+[
+  {
+    "type": "MODIFY",
+    "path": {
+      "toString": ".gitignore"
+    }
+  },
+  {
+    "type": "ADD",
+    "path": {
+      "toString": "banana"
+    }
+  },
+  {
+    "type": "MOVE",
+    "path": {
+      "toString": ".babelrc"
+    },
+    "srcPath": {
+      "toString": ".babelrc.example"
+    }
+  },
+  {
+    "type": "DELETE",
+    "path": {
+      "toString": "jest.eslint.config.js"
+    }
+  }
+]

--- a/source/platforms/bitbucket_server/_tests/_bitbucket_server_git.test.ts
+++ b/source/platforms/bitbucket_server/_tests/_bitbucket_server_git.test.ts
@@ -48,8 +48,8 @@ describe("the dangerfile gitDSL - BitBucket Server", async () => {
     bbs = new BitBucketServer(api)
 
     api.getIssues = await requestWithFixturedJSON("bitbucket_server_issues.json")
-    api.getPullRequestDiff = await requestWithFixturedJSON("bitbucket_server_diff.json")
-    api.getStructuredDiff = await requestWithFixturedJSON("bitbucket_server_diff.json")
+    api.getPullRequestChanges = await requestWithFixturedJSON("bitbucket_server_changes.json")
+    api.getStructuredDiffForFile = await requestWithFixturedJSON("bitbucket_server_diff.json")
     api.getPullRequestInfo = await requestWithFixturedJSON(pullRequestInfoFilename)
     api.getPullRequestCommits = await requestWithFixturedJSON("bitbucket_server_commits.json")
     api.getPullRequestComments = await requestWithFixturedJSON("bitbucket_server_comments.json")
@@ -63,8 +63,8 @@ describe("the dangerfile gitDSL - BitBucket Server", async () => {
 
   it("sets the modified/created/deleted", async () => {
     expect(gitJSONDSL.modified_files).toEqual([".gitignore"])
-    expect(gitJSONDSL.created_files).toEqual(["banana"])
-    expect(gitJSONDSL.deleted_files).toEqual(["jest.eslint.config.js"])
+    expect(gitJSONDSL.created_files).toEqual(["banana", ".babelrc"])
+    expect(gitJSONDSL.deleted_files).toEqual([".babelrc.example", "jest.eslint.config.js"])
   })
 
   it("shows the diff for a specific file", async () => {

--- a/source/platforms/git/gitJSONToGitDSL.ts
+++ b/source/platforms/git/gitJSONToGitDSL.ts
@@ -32,7 +32,7 @@ export interface GitJSONToGitDSLConfig {
   getFileContents: (path: string, repo: string | undefined, sha: string) => Promise<string>
   /** A promise which will return the diff string content for a file between shas */
   getFullDiff?: (base: string, head: string) => Promise<string>
-  getFullStructuredDiff?: (base: string, head: string) => Promise<GitStructuredDiff>
+  getStructuredDiffForFile?: (base: string, head: string, filename: string) => Promise<GitStructuredDiff>
 }
 
 export type GitStructuredDiff = {
@@ -155,8 +155,8 @@ export const gitJSONToGitDSL = (gitJSONRep: GitJSONDSL, config: GitJSONToGitDSLC
   const structuredDiffForFile = async (filename: string): Promise<StructuredDiff | null> => {
     let fileDiffs: GitStructuredDiff
 
-    if (config.getFullStructuredDiff) {
-      fileDiffs = await config.getFullStructuredDiff(config.baseSHA, config.headSHA)
+    if (config.getStructuredDiffForFile) {
+      fileDiffs = await config.getStructuredDiffForFile(config.baseSHA, config.headSHA, filename)
     } else {
       const diff = await config.getFullDiff!(config.baseSHA, config.headSHA)
       fileDiffs = parseDiff(diff)


### PR DESCRIPTION
Bitbucket Server API for `diff` sometimes return `truncated: true` in root of response.
This means that Bitbucket Server don't provide full diff of all files.

In my practical with Danger, this breaks `modified_files`, `created_files` and `deleted_files`.

Bitbucket Server has another API, which returns list of changes in PR, without diff.
I replaced `diff` API with `changes` API for generation `GitJSONDSL`.

Also I reworked `diffForFile` to fix potential bug with Bitbucket Server, when `diff` API may return truncated results.