### PR TITLE
Azure DevOps support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,17 @@ yarn test
 yarn lint
 ```
 
-The fixers for both tslint and prettier will be applied when you commit, and on a push your code will be verified
-that it compiles.
+The fixers for both tslint and prettier will be applied when you commit, and on a push your code will be verified that
+it compiles.
+
+You can see how your changes quickly affect the project you're running by the following.
+
+```sh
+cd ./forked-danger-js-repo
+yarn build
+cd ../local-repo
+yarn add file:./../forked-danger-js-repo -D
+```
 
 ### How does Danger JS work?
 
@@ -34,21 +43,28 @@ Check the issues, I try and keep my short term perspective there. Long term is i
 
 Following [this commit](https://github.com/danger/danger-js/commit/a26ac3b3bd4f002acd37f6a363c8e74c9d5039ab) as a model:
 
-* Checkout the `master` branch. Ensure your working tree is clean, and make sure you have the latest changes by running `git pull`.
-* Update `package.json` with the new version - for the sake of this example, the new version is **0.21.0**.
-* Modify `changelog.md`, adding a new `### 0.21.0` heading under the `### Master` heading at the top of the file.
-* Commit both changes with the commit message **Version bump**.
-* Tag this commit - `git tag 0.21.0`.
-* Push the commit and tag to master - `git push origin master --follow-tags`. Travis CI will build the tagged commit and publish that tagged version to NPM.
+- Checkout the `master` branch. Ensure your working tree is clean, and make sure you have the latest changes by running
+  `git pull`.
+- Update `package.json` with the new version - for the sake of this example, the new version is **0.21.0**.
+- Modify `changelog.md`, adding a new `### 0.21.0` heading under the `### Master` heading at the top of the file.
+- Commit both changes with the commit message **Version bump**.
+- Tag this commit - `git tag 0.21.0`.
+- Push the commit and tag to master - `git push origin master --follow-tags`. Travis CI will build the tagged commit and
+  publish that tagged version to NPM.
 
 :ship:
 
 ## License, Contributor's Guidelines and Code of Conduct
 
