### PR TITLE
Update ts-jest to 24.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 <!-- Your comment below this -->
 
+- Update ts-jest to 24.0.2 - [@friederbluemle]
 - Adds a fix for the default name of Danger in status - [@orta]
 
 # 7.1.0

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "prettier": "^1.14.2",
     "release-it": "^7.6.1",
     "shx": "^0.3.2",
-    "ts-jest": "^23.10.5",
+    "ts-jest": "^24.0.2",
     "ts-node": "^8.0.2",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8685,10 +8685,10 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-ts-jest@^23.10.5:
-  version "23.10.5"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-23.10.5.tgz#cdb550df4466a30489bf70ba867615799f388dd5"
-  integrity sha512-MRCs9qnGoyKgFc8adDEntAOP64fWK1vZKnOYU1o2HxaqjdJvGqmkLCPCnVq1/If4zkUmEjKPnCiUisTrlX2p2A==
+ts-jest@^24.0.2:
+  version "24.0.2"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.0.2.tgz#8dde6cece97c31c03e80e474c749753ffd27194d"
+  integrity sha512-h6ZCZiA1EQgjczxq+uGLXQlNgeg02WWJBbeT8j6nyIBRQdglqbvzDoHahTEIiS6Eor6x8mK6PfZ7brQ9Q6tzHw==
   dependencies:
     bs-logger "0.x"
     buffer-from "1.x"


### PR DESCRIPTION
This updates `ts-jest` to `24.0.2`, fixing several warnings.

#### During `yarn install` phase

```
warning " > ts-jest@23.10.5" has incorrect peer dependency "jest@>=22 <24".
```

#### During `yarn test` phase

```
ts-jest[versions] (WARN) Version 24.0.0 of jest installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=22.0.0 <24.0.0). Please do not report issues in ts-jest if you are using unsupported versions.
```