### PR TITLE
Fix incorrect Codefresh repo slug for fork builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 <!-- Your comment below this -->
 
+- Fixes incorrect slug for builds from forks on Codefresh - [@stevenp]
+
 # 8.0.0
 
 - Adds GitLab & GitLab CI support - [@notjosh], [@bigkraig], [@jamime]

--- a/source/ci_source/providers/Codefresh.ts
+++ b/source/ci_source/providers/Codefresh.ts
@@ -58,9 +58,13 @@ export class Codefresh implements CISource {
   }
 
   get repoSlug(): string {
-    const owner = this.env.CF_REPO_OWNER
-    const reponame = this.env.CF_REPO_NAME
-    return owner && reponame ? `${owner}/${reponame}` : ""
+    const splitSlug = this.env.CF_COMMIT_URL.split("/")
+    if (splitSlug.length === 7) {
+      const owner = splitSlug[3]
+      const reponame = splitSlug[4]
+      return owner && reponame ? `${owner}/${reponame}` : ""
+    }
+    return ""
   }
 
   get ciRunURL() {

--- a/source/ci_source/providers/_tests/_codefresh.test.ts
+++ b/source/ci_source/providers/_tests/_codefresh.test.ts
@@ -2,8 +2,7 @@ import { Codefresh } from "../Codefresh"
 import { getCISourceForEnv } from "../../get_ci_source"
 
 const correctEnv = {
-  CF_REPO_OWNER: "codefresh",
-  CF_REPO_NAME: "someproject",
+  CF_COMMIT_URL: "https://github.com/codefresh/someproject/commit/123456",
   CF_BUILD_ID: "1501",
   CF_PULL_REQUEST_NUMBER: "800",
   CF_BUILD_URL: "https://g.codefresh.io/build/1234",
@@ -39,11 +38,10 @@ describe(".isPR", () => {
     expect(codefresh.isPR).toBeFalsy()
   })
 
-  const envs = ["CF_REPO_OWNER", "CF_REPO_NAME", "CF_BUILD_ID", "CF_PULL_REQUEST_NUMBER", "CF_BUILD_URL"]
+  const envs = ["CF_COMMIT_URL", "CF_BUILD_ID", "CF_PULL_REQUEST_NUMBER", "CF_BUILD_URL"]
   envs.forEach((key: string) => {
     let env = {
-      CF_REPO_OWNER: "codefresh",
-      CF_REPO_NAME: "someproject",
+      CF_COMMIT_URL: "https://github.com/codefresh/someproject/commit/123456",
       CF_BUILD_ID: "1501",
       CF_PULL_REQUEST_NUMBER: "800",
       CF_BUILD_URL: "https://g.codefresh.io/build/1234",


### PR DESCRIPTION
The repo slug for Codefresh was being calculated using the `CF_REPO_OWNER` environment variable, but in builds for forks, the owner is the owner of the fork, not the owner of the main repo. As a result, the API calls were pointing to the wrong URL and failing.

This change users the `CF_COMMIT_URL` variable instead, which contains the correct slug information.