-We try to keep as much discussion as possible in GitHub issues, but also have a pretty inactive Slack --- if you'd like an invite, ping [@Orta](https://twitter.com/orta/) a DM on Twitter with your email. It's mostly interesting if you want to stay on top of Danger without all the emails from GitHub.
+We try to keep as much discussion as possible in GitHub issues, but also have a pretty inactive Slack --- if you'd like
+an invite, ping [@Orta](https://twitter.com/orta/) a DM on Twitter with your email. It's mostly interesting if you want
+to stay on top of Danger without all the emails from GitHub.
 
-> This project is open source under the MIT license, which means you have full access to the source code and can modify it to fit your own needs.
+> This project is open source under the MIT license, which means you have full access to the source code and can modify
+> it to fit your own needs.
 >
-> This project subscribes to the [Moya Contributors Guidelines](https://github.com/Moya/contributors) which TLDR: means we give out push access easily and often.
+> This project subscribes to the [Moya Contributors Guidelines](https://github.com/Moya/contributors) which TLDR: means
+> we give out push access easily and often.
 >
-> Contributors subscribe to the [Contributor Code of Conduct](http://contributor-covenant.org/version/1/3/0/) based on the [Contributor Covenant](http://contributor-covenant.org) version 1.3.0.
+> Contributors subscribe to the [Contributor Code of Conduct](http://contributor-covenant.org/version/1/3/0/) based on
+> the [Contributor Covenant](http://contributor-covenant.org) version 1.3.0.

--- a/source/ci_source/providers/AzureDevops.ts
+++ b/source/ci_source/providers/AzureDevops.ts
@@ -1,0 +1,36 @@
+import { Env, CISource } from "../ci_source"
+import { ensureEnvKeysExist, ensureEnvKeysAreInt } from "../ci_source_helpers"
+
+export class AzureDevops implements CISource {
+  constructor(private readonly env: Env) {}
+  get name(): string {
+    return "AzureDevops"
+  }
+
+  get isCI(): boolean {
+    return true
+  }
+  get isPR(): boolean {
+    if (ensureEnvKeysExist(this.env, ["CI_PULL_REQUEST"]) || ensureEnvKeysExist(this.env, ["CIRCLE_PULL_REQUEST"])) {
+      return true
+    }
+
+    const mustHave = ["CIRCLE_CI_API_TOKEN", "CIRCLE_PROJECT_USERNAME", "CIRCLE_PROJECT_REPONAME", "CIRCLE_BUILD_NUM"]
+    return ensureEnvKeysExist(this.env, mustHave) && ensureEnvKeysAreInt(this.env, ["CIRCLE_PR_NUMBER"])
+  }
+  get repoSlug(): string {
+    return ""
+  }
+  get pullRequestID(): string {
+    return this.env.BITRISE_PULL_REQUEST
+  }
+  get commitHash(): string {
+    return this.env.BITRISE_GIT_COMMIT
+  }
+  get ciRunURL(): string {
+    return this.env.BITRISE_PULL_REQUEST
+  }
+  get useEventDSL(): boolean {
+    return this.env.GITHUB_EVENT_NAME !== "pull_request"
+  }
+}

--- a/source/commands/danger-init.ts
+++ b/source/commands/danger-init.ts
@@ -34,8 +34,6 @@ const go = async (app: App) => {
   const state = generateInitialState(process)
   const ui: InitUI = createUI(state, app)
 
-  ui.say("Repo slug " + state.repoSlug)
-
   if (!state.isGitHub) {
     return showNonGitHubWarning(ui)
   }

--- a/source/commands/danger-init.ts
+++ b/source/commands/danger-init.ts
@@ -6,7 +6,7 @@ import program from "commander"
 import * as fs from "fs"
 
 import { generateDefaultDangerfile } from "./init/default-dangerfile"
-import { travis, circle, unsure } from "./init/add-to-ci"
+import { travis, circle, azureDevops, unsure } from "./init/add-to-ci"
 import { generateInitialState, createUI } from "./init/state-setup"
 import { InitUI, InitState, highlight } from "./init/interfaces"
 
@@ -33,6 +33,8 @@ const app: App = program as any
 const go = async (app: App) => {
   const state = generateInitialState(process)
   const ui: InitUI = createUI(state, app)
+
+  ui.say("Repo slug " + state.repoSlug)
 
   if (!state.isGitHub) {
     return showNonGitHubWarning(ui)
@@ -229,6 +231,8 @@ const addToCI = async (ui: InitUI, state: InitState) => {
     await travis(ui, state)
   } else if (state.ciType === "circle") {
     await circle(ui, state)
+  } else if (state.ciType === "azureDevops") {
+    await azureDevops(ui)
   } else {
     await unsure(ui, state)
   }

--- a/source/commands/danger-init.ts
+++ b/source/commands/danger-init.ts
@@ -34,7 +34,7 @@ const go = async (app: App) => {
   const state = generateInitialState(process)
   const ui: InitUI = createUI(state, app)
 
-  if (!state.isGitHub) {
+  if (state.repoType != "github") {
     return showNonGitHubWarning(ui)
   }
 
@@ -50,7 +50,7 @@ const go = async (app: App) => {
 }
 
 const showNonGitHubWarning = (ui: InitUI) => {
-  ui.say("Hi, welcome to Danger Init - I'm afraid at the moment this command only works for GitHub projects.")
+  ui.say("Hi, welcome to Danger Init - I'm afraid at the moment there is only limited support for non-GitHub projects.")
   ui.say("\nWe're definitely open to PRs improving this. You can find the code at:")
   const link = ui.link(
     "danger/danger-js#/source/commands/danger-init.ts",

--- a/source/commands/init/add-to-ci.ts
+++ b/source/commands/init/add-to-ci.ts
@@ -84,7 +84,11 @@ export const circle = async (ui: InitUI, state: InitState) => {
 
 export const azureDevops = async (ui: InitUI) => {
   // https://travis-ci.org/artsy/eigen/settings
-  ui.say("This is ground-level foundation.  This support is still not supported for Azure Devops")
+  ui.say("Currently your two options for Azure Devops (Formerly VSTS) support are the following.")
+  ui.say("1. Use AzureDevops as the CI provider (running danger). Use Github as the repo/PR provider.")
+  ui.say(highlight("This approach is far more feature complete."))
+  ui.say("2. Use AzureDevops as the CI provider (running danger). Use Azure Devops as the repo/PR provider.")
+  ui.say(highlight("This approach is incubating PRs are welcome!"))
 }
 
 export const unsure = async (ui: InitUI, _state: InitState) => {

--- a/source/commands/init/add-to-ci.ts
+++ b/source/commands/init/add-to-ci.ts
@@ -82,6 +82,11 @@ export const circle = async (ui: InitUI, state: InitState) => {
   ui.say("  ```")
 }
 
+export const azureDevops = async (ui: InitUI) => {
+  // https://travis-ci.org/artsy/eigen/settings
+  ui.say("This is ground-level foundation.  This support is still not supported for Azure Devops")
+}
+
 export const unsure = async (ui: InitUI, _state: InitState) => {
   ui.say(
     "You need to expose a token called " +

--- a/source/commands/init/common-setup.ts
+++ b/source/commands/init/common-setup.ts
@@ -1,0 +1,9 @@
+import { InitUI, InitState } from "./interfaces"
+import chalk from "chalk"
+
+export const noteAboutClickingLinks = (ui: InitUI, state: InitState) => {
+  const modifier_key = state.isMac ? "cmd ( ⌘ )" : "ctrl"
+  const clicks = state.isWindows || state.supportsHLinks ? "clicking" : "double clicking"
+  const sidenote = chalk.italic.bold("Sidenote: ")
+  ui.say(`${sidenote} Holding ${modifier_key} and ${clicks} a link will open it in your browser.\n`)
+}

--- a/source/commands/init/get-repo-slug.ts
+++ b/source/commands/init/get-repo-slug.ts
@@ -11,3 +11,26 @@ export const getRepoSlug = () => {
   const ghData = possibleRemotes.map(r => parseGithubURL(r.url))
   return ghData.length ? ghData[0].repo : undefined
 }
+
+export const getRepoInfo = () => {
+  const config = parseGitConfig.sync()
+  const possibleRemotes = [config['remote "upstream"'], config['remote "origin"']].filter(f => f)
+  if (possibleRemotes.length === 0) {
+    return "unknown"
+  }
+
+  const repoData = possibleRemotes.map(r => inspectURL(r.url))
+  return repoData.length ? repoData[0] : "unknown"
+}
+
+const inspectURL = (url: string) => {
+  if (url.includes("github")) {
+    return "github"
+  } else if (url.includes("dev.azure.com") || url.includes(".visualstudio.com")) {
+    return "azureDevops"
+  } else if (url.includes("bitbucket.org")) {
+    return "bitbucket"
+  } else {
+    return "unknown"
+  }
+}

--- a/source/commands/init/interfaces.ts
+++ b/source/commands/init/interfaces.ts
@@ -17,6 +17,7 @@ export interface InitState {
   hasSetUpAccountToken: boolean
 
   repoSlug: string | null
+  repoType: "github" | "azureDevops" | unknown
   ciType: "travis" | "circle" | "azureDevops" | "unknown"
   isGitHub: boolean
 }

--- a/source/commands/init/interfaces.ts
+++ b/source/commands/init/interfaces.ts
@@ -17,7 +17,7 @@ export interface InitState {
   hasSetUpAccountToken: boolean
 
   repoSlug: string | null
-  ciType: "travis" | "circle" | "unknown"
+  ciType: "travis" | "circle" | "azureDevops" | "unknown"
   isGitHub: boolean
 }
 

--- a/source/commands/init/interfaces.ts
+++ b/source/commands/init/interfaces.ts
@@ -17,9 +17,8 @@ export interface InitState {
   hasSetUpAccountToken: boolean
 
   repoSlug: string | null
-  repoType: "github" | "azureDevops" | unknown
+  repoType: "github" | "azureDevops" | "bitbucket" | "unknown"
   ciType: "travis" | "circle" | "azureDevops" | "unknown"
-  isGitHub: boolean
 }
 
 export interface InitUI {

--- a/source/commands/init/setup-bot-account.ts
+++ b/source/commands/init/setup-bot-account.ts
@@ -1,0 +1,77 @@
+import { InitUI, InitState, highlight } from "./interfaces"
+import { noteAboutClickingLinks } from "./common-setup"
+
+export const setupUnknownRepoProvider = async (ui: InitUI) => {
+  ui.say("In order to get the most out of Danger, I'd recommend giving it the ability to post in")
+  ui.say("the code-review comment section.")
+
+  ui.say("Unfortunately we are unable to tell what type of repo provider this is.")
+}
+
+export const setupAzureDevopsAccount = async (ui: InitUI, state: InitState) => {
+  ui.header("Step 2: Give Azure Devops to update")
+
+  ui.say("In order to get the most out of Danger, I'd recommend giving it the ability to post in")
+  ui.say("the code-review comment section.")
+  ui.say("Unfortunately, these types of users required directly go into your pricing.")
+  ui.say(
+    "\n" +
+      ui.link(
+        "Azure Devops Services pricing",
+        "https://azure.microsoft.com/en-us/pricing/details/devops/azure-devops-services/"
+      ) +
+      "\n"
+  )
+
+  await ui.pause(1)
+
+  noteAboutClickingLinks(ui, state)
+  await ui.pause(1)
+
+  ui.say("Here are your current options to accomodate these pricing constraints")
+  ui.say("1. (pricing friendly) Use an existing user with a provisioned PAT token to post in PRs")
+  ui.say("2. (ideal) Create a new basic user with a provisioned PAT token o post in PRs")
+  ui.say("3. Use OAuth access via Azure Devops to handle PRs")
+  ui.say("Regardless you need to setup a PAT token")
+}
+
+export const setupGithubAccount = async (ui: InitUI, state: InitState) => {
+  ui.header("Step 2: Creating a GitHub account")
+
+  ui.say("In order to get the most out of Danger, I'd recommend giving it the ability to post in")
+  ui.say("the code-review comment section.")
+
+  ui.say("\n" + ui.link("GitHub Home", "https://github.com") + "\n")
+
+  await ui.pause(1)
+
+  ui.say(`IMO, it's best to do this by using the private mode of your browser.`)
+  ui.say(`Create an account like: ${highlight(state.botName)} and don't forget a cool robot avatar too.\n`)
+
+  await ui.pause(1)
+  ui.say("Here are great resources for creative-commons images of robots:\n")
+  const flickr = ui.link("flickr", "https://www.flickr.com/search/?text=robot&license=2%2C3%2C4%2C5%2C6%2C9")
+  const googImages = ui.link(
+    "googleimages",
+    "https://www.google.com/search?q=robot&tbs=sur:fmc&tbm=isch&tbo=u&source=univ&sa=X&ved=0ahUKEwjgy8-f95jLAhWI7hoKHV_UD00QsAQIMQ&biw=1265&bih=1359"
+  )
+  ui.say(" - " + flickr)
+  ui.say(" - " + googImages)
+  ui.say("")
+  await ui.pause(1)
+
+  noteAboutClickingLinks(ui, state)
+  await ui.pause(1)
+
+  if (state.isAnOSSRepo) {
+    ui.say(`${state.botName} does not need privileged access to your repo or org. This is because Danger will only`)
+    ui.say("be writing comments, and you do not need special access for that.")
+  } else {
+    ui.say(`${state.botName} will need access to your repo. Simply because the code is not available for the public`)
+    ui.say("to read and comment on.")
+  }
+
+  await ui.pause(1)
+  ui.say("\nCool, please press return when you have your account ready (and you've verified the email...)")
+  ui.waitForReturn()
+}

--- a/source/commands/init/state-setup.ts
+++ b/source/commands/init/state-setup.ts
@@ -43,7 +43,6 @@ export const generateInitialState = (osProcess: NodeJS.Process): InitState => {
   const ciType = hasTravis ? "travis" : hasCircle ? "circle" : hasAzureDevops ? "azureDevops" : "unknown"
   const repoSlug = getRepoSlug()
   const repoType = getRepoInfo()
-  const isGitHub = !!repoSlug
 
   return {
     isMac,
@@ -60,7 +59,6 @@ export const generateInitialState = (osProcess: NodeJS.Process): InitState => {
     repoSlug,
     repoType,
     ciType,
-    isGitHub,
   }
 }
 

--- a/source/commands/init/state-setup.ts
+++ b/source/commands/init/state-setup.ts
@@ -7,7 +7,7 @@ import { basename } from "path"
 import { setTimeout } from "timers"
 import * as fs from "fs"
 
-import { getRepoSlug } from "./get-repo-slug"
+import { getRepoSlug, getRepoInfo } from "./get-repo-slug"
 import { InitState, InitUI } from "./interfaces"
 
 export const createUI = (state: InitState, app: any): InitUI => {
@@ -42,6 +42,7 @@ export const generateInitialState = (osProcess: NodeJS.Process): InitState => {
   //TODO - conditional statement won't scale
   const ciType = hasTravis ? "travis" : hasCircle ? "circle" : hasAzureDevops ? "azureDevops" : "unknown"
   const repoSlug = getRepoSlug()
+  const repoType = getRepoInfo()
   const isGitHub = !!repoSlug
 
   return {
@@ -57,6 +58,7 @@ export const generateInitialState = (osProcess: NodeJS.Process): InitState => {
     hasCreatedDangerfile: false,
     hasSetUpAccountToken: false,
     repoSlug,
+    repoType,
     ciType,
     isGitHub,
   }

--- a/source/commands/init/state-setup.ts
+++ b/source/commands/init/state-setup.ts
@@ -38,7 +38,9 @@ export const generateInitialState = (osProcess: NodeJS.Process): InitState => {
   const isBabel = checkForBabel()
   const hasTravis = fs.existsSync(".travis.yml")
   const hasCircle = fs.existsSync("circle.yml")
-  const ciType = hasTravis ? "travis" : hasCircle ? "circle" : "unknown"
+  const hasAzureDevops = fs.existsSync("azure-pipelines.yml")
+  //TODO - conditional statement won't scale
+  const ciType = hasTravis ? "travis" : hasCircle ? "circle" : hasAzureDevops ? "azureDevops" : "unknown"
   const repoSlug = getRepoSlug()
   const isGitHub = !!repoSlug
 


### PR DESCRIPTION
Azure DevOps provides all capabilities for Danger in theory.
Has source repositories.
Has PR capabilities.
Has CI driving it.

Danger currently supports mostly things around github/bitbucket/circle/travis.  Need to generacize these capabilities to make it easier to add-in Azure Devops.

- [ ] Reposlug functionality is geared only to Azure Devops support
- [ ] CI Type is only for travis / circle. Unclear where this capability is required.
- [ ] PR process only for danger.