### PR TITLE
Fix CHANGELOG.md documentation about "--failOnErrors"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,9 +71,8 @@
 
 # 7.0.18
 
-- Adds a CLI option `--fail-on-errors` so that you can force `danger ci` to return a failed exit code on any `fail`s in
+- Adds a CLI option `--failOnErrors` so that you can force `danger ci` to return a failed exit code on any `fail`s in
   a Dangerfile [@f-meloni]
-- Add a failOnErrors option to fail the build if there are error on the danger report [@f-meloni]
 
 # 7.0.17
 


### PR DESCRIPTION
Tiny fix, as currently the changelog is a bit confusing about what's the option to use.