### PR TITLE
Build a Docker image from source code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ LABEL "com.github.actions.color"="blue"
 
 RUN mkdir -p /usr/src/danger
 COPY . /usr/src/danger
-RUN cd /usr/src/danger && yarn && yarn run build:fast && ln -s $(pwd)/distribution/commands/danger.js /usr/bin/danger
+RUN cd /usr/src/danger && \
+  yarn && \
+  yarn run build:fast && \
+  chmod +x /distribution/commands/danger.js && \
+  ln -s $(pwd)/distribution/commands/danger.js /usr/bin/danger
 
 ENTRYPOINT ["danger", "ci"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ LABEL "com.github.actions.description"="Runs JavaScript/TypeScript Dangerfiles"
 LABEL "com.github.actions.icon"="zap"
 LABEL "com.github.actions.color"="blue"
 
-RUN yarn run build
-RUN ln -s distribution/commands/danger.js /usr/bin/danger
+RUN mkdir -p /usr/src/danger
+COPY . /usr/src/danger
+RUN cd /usr/src/danger && yarn run build && ln -s distribution/commands/danger.js /usr/bin/danger
 
 ENTRYPOINT ["danger", "ci"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,7 @@ LABEL "com.github.actions.description"="Runs JavaScript/TypeScript Dangerfiles"
 LABEL "com.github.actions.icon"="zap"
 LABEL "com.github.actions.color"="blue"
 
-ENTRYPOINT ["npx", "--package", "danger@beta", "--package", "typescript", "--package", "@babel/cli", "danger", "ci"]
+RUN yarn run build
+RUN ln -s distribution/commands/danger.js /usr/bin/danger
+
+ENTRYPOINT ["danger", "ci"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ LABEL "com.github.actions.color"="blue"
 
 RUN mkdir -p /usr/src/danger
 COPY . /usr/src/danger
-RUN cd /usr/src/danger && yarn && yarn run build && ln -s $(pwd)/distribution/commands/danger.js /usr/bin/danger
+RUN cd /usr/src/danger && yarn && yarn run build:fast && ln -s $(pwd)/distribution/commands/danger.js /usr/bin/danger
 
 ENTRYPOINT ["danger", "ci"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ LABEL "com.github.actions.color"="blue"
 
 RUN mkdir -p /usr/src/danger
 COPY . /usr/src/danger
-RUN cd /usr/src/danger && yarn && yarn run build && ln -s distribution/commands/danger.js /usr/bin/danger
+RUN cd /usr/src/danger && yarn && yarn run build && ln -s $(pwd)/distribution/commands/danger.js /usr/bin/danger
 
 ENTRYPOINT ["danger", "ci"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ LABEL "com.github.actions.color"="blue"
 
 RUN mkdir -p /usr/src/danger
 COPY . /usr/src/danger
-RUN cd /usr/src/danger && yarn run build && ln -s distribution/commands/danger.js /usr/bin/danger
+RUN cd /usr/src/danger && yarn && yarn run build && ln -s distribution/commands/danger.js /usr/bin/danger
 
 ENTRYPOINT ["danger", "ci"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . /usr/src/danger
 RUN cd /usr/src/danger && \
   yarn && \
   yarn run build:fast && \
-  chmod +x /distribution/commands/danger.js && \
+  chmod +x distribution/commands/danger.js && \
   ln -s $(pwd)/distribution/commands/danger.js /usr/bin/danger
 
 ENTRYPOINT ["danger", "ci"]


### PR DESCRIPTION
## Problems

- We struggle with getting the GitHub Actions to work on our project, but it is not easy to debug Danger when running on GitHub Actions. We’ve tried setting `DEBUG=*` and `--verbose` to no avail.

- We tried forking Danger JS, but since its Dockerfile always install `danger-js` from the npm registry (via `npx danger@beta`), it is not easy for us to modify the source code and debug Danger on GitHub actions.

- Upon [inspecting the npm registry](https://www.npmjs.com/package/danger) I found that the beta tag is two major versions behind. `danger@latest` is at v7.0.2, whereas `danger@beta` is at v5.0.0-beta.24. That means people running Danger on GitHub Actions, following [the documentation](https://github.com/danger/danger-js/blob/b9148d5f216ac7358dc9ea179792c3aa0168d091/source/ci_source/providers/GitHubActions.ts#L8-L24) are running an utterly outdated version of Danger.

## Solution

- I updated the Dockerfile so that it always compile Danger from source code. This means:

   - People can use a specific version of Danger via `uses = "danger/danger-js@v7.0.3"` or use a cutting edge version via `uses = "danger/danger-js@master"`.

   - People can fork `danger-js` and use it right away via `uses = "<username>/danger-js@master"`.

- By using the latest version of Danger. The problem is gone — our configuration works now.

## Caveat

- It will take a longer time to run Danger the first time, due to compiling TypeScript from source code (I used `yarn run build:fast` for faster build). This takes ~2 minutes.

  But subsequent runs will be faster, as Docker cache is used. For example, here, on subsequent runs `---> Using cache` is present in all steps.

    ```
    Step 1/10 : FROM node:10-slim
    Status: Downloaded newer image for node:10-slim
    ---> 1ee14be408b9
    Step 2/10 : MAINTAINER Orta Therox
    ---> Using cache
    ---> 15e1c45a0159
    Step 3/10 : LABEL "com.github.actions.name"="Danger JS"
    ---> Using cache
    ---> c23ae56f8c2f
    Step 4/10 : LABEL "com.github.actions.description"="Runs JavaScript/TypeScript Dangerfiles"
    ---> Using cache
    ---> 106e82f2cc17
    Step 5/10 : LABEL "com.github.actions.icon"="zap"
    ---> Using cache
    ---> 14262429c7b7
    Step 6/10 : LABEL "com.github.actions.color"="blue"
    ---> Using cache
    ---> 9536a2e390ed
    Step 7/10 : RUN mkdir -p /usr/src/danger
    ---> Using cache
    ---> 3e3a0ce8c201
    Step 8/10 : COPY . /usr/src/danger
    ---> Using cache
    ---> de4f5756278f
    Step 9/10 : RUN cd /usr/src/danger &&   yarn &&   yarn run build:fast &&   chmod +x distribution/commands/danger.js &&   ln -s $(pwd)/distribution/commands/danger.js /usr/bin/danger
    ---> Using cache
    ---> beb1b82f53bd
    Step 10/10 : ENTRYPOINT ["danger", "ci"]
    ---> Using cache
    ---> 5383fc05ca7d
    Successfully built 5383fc05ca7d
    ```