### PR TITLE
 Send different build update keys based on the id on Bitbucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 <!-- Your comment below this -->
 
+- Send different build update keys based on the id on Bitbucket [@f-meloni]
+
 # 7.0.16
 
 - Add support for CodeBuild CI source [@sharkysharks]

--- a/source/platforms/BitBucketServer.ts
+++ b/source/platforms/BitBucketServer.ts
@@ -54,16 +54,18 @@ export class BitBucketServer implements Platform {
     }
 
     let name = "Danger"
+    let key = "danger.systems"
     if (process.env["PERIL_INTEGRATION_ID"]) {
       name = "Peril"
     } else if (dangerID) {
       name = dangerID
+      key = dangerID
     }
 
     try {
       await this.api.postBuildStatus(latestCommit, {
         state: state,
-        key: "danger.systems",
+        key: key,
         name: name,
         url: url || "http://danger.systems/js",
         description: message,


### PR DESCRIPTION
Bitbucket requires different keys in order to show different build reports