### PR TITLE
Fix Bitbucket Server binary files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 
 <!-- Your comment below this -->
 
-<!-- Your comment above this -->
+- Fix binary files for BitBucket Server - [@osmestad]
+  <!-- Your comment above this -->
 
 # 9.2.1
 

--- a/source/platforms/git/gitJSONToGitDSL.ts
+++ b/source/platforms/git/gitJSONToGitDSL.ts
@@ -197,7 +197,7 @@ export const gitJSONToGitDSL = (gitJSONRep: GitJSONDSL, config: GitJSONToGitDSLC
       fileDiffs = parseDiff(diff)
     }
     const structuredDiff = fileDiffs.find(diff => diff.from === filename || diff.to === filename)
-    if (structuredDiff !== undefined) {
+    if (structuredDiff !== undefined && structuredDiff.chunks !== undefined) {
       return { chunks: structuredDiff.chunks }
     } else {
       return null


### PR DESCRIPTION
Thanks for getting my previous fix in! When testing `9.2.1` I noticed PRs with binary files failing, this should fix that:

When getting diffs for binary files with BitBucket Server, Danger fails when trying to map over chunks.
This fix avoids setting the `chunks` property in `structuredDiffForFile` if it is `undefined`.

Not sure if this is the correct location to fix it?
(for me it fails at: `const allLines = structuredDiff.chunks.map...` so I think this should make the code safer at least, and it fixes the issue for me.)