### PR TITLE
If DangerID is defined, use it as the context for platform status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 <!-- Your comment below this -->
 
+- Enable Danger runs with different DangerIDs to post separate statuses [@randak]
 - Docs: fix typo - [@hiroppy]
 - Fixed: isCI check for Codeship - [@msteward]
 

--- a/source/commands/ci/resetStatus.ts
+++ b/source/commands/ci/resetStatus.ts
@@ -30,7 +30,7 @@ export const runRunner = async (app: SharedCLI, config?: RunnerConfig) => {
     }
 
     if (platform) {
-      await platform.updateStatus("pending", "Danger is waiting for your CI run to complete...")
+      await platform.updateStatus("pending", "Danger is waiting for your CI run to complete...", undefined, app.id)
     }
   }
 }

--- a/source/platforms/github/comms/issueCommenter.ts
+++ b/source/platforms/github/comms/issueCommenter.ts
@@ -55,8 +55,12 @@ export const GitHubIssueCommenter = (api: GitHubAPI) => {
      * Fails the current build, if status setting succeeds
      * then return true.
      */
-    updateStatus: async (passed: boolean | "pending", message: string, url?: string): Promise<boolean> =>
-      api.updateStatus(passed, message, url),
+    updateStatus: async (
+      passed: boolean | "pending",
+      message: string,
+      url?: string,
+      dangerID?: string
+    ): Promise<boolean> => api.updateStatus(passed, message, url, dangerID),
 
     /**
      * Gets inline comments for current PR

--- a/source/platforms/platform.ts
+++ b/source/platforms/platform.ts
@@ -78,7 +78,7 @@ export interface PlatformCommunicator {
   /** Replace the main Danger comment, returning the URL to the issue */
   updateOrCreateComment: (dangerID: string, newComment: string) => Promise<string | undefined>
   /** Sets the current PR's status */
-  updateStatus: (passed: boolean | "pending", message: string, url?: string) => Promise<boolean>
+  updateStatus: (passed: boolean | "pending", message: string, url?: string, dangerID?: string) => Promise<boolean>
 }
 
 /**

--- a/source/runner/Executor.ts
+++ b/source/runner/Executor.ts
@@ -277,7 +277,7 @@ export class Executor {
     }
 
     const urlForInfo = issueURL || this.ciSource.ciRunURL
-    const successPosting = await this.platform.updateStatus(!failed, messageForResults(results), urlForInfo)
+    const successPosting = await this.platform.updateStatus(!failed, messageForResults(results), urlForInfo, dangerID)
     if (!successPosting && this.options.verbose) {
       this.log("Could not add a commit status, the GitHub token for Danger does not have access rights.")
       this.log("If the build fails, then danger will use a failing exit code.")

--- a/source/runner/_tests/_executor.test.ts
+++ b/source/runner/_tests/_executor.test.ts
@@ -280,7 +280,7 @@ describe("setup", () => {
     platform.updateStatus = jest.fn()
 
     await exec.handleResults(emptyResults, dsl.git)
-    expect(platform.updateStatus).toBeCalledWith(true, jasmine.any(String), undefined)
+    expect(platform.updateStatus).toBeCalledWith(true, jasmine.any(String), undefined, defaultConfig.dangerID)
   })
 
   it("Updates the status with success for a passed results", async () => {
@@ -294,7 +294,8 @@ describe("setup", () => {
     expect(platform.updateStatus).toBeCalledWith(
       true,
       ":warning: Danger found some issues. Don't worry, everything is fixable.",
-      undefined
+      undefined,
+      defaultConfig.dangerID
     )
   })
 
@@ -309,7 +310,8 @@ describe("setup", () => {
     expect(platform.updateStatus).toBeCalledWith(
       false,
       ":warning: Danger found some issues. Don't worry, everything is fixable.",
-      undefined
+      undefined,
+      defaultConfig.dangerID
     )
   })
 
@@ -324,6 +326,6 @@ describe("setup", () => {
     platform.updateStatus = jest.fn()
 
     await exec.handleResults(failsResults, dsl.git)
-    expect(platform.updateStatus).toBeCalledWith(expect.anything(), expect.anything(), ci.ciRunURL)
+    expect(platform.updateStatus).toBeCalledWith(expect.anything(), expect.anything(), ci.ciRunURL, expect.anything())
   })
 })


### PR DESCRIPTION
Resolves #839.

Currently, if you run two separate danger builds with their own IDs, they will post two separate comments. However, the status is not tied to the ID, so if one danger build fails and the second one passes, your PR will incorrectly be marked as passing.

This change uses the ID as the `context`/`name` for the status, which will allow each build to show up as an independent status, making it possible to have multiple Danger runs on one PR. (We use this to run our build and test in parallel in the CI and report issues from each of them.)