### PR TITLE
Fix Buddy.works isPR because PR ids are not always ints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 <!-- Your comment below this -->
 
-- Fix Buddy.works isPR because PR ids are not always ints - [@mmiszy]
+- Fix Buddy.works isPR and use PR number instead of PR ID - [@mmiszy]
 
 <!-- Your comment above this -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 <!-- Your comment below this -->
 
+- Fix Buddy.works isPR because PR ids are not always ints - [@mmiszy]
+
 <!-- Your comment above this -->
 
 # 9.2.0

--- a/source/ci_source/providers/BuddyWorks.ts
+++ b/source/ci_source/providers/BuddyWorks.ts
@@ -1,5 +1,5 @@
 import { Env, CISource } from "../ci_source"
-import { ensureEnvKeysExist } from "../ci_source_helpers"
+import { ensureEnvKeysExist, ensureEnvKeysAreInt } from "../ci_source_helpers"
 /**
  * ### CI Setup
  *
@@ -26,12 +26,14 @@ export class BuddyWorks implements CISource {
   }
 
   get isPR(): boolean {
-    const mustHave = ["BUDDY_PIPELINE_ID", "BUDDY_EXECUTION_PULL_REQUEST_ID", "BUDDY_REPO_SLUG"]
-    return ensureEnvKeysExist(this.env, mustHave)
+    const mustHave = ["BUDDY_PIPELINE_ID", "BUDDY_EXECUTION_PULL_REQUEST_NO", "BUDDY_REPO_SLUG"]
+    const mustBeInts = ["BUDDY_EXECUTION_PULL_REQUEST_NO"]
+
+    return ensureEnvKeysExist(this.env, mustHave) && ensureEnvKeysAreInt(this.env, mustBeInts)
   }
 
   get pullRequestID(): string {
-    return this.env.BUDDY_EXECUTION_PULL_REQUEST_ID
+    return this.env.BUDDY_EXECUTION_PULL_REQUEST_NO
   }
 
   get repoSlug(): string {

--- a/source/ci_source/providers/BuddyWorks.ts
+++ b/source/ci_source/providers/BuddyWorks.ts
@@ -1,5 +1,5 @@
 import { Env, CISource } from "../ci_source"
-import { ensureEnvKeysExist, ensureEnvKeysAreInt } from "../ci_source_helpers"
+import { ensureEnvKeysExist } from "../ci_source_helpers"
 /**
  * ### CI Setup
  *
@@ -27,8 +27,7 @@ export class BuddyWorks implements CISource {
 
   get isPR(): boolean {
     const mustHave = ["BUDDY_PIPELINE_ID", "BUDDY_EXECUTION_PULL_REQUEST_ID", "BUDDY_REPO_SLUG"]
-    const mustBeInts = ["BUDDY_EXECUTION_PULL_REQUEST_ID"]
-    return ensureEnvKeysExist(this.env, mustHave) && ensureEnvKeysAreInt(this.env, mustBeInts)
+    return ensureEnvKeysExist(this.env, mustHave)
   }
 
   get pullRequestID(): string {

--- a/source/ci_source/providers/_tests/_buddyWorks.test.ts
+++ b/source/ci_source/providers/_tests/_buddyWorks.test.ts
@@ -3,7 +3,7 @@ import { getCISourceForEnv } from "../../get_ci_source"
 
 const correctEnv = {
   BUDDY_PIPELINE_ID: "170873",
-  BUDDY_EXECUTION_PULL_REQUEST_ID: "1799",
+  BUDDY_EXECUTION_PULL_REQUEST_ID: "pull/1799",
   BUDDY_REPO_SLUG: "danger/dangerjs",
   BUDDY_EXECUTION_URL:
     "https://app.buddy.works/danger/dangerjs/pipelines/pipeline/170873/execution/5d6d49dbaab2cb6fdf975c71",
@@ -50,7 +50,7 @@ describe(".isPR", () => {
     })
   })
 
-  it("needs to have a PR number", () => {
+  it("needs to have a PR id", () => {
     const env = Object.assign({}, correctEnv)
     delete env.BUDDY_EXECUTION_PULL_REQUEST_ID
     const buddyWorks = new BuddyWorks(env)
@@ -61,7 +61,7 @@ describe(".isPR", () => {
 describe(".pullRequestID", () => {
   it("pulls it out of the env", () => {
     const buddyWorks = new BuddyWorks(correctEnv)
-    expect(buddyWorks.pullRequestID).toEqual("1799")
+    expect(buddyWorks.pullRequestID).toEqual("pull/1799")
   })
 })
 

--- a/source/ci_source/providers/_tests/_buddyWorks.test.ts
+++ b/source/ci_source/providers/_tests/_buddyWorks.test.ts
@@ -3,7 +3,7 @@ import { getCISourceForEnv } from "../../get_ci_source"
 
 const correctEnv = {
   BUDDY_PIPELINE_ID: "170873",
-  BUDDY_EXECUTION_PULL_REQUEST_ID: "pull/1799",
+  BUDDY_EXECUTION_PULL_REQUEST_NO: "1799",
   BUDDY_REPO_SLUG: "danger/dangerjs",
   BUDDY_EXECUTION_URL:
     "https://app.buddy.works/danger/dangerjs/pipelines/pipeline/170873/execution/5d6d49dbaab2cb6fdf975c71",
@@ -39,7 +39,7 @@ describe(".isPR", () => {
     expect(buddyWorks.isPR).toBeFalsy()
   })
 
-  const envs = ["BUDDY_EXECUTION_PULL_REQUEST_ID", "BUDDY_REPO_SLUG"]
+  const envs = ["BUDDY_EXECUTION_PULL_REQUEST_NO", "BUDDY_REPO_SLUG"]
   envs.forEach((key: string) => {
     const env = Object.assign({}, correctEnv)
     env[key] = null
@@ -50,9 +50,9 @@ describe(".isPR", () => {
     })
   })
 
-  it("needs to have a PR id", () => {
+  it("needs to have a PR number", () => {
     const env = Object.assign({}, correctEnv)
-    delete env.BUDDY_EXECUTION_PULL_REQUEST_ID
+    delete env.BUDDY_EXECUTION_PULL_REQUEST_NO
     const buddyWorks = new BuddyWorks(env)
     expect(buddyWorks.isPR).toBeFalsy()
   })
@@ -61,7 +61,7 @@ describe(".isPR", () => {
 describe(".pullRequestID", () => {
   it("pulls it out of the env", () => {
     const buddyWorks = new BuddyWorks(correctEnv)
-    expect(buddyWorks.pullRequestID).toEqual("pull/1799")
+    expect(buddyWorks.pullRequestID).toEqual("1799")
   })
 })
 


### PR DESCRIPTION
I was testing Buddy.works CI and it seems the integration with Danger doesn't work. I figured it's because of an incorrect assumption that PR ids are always integers. In my case, in a public GitHub repository, PR id is eg. `pull/42`.

I tested this and it works fine now 👍 

Pinging @kristof0425 because he implemented the integration.