### PR TITLE
remove 'Dangerfile.ts' and 'Dangerfile.js'

### DIFF
--- a/source/commands/utils/fileUtils.ts
+++ b/source/commands/utils/fileUtils.ts
@@ -19,13 +19,5 @@ export function dangerfilePath(program: any): string {
     return "dangerfile.js"
   }
 
-  if (existsSync("Dangerfile.ts")) {
-    return "Dangerfile.ts"
-  }
-
-  if (existsSync("Dangerfile.js")) {
-    return "Dangerfile.js"
-  }
-
   throw new Error("Could not find a `dangerfile.js` or `dangerfile.ts` in the current working directory.")
 }


### PR DESCRIPTION
I do not think the dangerfile named with uppercase is used by user. Cause the error message we hint is all by lower case if user passed with wrong options.