### PR TITLE
Update isCI check for Codeship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 <!-- Your comment below this -->
 
+- Fixed: isCI check for Codeship - [@msteward]
+
 # 7.0.14
 
 - Fixed: Crash on BitbucketServer when the change type is unknown - [@f-meloni]
@@ -367,7 +369,7 @@ Also, `danger pr` now accepts a `--process` arg.
 # 3.7.19
 
 - Convert the `exec` in `danger local` to a `spawn` hopefully unblocking large diffs from going through it -
-  [@joshacheson] [@orta]
+  [@joshacheson][@orta]
 
 # 3.7.18
 
@@ -795,8 +797,8 @@ You'll need to have [husky](https://www.npmjs.com/package/husky) installed for t
 ### 2.0.0-beta.2
 
 - Fixes a bug with `danger.github.utils` in that it didn't work as of b1, and now it does :+1: - [@orta]
-- Ships a `danger.js.flow` in the root of the project, this may be enough to support flow typing, thanks to
-  [@joarwilk] and [flowgen](https://github.com/joarwilk/flowgen) - [@orta]
+- Ships a `danger.js.flow` in the root of the project, this may be enough to support flow typing, thanks to [@joarwilk]
+  and [flowgen](https://github.com/joarwilk/flowgen) - [@orta]
 
 ### 2.0.0-beta.1
 

--- a/source/ci_source/providers/Codeship.ts
+++ b/source/ci_source/providers/Codeship.ts
@@ -1,7 +1,8 @@
 import { Env, CISource } from "../ci_source"
 import { ensureEnvKeysExist, getPullRequestIDForBranch } from "../ci_source_helpers"
 
-// https://documentation.codeship.com/pro/builds-and-configuration/environment-variables/
+// Codeship Pro: https://documentation.codeship.com/pro/builds-and-configuration/environment-variables/
+// Codeship Basic: https://documentation.codeship.com/basic/builds-and-configuration/set-environment-variables/
 
 /**
  * ### CI Setup
@@ -48,7 +49,10 @@ export class Codeship implements CISource {
   }
 
   get isCI(): boolean {
-    return ensureEnvKeysExist(this.env, ["CODESHIP"])
+    if (ensureEnvKeysExist(this.env, ["CI_NAME"]) && this.env.CI_NAME === "codeship") {
+      return true
+    }
+    return false
   }
 
   get isPR(): boolean {


### PR DESCRIPTION
## Problem
- The current Codeship configuration relies on an environment variable called `CODESHIP` being set which is no longer the case on both Codeship Basic/Pro.

## Solution
- Add check against `CI_NAME` which in both Codeship Pro and Codeship Basic is set to `codeship` (see [Codeship Pro environment variable documentation](https://documentation.codeship.com/pro/builds-and-configuration/environment-variables/) and [Codeship Basic environment variable documentation](https://documentation.codeship.com/basic/builds-and-configuration/set-environment-variables/)