### PR TITLE
Add support for COPY change type to fix BitBucket Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 ## Master
 
+- Add support for `COPY` change type to fix a BitBucket Server regression in
+  [danger/danger-js#764](https://github.com/danger/danger-js/pull/764) - [@sebinsua][]
+
 # 6.1.8
 
 - Revert removal of implicit `<p>` tag from [danger/danger-js#754](https://github.com/danger/danger-js/pull/754) and add

--- a/source/danger.d.ts
+++ b/source/danger.d.ts
@@ -306,8 +306,8 @@ interface BitBucketServerPagedResponse<T> {
   values: T
 }
 
-interface BitBucketServerChangesValueAddModifyDelete {
-  type: "ADD" | "MODIFY" | "DELETE"
+interface BitBucketServerChangesValueAddCopyModifyDelete {
+  type: "ADD" | "COPY" | "MODIFY" | "DELETE" | "UNKNOWN"
   path: {
     toString: string
   }
@@ -323,7 +323,9 @@ interface BitBucketServerChangesValueMove {
   }
 }
 
-type BitBucketServerChangesValue = BitBucketServerChangesValueAddModifyDelete | BitBucketServerChangesValueMove
+type BitBucketServerChangesValue =
+  | BitBucketServerChangesValueAddCopyModifyDelete
+  | BitBucketServerChangesValueMove
 
 /** A platform agnostic reference to a Git commit */
 interface GitCommit {

--- a/source/dsl/BitBucketServerDSL.ts
+++ b/source/dsl/BitBucketServerDSL.ts
@@ -298,8 +298,8 @@ export interface BitBucketServerPagedResponse<T> {
   values: T
 }
 
-export interface BitBucketServerChangesValueAddModifyDelete {
-  type: "ADD" | "MODIFY" | "DELETE"
+export interface BitBucketServerChangesValueAddCopyModifyDelete {
+  type: "ADD" | "COPY" | "MODIFY" | "DELETE" | "UNKNOWN"
   path: {
     toString: string
   }
@@ -315,4 +315,6 @@ export interface BitBucketServerChangesValueMove {
   }
 }
 
-export type BitBucketServerChangesValue = BitBucketServerChangesValueAddModifyDelete | BitBucketServerChangesValueMove
+export type BitBucketServerChangesValue =
+  | BitBucketServerChangesValueAddCopyModifyDelete
+  | BitBucketServerChangesValueMove

--- a/source/platforms/_tests/fixtures/bbs-dsl-input.json
+++ b/source/platforms/_tests/fixtures/bbs-dsl-input.json
@@ -1,12 +1,23 @@
 {
   "git": {
-    "modified_files": [".gitignore"],
-    "created_files": ["banana", ".babelrc"],
-    "deleted_files": [".babelrc.example", "jest.eslint.config.js"],
+    "modified_files": [
+      ".gitignore"
+    ],
+    "created_files": [
+      "banana",
+      "orange",
+      ".babelrc"
+    ],
+    "deleted_files": [
+      ".babelrc.example",
+      "jest.eslint.config.js"
+    ],
     "commits": [
       {
         "sha": "d6725486c38d46a33e76f622cf24b9a388c8d13d",
-        "parents": ["c62ada76533a2de045d4c6062988ba84df140729"],
+        "parents": [
+          "c62ada76533a2de045d4c6062988ba84df140729"
+        ],
         "author": {
           "email": "foo@bar.com",
           "name": "danger",
@@ -23,7 +34,9 @@
       },
       {
         "sha": "c62ada76533a2de045d4c6062988ba84df140729",
-        "parents": ["8942a1f75e4c95df836f19ef681d20a87da2ee20"],
+        "parents": [
+          "8942a1f75e4c95df836f19ef681d20a87da2ee20"
+        ],
         "author": {
           "email": "foo@bar.com",
           "name": "danger",
@@ -528,7 +541,9 @@
         "createdDate": 1518870689956,
         "diff": {
           "destination": {
-            "components": ["banana"],
+            "components": [
+              "banana"
+            ],
             "name": "banana",
             "parent": "",
             "toString": "banana"
@@ -541,7 +556,9 @@
                 {
                   "lines": [
                     {
-                      "commentIds": [2],
+                      "commentIds": [
+                        2
+                      ],
                       "destination": 1,
                       "line": "bar",
                       "source": 0,
@@ -939,7 +956,9 @@
         "diff": {
           "source": null,
           "destination": {
-            "components": ["banana"],
+            "components": [
+              "banana"
+            ],
             "parent": "",
             "name": "banana",
             "toString": "banana"
@@ -959,7 +978,9 @@
                       "source": 0,
                       "line": "bar",
                       "truncated": false,
-                      "commentIds": [2]
+                      "commentIds": [
+                        2
+                      ]
                     }
                   ],
                   "truncated": false

--- a/source/platforms/_tests/fixtures/bitbucket_server_changes.json
+++ b/source/platforms/_tests/fixtures/bitbucket_server_changes.json
@@ -12,6 +12,12 @@
     }
   },
   {
+    "type": "COPY",
+    "path": {
+      "toString": "orange"
+    }
+  },
+  {
     "type": "MOVE",
     "path": {
       "toString": ".babelrc"

--- a/source/platforms/bitbucket_server/BitBucketServerGit.ts
+++ b/source/platforms/bitbucket_server/BitBucketServerGit.ts
@@ -90,8 +90,10 @@ const bitBucketServerChangesToGitJSONDSL = (
 ): GitJSONDSL => {
   return changes.reduce<GitJSONDSL>(
     (git, value) => {
+      // See: https://docs.atlassian.com/bitbucket-server/javadoc/4.1.0/api/reference/com/atlassian/bitbucket/content/ChangeType.html
       switch (value.type) {
         case "ADD":
+        case "COPY":
           return {
             ...git,
             created_files: [...git.created_files, value.path.toString],
@@ -113,7 +115,7 @@ const bitBucketServerChangesToGitJSONDSL = (
             deleted_files: [...git.deleted_files, value.path.toString],
           }
         default:
-          throw new Error("Unhandled change type")
+          throw new Error(`Unhandled change type: ${value.type}`)
       }
     },
     {

--- a/source/platforms/bitbucket_server/_tests/_bitbucket_server_git.test.ts
+++ b/source/platforms/bitbucket_server/_tests/_bitbucket_server_git.test.ts
@@ -64,7 +64,7 @@ describe("the dangerfile gitDSL - BitBucket Server", async () => {
 
   it("sets the modified/created/deleted", async () => {
     expect(gitJSONDSL.modified_files).toEqual([".gitignore"])
-    expect(gitJSONDSL.created_files).toEqual(["banana", ".babelrc"])
+    expect(gitJSONDSL.created_files).toEqual(["banana", "orange", ".babelrc"])
     expect(gitJSONDSL.deleted_files).toEqual([".babelrc.example", "jest.eslint.config.js"])
   })
 


### PR DESCRIPTION
I noticed that [since this PR](https://github.com/danger/danger-js/commit/f680b5f65c32f339a21a242462c890e829dde9dc#r31538980) some of our PRs on BitBucket Server cause Danger to throw the error: `"Unhandled change type"`.

This seems to be because BitBucket has an extra change type `COPY` which appears when it detects that a file has been added which is 'similar' to another file that already exists in the repository.

[The `ChangeType`s are defined here](https://docs.atlassian.com/bitbucket-server/javadoc/4.1.0/api/reference/com/atlassian/bitbucket/content/ChangeType.html).

There was also an `UNKNOWN` change type. I don't know when this can occur: I added it for correctness sake and because it allowed me to put the `${value.type}` into the error that will be thrown if a new change type is added by BitBucket Server in future. This should make it slightly easier to debug any future additions of change types.

/cc @langovoi 