### PR TITLE
Don't automatically download gitlab minors

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "commander": "^2.18.0",
     "debug": "^4.1.1",
     "get-stdin": "^6.0.0",
-    "gitlab": "^6.0.0",
+    "gitlab": "~6.0.0",
     "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.1",
     "hyperlinker": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4067,7 +4067,7 @@ gitconfiglocal@^1.0.0:
   dependencies:
     ini "^1.3.2"
 
-gitlab@^6.0.0:
+gitlab@~6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/gitlab/-/gitlab-6.0.0.tgz#7bd44bf57dcb6b1231c70a52ea9b83934e6c1539"
   integrity sha512-/0KE/Un0Hg/CDTtiYfC1Z4lkuHhkSmC3JjkKy4VsCgTb51rTtOfk7NGspyM+wTIgEPd6cE061Pu5m4a5ao01Ow==


### PR DESCRIPTION
Should fix https://github.com/danger/danger-js/issues/884
Not sure if we want to keep it also after they fix the issue, and update gitlab manually.
That would at least avoid that an issue like the one we have happens again