### PR TITLE
Retry API requests in fetch.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 <!-- Your comment below this -->
 
+- Add retry handling for API requests - [@jtreanor]
+
 # 9.1.1
 
 - Fixes TS declarations - [@orta]

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@babel/plugin-transform-typescript": "7.1.0",
     "@babel/preset-env": "7.1.0",
     "@babel/traverse": "7.1.0",
+    "@types/async-retry": "^1.4.1",
     "@types/debug": "0.0.30",
     "@types/get-stdin": "^5.0.1",
     "@types/http-proxy-agent": "^2.0.1",
@@ -136,6 +137,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
     "@octokit/rest": "^16.14.1",
+    "async-retry": "1.2.3",
     "chalk": "^2.3.0",
     "commander": "^2.18.0",
     "debug": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -816,6 +816,13 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
+"@types/async-retry@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@types/async-retry/-/async-retry-1.4.1.tgz#3b136a707b7a850f4947a727eb0f7b473b601992"
+  integrity sha512-hDI5Ttk9SUmDLcD/Yl2VuWQRGYZjJ7aaJFeRlomUOz/iTKSE7yA55SwY87QwjiZgwhMlVAKoT1rl08UyQoheag==
+  dependencies:
+    "@types/retry" "*"
+
 "@types/braces@*":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@types/braces/-/braces-2.3.0.tgz#d00ec0a76562b2acb6f29330be33a093e33ed25c"
@@ -967,6 +974,11 @@
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/@types/readline-sync/-/readline-sync-1.4.3.tgz#eac55a39d5a349912062c9e5216cd550c07fd9c8"
   integrity sha512-YP9NVli96E+qQLAF2db+VjnAUEeZcFVg4YnMgr8kpDUFwQBnj31rPLOVHmazbKQhaIkJ9cMHsZhpKdzUeL0KTg==
+
+"@types/retry@*":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
+  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
 "@types/shelljs@0.7.0":
   version "0.7.0"


### PR DESCRIPTION
This adds retry handling to the api wrapper in `fetch.ts`. It means that 5xx errors and 401 errors will be retried with backoff up to 3 times. As well as providing some resilience to API issues, once integrated into Peril it will allow https://github.com/danger/peril/issues/440 to be fixed.

@orta Would you prefer the retry logic to live in `GithubAPI.ts` so that it only applies to Github?