### PR TITLE
Fix babel polyfill import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@
 
 <!-- Your comment below this -->
 
+- Fix issue with detecting Babel if `babel-core` is installed [@sajjadzamani][]
+
 # 6.2.0
 
 - Fix detection of GitHub Actions event types [@cysp][]
-- Fix issue with detecting Babel versions prior to 7 caused by (#784) [@sajjadzamani][]
 
 # 6.1.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 # 6.2.0
 
 - Fix detection of GitHub Actions event types [@cysp][]
+- Fix issue with detecting Babel versions prior to 7 caused by (#784) [@sajjadzamani][]
 
 # 6.1.9
 

--- a/source/runner/runners/utils/transpiler.ts
+++ b/source/runner/runners/utils/transpiler.ts
@@ -37,7 +37,6 @@ export const checkForNodeModules = () => {
 
   const checkForBabel = (prefix: BabelPackagePrefix) => {
     require.resolve(`${prefix}core`) // tslint:disable-line
-    require(`${prefix}polyfill`) // tslint:disable-line
     babelPackagePrefix = prefix
     hasBabel = true
   }
@@ -55,6 +54,8 @@ export const checkForNodeModules = () => {
   }
 
   if (hasBabel) {
+    // @babel/polyfill is a direct dependency of Danger.
+    require("@babel/polyfill") // tslint:disable-line
     try {
       require.resolve(`${babelPackagePrefix}plugin-transform-typescript`) // tslint:disable-line
       hasBabelTypeScript = true


### PR DESCRIPTION
Relates to #781.
# Issue
The change of #784, introduced an extra dependency on the `babel-polyfill` package, to detect if the dangerfile should be transpiled, if the user had the older version of Babel (`babel-core`) installed.

# Fix
We should always import the version of the polyfill that is installed as part of Danger's dependencies which is`@babel/polyfill`. If the user environment has Babel then this package should be imported no matter the version of Babel installed.