### PR TITLE
Use new env variable to replace old

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 <!-- Your comment below this -->
 
+- Use new env `BITBUCKET_REPO_FULL_NAME` in bitbucket pipeline. - [@Soyn]
+
 # 9.1.3
 
 - Updates GitLab API to 10.x - [@awgeorge]

--- a/source/ci_source/providers/BitbucketPipelines.ts
+++ b/source/ci_source/providers/BitbucketPipelines.ts
@@ -54,7 +54,7 @@ export class BitbucketPipelines implements CISource {
   }
 
   get repoSlug(): string {
-    return `${this.env.BITBUCKET_REPO_OWNER}/${this.env.BITBUCKET_REPO_SLUG}`
+    return `${this.env.BITBUCKET_REPO_FULL_NAME}`
   }
 
   get repoURL(): string {

--- a/source/ci_source/providers/_tests/_bitbucketPipelines.test.ts
+++ b/source/ci_source/providers/_tests/_bitbucketPipelines.test.ts
@@ -11,6 +11,7 @@ const correctEnv = {
   BITBUCKET_BUILD_NUMBER: "5",
   BITBUCKET_PR_DESTINATION_COMMIT: "91c917d4389b82ec11a0d372b9e5754eb7727e4a",
   BITBUCKET_REPO_OWNER: "foo",
+  BITBUCKET_REPO_FULL_NAME: "foo/bar",
 }
 
 describe("being found when looking for CI", () => {


### PR DESCRIPTION
Bitbucket cloud already has the env variable we want. I have test this by my account.
More info in https://confluence.atlassian.com/bitbucket/variables-in-pipelines-794502608.html