### PR TITLE
Fix event.json path in new GitHub Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 
 <!-- Your comment below this -->
 
+# 9.1.8
+
+- Get GitHub Actions event file pathname from env variable - [@IljaDaderko]
+
 # 9.1.7
 
 - GitHub Actions docs update - [@orta]

--- a/source/ci_source/providers/GitHubActions.ts
+++ b/source/ci_source/providers/GitHubActions.ts
@@ -138,7 +138,8 @@ export class GitHubActions implements CISource {
 
   constructor(private readonly env: Env) {
     if (existsSync("/github/workflow/event.json")) {
-      const event = readFileSync("/github/workflow/event.json", "utf8")
+      const eventFilePath = process.env.GITHUB_EVENT_PATH || "/github/workflow/event.json"
+      const event = readFileSync(eventFilePath, "utf8")
       this.event = JSON.parse(event)
     }
   }

--- a/source/ci_source/providers/GitHubActions.ts
+++ b/source/ci_source/providers/GitHubActions.ts
@@ -133,12 +133,13 @@ import { readFileSync, existsSync } from "fs"
  *
  */
 
-const eventFilePath = process.env.GITHUB_EVENT_PATH || "/github/workflow/event.json"
-
 export class GitHubActions implements CISource {
   private event: any
 
   constructor(private readonly env: Env) {
+    const { GITHUB_EVENT_PATH } = env
+    const eventFilePath = GITHUB_EVENT_PATH || "/github/workflow/event.json"
+    
     if (existsSync(eventFilePath)) {
       const event = readFileSync(eventFilePath, "utf8")
       this.event = JSON.parse(event)

--- a/source/ci_source/providers/GitHubActions.ts
+++ b/source/ci_source/providers/GitHubActions.ts
@@ -133,12 +133,13 @@ import { readFileSync, existsSync } from "fs"
  *
  */
 
+const eventFilePath = process.env.GITHUB_EVENT_PATH || "/github/workflow/event.json"
+
 export class GitHubActions implements CISource {
   private event: any
 
   constructor(private readonly env: Env) {
-    if (existsSync("/github/workflow/event.json")) {
-      const eventFilePath = process.env.GITHUB_EVENT_PATH || "/github/workflow/event.json"
+    if (existsSync(eventFilePath)) {
       const event = readFileSync(eventFilePath, "utf8")
       this.event = JSON.parse(event)
     }


### PR DESCRIPTION
When using danger through `node_modules` during new actions run i.e `run: yarn danger ci` as opposed to `uses: danger/danger-js` path to `event.json` file is different. Path to this file exists on `GITHUB_EVENT_PATH` env variable.

Further discussion happened here: https://spectrum.chat/danger/general/does-danger-support-new-github-actions~e19e146a-c155-4e29-9b2b-d2ad9c3da3f0