### PR TITLE
Declare a direct dependency on http-proxy-agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "commander": "^2.18.0",
     "debug": "^4.1.1",
     "get-stdin": "^6.0.0",
+    "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.1",
     "hyperlinker": "^1.0.0",
     "jsome": "^2.3.25",


### PR DESCRIPTION
I'm seeing this error when running the latest version of danger-js:
```
internal/modules/cjs/loader.js:582
    throw err;
    ^

Error: Cannot find module 'http-proxy-agent'
```

… it looks like we used to get the package via a transitive dependency via `@octokit/rest`, but that changed with the recent upgrade of that package:
https://github.com/danger/danger-js/commit/085903291bd17107b17a6171ea4919dcdc8e70be#diff-8ee2343978836a779dc9f8d6b794c3b2L719