### PR TITLE
Fix GitHub comments overflow with icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ## Master
 
 <!-- Your comment below this -->
-
+- Fix Github comment template that message can overlap with icon when viewed in email notification - [@wenhuanli]
   <!-- Your comment above this -->
 
 # 9.2.2

--- a/source/runner/templates/_tests/__snapshots__/_githubIssueTemplates.test.ts.snap
+++ b/source/runner/templates/_tests/__snapshots__/_githubIssueTemplates.test.ts.snap
@@ -37,7 +37,7 @@ exports[`generating inline messages Shows correct messages for inline/regular vi
 <table>
   <thead>
     <tr>
-      <th width=\\"50\\"></th>
+      <th width=\\"50\\" style=\\"min-width:50\\"></th>
       <th width=\\"100%\\" data-danger-table=\\"true\\">Warnings</th>
     </tr>
   </thead>
@@ -79,7 +79,7 @@ exports[`generating inline messages Shows correct messages with custom icon for 
 <table>
   <thead>
     <tr>
-      <th width=\\"50\\"></th>
+      <th width=\\"50\\" style=\\"min-width:50\\"></th>
       <th width=\\"100%\\" data-danger-table=\\"true\\">Messages</th>
     </tr>
   </thead>
@@ -115,7 +115,7 @@ exports[`generating messages Mixed icon messages match snapshot 1`] = `
 <table>
   <thead>
     <tr>
-      <th width=\\"50\\"></th>
+      <th width=\\"50\\" style=\\"min-width:50\\"></th>
       <th width=\\"100%\\" data-danger-table=\\"true\\">Messages</th>
     </tr>
   </thead>
@@ -158,7 +158,7 @@ exports[`generating messages avoids adding space inside the <td> for proper vert
 <table>
   <thead>
     <tr>
-      <th width=\\"50\\"></th>
+      <th width=\\"50\\" style=\\"min-width:50\\"></th>
       <th width=\\"100%\\" data-danger-table=\\"true\\">Messages</th>
     </tr>
   </thead>
@@ -189,7 +189,7 @@ exports[`generating messages leaves space between <td>s to allow GitHub to rende
 <table>
   <thead>
     <tr>
-      <th width=\\"50\\"></th>
+      <th width=\\"50\\" style=\\"min-width:50\\"></th>
       <th width=\\"100%\\" data-danger-table=\\"true\\">Fails</th>
     </tr>
   </thead>
@@ -207,7 +207,7 @@ exports[`generating messages leaves space between <td>s to allow GitHub to rende
 <table>
   <thead>
     <tr>
-      <th width=\\"50\\"></th>
+      <th width=\\"50\\" style=\\"min-width:50\\"></th>
       <th width=\\"100%\\" data-danger-table=\\"true\\">Warnings</th>
     </tr>
   </thead>
@@ -225,7 +225,7 @@ exports[`generating messages leaves space between <td>s to allow GitHub to rende
 <table>
   <thead>
     <tr>
-      <th width=\\"50\\"></th>
+      <th width=\\"50\\" style=\\"min-width:50\\"></th>
       <th width=\\"100%\\" data-danger-table=\\"true\\">Messages</th>
     </tr>
   </thead>
@@ -268,7 +268,7 @@ exports[`generating messages summary result matches snapshot, with a commit 1`] 
 <table>
   <thead>
     <tr>
-      <th width=\\"50\\"></th>
+      <th width=\\"50\\" style=\\"min-width:50\\"></th>
       <th width=\\"100%\\" data-danger-table=\\"true\\">Fails</th>
     </tr>
   </thead>
@@ -283,7 +283,7 @@ exports[`generating messages summary result matches snapshot, with a commit 1`] 
 <table>
   <thead>
     <tr>
-      <th width=\\"50\\"></th>
+      <th width=\\"50\\" style=\\"min-width:50\\"></th>
       <th width=\\"100%\\" data-danger-table=\\"true\\">Warnings</th>
     </tr>
   </thead>
@@ -298,7 +298,7 @@ exports[`generating messages summary result matches snapshot, with a commit 1`] 
 <table>
   <thead>
     <tr>
-      <th width=\\"50\\"></th>
+      <th width=\\"50\\" style=\\"min-width:50\\"></th>
       <th width=\\"100%\\" data-danger-table=\\"true\\">Messages</th>
     </tr>
   </thead>
@@ -329,7 +329,7 @@ exports[`generating messages summary result matches snapshot, without a commit 1
 <table>
   <thead>
     <tr>
-      <th width=\\"50\\"></th>
+      <th width=\\"50\\" style=\\"min-width:50\\"></th>
       <th width=\\"100%\\" data-danger-table=\\"true\\">Fails</th>
     </tr>
   </thead>
@@ -344,7 +344,7 @@ exports[`generating messages summary result matches snapshot, without a commit 1
 <table>
   <thead>
     <tr>
-      <th width=\\"50\\"></th>
+      <th width=\\"50\\" style=\\"min-width:50\\"></th>
       <th width=\\"100%\\" data-danger-table=\\"true\\">Warnings</th>
     </tr>
   </thead>
@@ -359,7 +359,7 @@ exports[`generating messages summary result matches snapshot, without a commit 1
 <table>
   <thead>
     <tr>
-      <th width=\\"50\\"></th>
+      <th width=\\"50\\" style=\\"min-width:50\\"></th>
       <th width=\\"100%\\" data-danger-table=\\"true\\">Messages</th>
     </tr>
   </thead>

--- a/source/runner/templates/githubIssueTemplate.ts
+++ b/source/runner/templates/githubIssueTemplate.ts
@@ -18,7 +18,7 @@ function table(name: string, defaultEmoji: string, violations: Violation[]): str
   <thead>
     <tr>
       <th width="50"></th>
-      <th width="100%" data-danger-table="true">${name}</th>
+      <th data-danger-table="true">${name}</th>
     </tr>
   </thead>
   <tbody>${violations.map(violation => htmlForValidation(defaultEmoji, violation)).join("\n")}</tbody>

--- a/source/runner/templates/githubIssueTemplate.ts
+++ b/source/runner/templates/githubIssueTemplate.ts
@@ -17,8 +17,8 @@ function table(name: string, defaultEmoji: string, violations: Violation[]): str
 <table>
   <thead>
     <tr>
-      <th width="50"></th>
-      <th data-danger-table="true">${name}</th>
+      <th width="50" style="min-width:50"></th>
+      <th width="100%" data-danger-table="true">${name}</th>
     </tr>
   </thead>
   <tbody>${violations.map(violation => htmlForValidation(defaultEmoji, violation)).join("\n")}</tbody>


### PR DESCRIPTION
In the GitHub comment template the icon has fixed with of 50 and message has width of 100% of parent. It is possible to make text really take 100% of parent width and overlaps with icon. This happens especially when GitHub comment is forwarded to email and viewed on mobile phones that lines need break. It will take 100% width before it breaks.

**Outdated:** By deleting width=100% browser will make it take up the rest of the space, which is more proper IMO.

**Update:** By giving the first column a min-width of 50 same as fixed width, this will prevent text overlaps with the icon.

You can see the screenshots before and after the change on a phone.

<img width="404" alt="Screenshot 2019-10-26 at 16 51 05" src="https://user-images.githubusercontent.com/26609244/67622295-fbd95400-f810-11e9-8d39-6eb4c926e6bf.png">
<img width="404" alt="Screenshot 2019-10-26 at 16 51 30" src="https://user-images.githubusercontent.com/26609244/67622297-00057180-f811-11e9-8e47-e366ae166af6.png">
