### PR TITLE
Move base to danger local

### DIFF
--- a/source/commands/danger-local.ts
+++ b/source/commands/danger-local.ts
@@ -20,7 +20,6 @@ program
   // .option("-s, --staging", "Just use staged changes.")
   .description("Runs danger without PR metadata, useful for git hooks.")
   .option("-b, --base [branch_name]", "Use a different base branch")
-  .option("-s, --staging", "Use a different base branch")
 setSharedArgs(program).parse(process.argv)
 
 const app = (program as any) as App

--- a/source/commands/danger-local.ts
+++ b/source/commands/danger-local.ts
@@ -19,6 +19,8 @@ program
   // TODO: this option
   // .option("-s, --staging", "Just use staged changes.")
   .description("Runs danger without PR metadata, useful for git hooks.")
+  .option("-b, --base [branch_name]", "Use a different base branch")
+  .option("-s, --staging", "Use a different base branch")
 setSharedArgs(program).parse(process.argv)
 
 const app = (program as any) as App

--- a/source/commands/danger-pr.ts
+++ b/source/commands/danger-pr.ts
@@ -67,7 +67,7 @@ const app = (program as any) as App
 const customProcess = !!app.process
 
 if (program.args.length === 0) {
-  console.error("")
+  console.error("Please include a PR URL to run against")
   process.exitCode = 1
 } else {
   const customHost =

--- a/source/commands/danger-pr.ts
+++ b/source/commands/danger-pr.ts
@@ -67,7 +67,7 @@ const app = (program as any) as App
 const customProcess = !!app.process
 
 if (program.args.length === 0) {
-  console.error("Please include a PR URL to run against")
+  console.error("")
   process.exitCode = 1
 } else {
   const customHost =

--- a/source/commands/utils/sharedDangerfileArgs.ts
+++ b/source/commands/utils/sharedDangerfileArgs.ts
@@ -38,7 +38,6 @@ export default (command: any) =>
       "Specify a custom dangerfile path, remote urls only work with github"
     )
     .option("-i, --id [danger_id]", "Specify a unique Danger ID for the Danger run")
-    .option("-b, --base [branch_name]", "Use a different base branch")
     .option("-c, --external-ci-provider [modulePath]", "Specify custom CI provider")
     .option("-p, --process [command]", "[dev] Runs a custom sub-process instead of the Danger JS runtime")
     .option("-u, --passURLForDSL", "[dev] Use a custom URL to send the Danger DSL into the sub-process")


### PR DESCRIPTION
I think the only one that uses base is `local`, the I've added the option only to `local` instead of having it in the shared args