### PR TITLE
Add GitLab missing states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 <!-- Your comment below this -->
 
+- Add GitLab missing states - [@f-meloni]
 - Fixes incorrect slug for builds from forks on Codefresh - [@stevenp]
 
 # 8.0.0

--- a/source/dsl/GitLabDSL.ts
+++ b/source/dsl/GitLabDSL.ts
@@ -22,7 +22,7 @@ export interface GitLabUser {
   id: number
   name: string
   username: string
-  state: "active" // XXX: other states?
+  state: "active" | "blocked"
   avatar_url: string | null
   web_url: string
 }
@@ -97,7 +97,7 @@ export interface GitLabMRBase {
     project_id: number
     title: string
     description: string
-    state: "closed" // XXX: other states?
+    state: "closed" | "active"
     created_at: string
     updated_at: string
     due_date: string
@@ -139,7 +139,7 @@ export interface GitLabMR extends GitLabMRBase {
     id: number
     sha: string
     ref: string
-    status: "success" // XXX: other statuses?
+    status: "canceled" | "failed" | "pending" | "running" | "skipped" | "success"
     web_url: string
   }
   diff_refs: {


### PR DESCRIPTION
When I was implementing the swift GitLab support I had to look at the docs to get all the possible states, in order to avoid decode failures.
I then thought that would have been nice to update danger-js with the correct states too.