### PR TITLE
Fix formatting of danger.d.ts

### DIFF
--- a/source/danger.d.ts
+++ b/source/danger.d.ts
@@ -323,7 +323,9 @@ interface BitBucketServerChangesValueMove {
   }
 }
 
-type BitBucketServerChangesValue = BitBucketServerChangesValueAddCopyModifyDelete | BitBucketServerChangesValueMove
+type BitBucketServerChangesValue =
+  | BitBucketServerChangesValueAddCopyModifyDelete
+  | BitBucketServerChangesValueMove
 
 /** A platform agnostic reference to a Git commit */
 interface GitCommit {


### PR DESCRIPTION
This formatting changed in https://github.com/danger/danger-js/commit/c83dc564a38cd359bf3ddbcd2d17ab34eef18bb3#diff-b80101a8397dd9218bf49711f9f485f0R326 and then it looks like an attempt was made to correct it in https://github.com/danger/danger-js/commit/4a62feaf1b9dbd5a1af8b409a628118836ffcb39 but must have been stymied by one of the git hooks, which also made making this commit a little difficult. 🙃 