### PR TITLE
Declares the html_url on the pr json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@
 
 ## Master
 
+- Adds `html_url` to the PR JSON declaration - [@orta][]
+
 # 6.1.4
 
-- Fix `GitJSONDSL` and `diffForFile` for BitBucket Server [@langovoi][]
+- Fix `GitJSONDSL` and `diffForFile` for BitBucket Server - [@langovoi][]
 
 # 6.1.3
 

--- a/source/danger-incoming-process-schema.json
+++ b/source/danger-incoming-process-schema.json
@@ -820,6 +820,10 @@
           "$ref": "#/definitions/GitHubMergeRef",
           "description": "Merge reference for the _other_ repo."
         },
+        "html_url": {
+          "description": "The link back to this PR as user-facing",
+          "type": "string"
+        },
         "locked": {
           "description": "Has the PR been locked to contributors only?",
           "type": "boolean"

--- a/source/danger.d.ts
+++ b/source/danger.d.ts
@@ -947,6 +947,11 @@ interface GitHubPRDSL {
    * The number of changed files in the PR
    */
   changed_files: number
+
+  /**
+   * The link back to this PR as user-facing
+   */
+  html_url: string
 }
 
 // These are the individual subtypes of objects inside the larger DSL objects above.

--- a/source/dsl/GitHubDSL.ts
+++ b/source/dsl/GitHubDSL.ts
@@ -250,6 +250,11 @@ export interface GitHubPRDSL {
    * The number of changed files in the PR
    */
   changed_files: number
+
+  /**
+   * The link back to this PR as user-facing
+   */
+  html_url: string
 }
 
 // These are the individual subtypes of objects inside the larger DSL objects above.


### PR DESCRIPTION
This always existed, but to use it you had to remove the type system.