### PR TITLE
Update GITHUB_EVENT_TYPE to GITHUB_EVENT_NAME for Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add support for `COPY` change type to fix a BitBucket Server regression in
   [danger/danger-js#764](https://github.com/danger/danger-js/pull/764) - [@sebinsua][]
 - Add support for older Babel versions (prior 7) [@sajjadzamani][]
+- Fix detection of GitHub Actions event types [@cysp][]
 
 # 6.1.8
 
@@ -1438,3 +1439,4 @@ Not usable for others, only stubs of classes etc. - [@orta][]
 [@langovoi]: https://github.com/langovoi
 [@randak]: https://github.com/randak
 [@sajjadzamani]: https://github.com/sajjadzamani
+[@cysp]: https://github.com/cysp

--- a/source/ci_source/providers/GitHubActions.ts
+++ b/source/ci_source/providers/GitHubActions.ts
@@ -75,11 +75,11 @@ export class GitHubActions implements CISource {
 
   get useEventDSL() {
     // Support event based PR runs
-    return this.env.GITHUB_EVENT_TYPE !== "pull_request"
+    return this.env.GITHUB_EVENT_NAME !== "pull_request"
   }
 
   get pullRequestID(): string {
-    if (this.env.GITHUB_EVENT_TYPE === "pull_request") {
+    if (this.env.GITHUB_EVENT_NAME === "pull_request") {
       return this.event.pull_request.number
     }
 
@@ -87,7 +87,7 @@ export class GitHubActions implements CISource {
   }
 
   get repoSlug(): string {
-    if (this.env.GITHUB_EVENT_TYPE === "pull_request") {
+    if (this.env.GITHUB_EVENT_NAME === "pull_request") {
       return this.event.pull_request.base.repo.full_name
     }
 

--- a/source/platforms/platform.ts
+++ b/source/platforms/platform.ts
@@ -103,7 +103,7 @@ export function getPlatformForEnv(env: Env, source: CISource, requireAuth = true
   }
 
   // They need to set the token up for GitHub actions to work
-  if (env["GITHUB_EVENT_TYPE"] && !env["GITHUB_TOKEN"]) {
+  if (env["GITHUB_EVENT_NAME"] && !env["GITHUB_TOKEN"]) {
     console.error(`You need to add GITHUB_TOKEN to your Danger action in the workflow:
 
     action "${env["GITHUB_ACTION"]}" {


### PR DESCRIPTION
Fixes #782 (for me 🙃)

Unfortunately GitHub Actions' runtime environment doesn't provide `git` so I tested this fix by bundling a snapshot of all of `danger-js` in my app. 🙂 