### PR TITLE
Add support for older Babel versions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Add support for `COPY` change type to fix a BitBucket Server regression in
   [danger/danger-js#764](https://github.com/danger/danger-js/pull/764) - [@sebinsua][]
+- Add support for older Babel versions (prior 7) [@sajjadzamani][]
 
 # 6.1.8
 
@@ -1434,3 +1435,4 @@ Not usable for others, only stubs of classes etc. - [@orta][]
 [@patrickkempff]: https://github.com/patrickkempff
 [@imorente]: https://github.com/imorente
 [@langovoi]: https://github.com/langovoi
+[@sajjadzamani]: https://github.com/sajjadzamani


### PR DESCRIPTION
Fix for #781.

## Changes
- To support both Babel packages prior to the v7 release and after, the package names have to be dynamically calculated during runtime. This is simple as using a prefix of `@babel/` for `>=7.x.x` versions and `babel-` for `<7.x.x` versions.
- With Babel 7 it is recommended to use `transformSync` instead of `transform` if the transformation needs to be done synchronously. `transform` worked fine but it might be dropped in future releases of Babel.