### PR TITLE
fix: use node 12 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-slim
+FROM node:12-slim
 
 MAINTAINER Orta Therox
 


### PR DESCRIPTION
12 is LTS: https://nodejs.org/en/blog/release/v12.13.0/

any chance of a prebuilt image btw? building the entire danger every time is pretty inefficient