### PR TITLE
Add `danger.git.fileMatch.getKeyedPaths()`, providing more convenient access to paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@
 
 <!-- Your comment below this -->
 
+- Add `danger.git.fileMatch.getKeyedPaths()`, providing more convenient access to paths. This replaces `fileMatch.tap()`
+  and `fileMatch.debug()`.
+
+  ```ts
+  const components = fileMatch("components/**/*.js", "!**/*.test.js")
+  const componentTests = fileMatch("!**/*.test.js")
+
+  if (components.edited && !componentTests.edited) {
+    warn(
+      [
+        "This PR modified some components but none of their tests. <br>",
+        "That's okay so long as it's refactoring existing code. <br>",
+        "Affected files: ",
+        components.getKeyedPaths().edited.join(", "),
+      ].join("")
+    )
+  }
+  ```
+
+  This makes it much simpler to compose a collection of file checks - [@paulmelnikow]
+
 # 7.1.0
 
 - Adds Chainsmoker, and expands the Danger DSL with the addition of `danger.git.fileMatch`.

--- a/source/commands/utils/chainsmoker.ts
+++ b/source/commands/utils/chainsmoker.ts
@@ -7,15 +7,14 @@ import mapValues from "lodash.mapvalues"
 
 export type Pattern = string
 export type Path = string
-export type KeyedPatterns<T> = { [K in Extract<keyof T, string>]: Pattern[] }
-export type KeyedPaths<T> = { [K in Extract<keyof T, string>]: Path[] }
-export type MatchResult<T> = { [K in Extract<keyof T, string>]: boolean }
-
-export interface Chainsmoker<T> {
-  (...patterns: Pattern[]): MatchResult<T>
-  debug(...patterns: Pattern[]): MatchResult<T>
-  tap(callback: (keyedPaths: KeyedPaths<T>) => void): (...patterns: Pattern[]) => MatchResult<T>
+export type KeyedPatterns<T> = { readonly [K in keyof T]: Pattern[] }
+export type KeyedPaths<T> = { readonly [K in keyof T]: Path[] }
+export type _MatchResult<T> = { readonly [K in keyof T]: boolean }
+export type MatchResult<T> = _MatchResult<T> & {
+  /** Returns an object containing arrays of matched files instead of the usual boolean values. */
+  getKeyedPaths(): KeyedPaths<T>
 }
+export type Chainsmoker<T> = (...patterns: Pattern[]) => MatchResult<T>
 
 const isExclude = (p: Pattern) => p.startsWith("!")
 
@@ -35,24 +34,11 @@ export default function chainsmoker<T>(keyedPaths: KeyedPaths<T>): Chainsmoker<T
   }
 
   function finalize(keyedPaths: KeyedPaths<T>): MatchResult<T> {
-    return mapValues(keyedPaths, (paths: Path[]) => paths.length > 0) as MatchResult<T>
+    return {
+      ...mapValues(keyedPaths, (paths: Path[]) => paths.length > 0),
+      getKeyedPaths: () => keyedPaths,
+    } as MatchResult<T>
   }
 
-  const fileMatch = ((...patterns) => finalize(matchPatterns(patterns))) as Chainsmoker<T>
-
-  /** Logs an object containing matched files before returning the usual boolean values. */
-  fileMatch.debug = (...patterns) => {
-    const results = matchPatterns(patterns)
-    console.log(JSON.stringify(results, undefined, 2))
-    return finalize(results)
-  }
-
-  /** Invoke the callback with an object containing matched files before returning the usual boolean values. */
-  fileMatch.tap = callback => (...patterns) => {
-    const results = matchPatterns(patterns)
-    callback(results)
-    return finalize(results)
-  }
-
-  return fileMatch
+  return (...patterns) => finalize(matchPatterns(patterns))
 }


### PR DESCRIPTION
This adds a function that provides an object containing arrays of matched paths. I made this a function instead of a property because `getKeyedPaths()` will stand out more in the dangerfile and be easier to search for. The name will also make clear, that this isn't an array of paths, rather an object containing arrays of paths.

Technically a breaking change, though `tap()` and `debug()` had only existed for a day. 🤷‍♂️ 

Ref https://github.com/danger/danger-js/pull/850#issuecomment-480536193