### PR TITLE
Handle more events than just pull_request

### DIFF
--- a/source/ci_source/providers/GitHubActions.ts
+++ b/source/ci_source/providers/GitHubActions.ts
@@ -137,11 +137,13 @@ import { readFileSync, existsSync } from "fs"
 export class GitHubActions implements CISource {
   private event: any
 
-  constructor(private readonly env: Env) {
+  constructor(private readonly env: Env, event: any = undefined) {
     const { GITHUB_EVENT_PATH } = env
     const eventFilePath = GITHUB_EVENT_PATH || "/github/workflow/event.json"
-    
-    if (existsSync(eventFilePath)) {
+
+    if (event !== undefined) {
+      this.event = event
+    } else if (existsSync(eventFilePath)) {
       const event = readFileSync(eventFilePath, "utf8")
       this.event = JSON.parse(event)
     }
@@ -161,21 +163,24 @@ export class GitHubActions implements CISource {
   }
 
   get useEventDSL() {
-    // Support event based PR runs
-    return this.env.GITHUB_EVENT_NAME !== "pull_request"
+    return this.event.pull_request !== undefined || this.event.issue !== undefined
   }
 
   get pullRequestID(): string {
-    if (this.env.GITHUB_EVENT_NAME === "pull_request") {
+    if (this.event.pull_request !== undefined) {
       return this.event.pull_request.number
+    } else if (this.event.issue !== undefined) {
+      return this.event.issue.number
     }
 
     throw new Error("pullRequestID was called on GitHubActions when it wasn't a PR")
   }
 
   get repoSlug(): string {
-    if (this.env.GITHUB_EVENT_NAME === "pull_request") {
+    if (this.event.pull_request !== undefined) {
       return this.event.pull_request.base.repo.full_name
+    } else if (this.event.repo !== undefined) {
+      return this.event.repo.full_name
     }
 
     throw new Error("repoSlug was called on GitHubActions when it wasn't a PR")

--- a/source/ci_source/providers/_tests/_gitHubActions.test.ts
+++ b/source/ci_source/providers/_tests/_gitHubActions.test.ts
@@ -1,0 +1,78 @@
+import { GitHubActions } from "../GitHubActions"
+
+const pullRequestEvent = {
+  pull_request: {
+    number: "2",
+    base: {
+      repo: {
+        full_name: "danger/danger-js",
+      },
+    },
+  },
+}
+
+const issueEvent = {
+  issue: {
+    number: "2",
+  },
+  repo: {
+    full_name: "danger/danger-js",
+  },
+}
+
+describe("use event DSL", () => {
+  it("returns true when event.json contains pull_request data", () => {
+    const ci = new GitHubActions({}, pullRequestEvent)
+    expect(ci.useEventDSL).toBeTruthy()
+  })
+
+  it("returns true when event.json contains issue data", () => {
+    const ci = new GitHubActions({}, issueEvent)
+    expect(ci.useEventDSL).toBeTruthy()
+  })
+
+  it("returns false when event.json doesn't contain issue or pull_request data", () => {
+    const ci = new GitHubActions({}, {})
+    expect(ci.useEventDSL).toBeFalsy()
+  })
+})
+
+describe("pullRequestID", () => {
+  it("returns the correct id when event.json contains pull_request data", () => {
+    const ci = new GitHubActions({}, pullRequestEvent)
+    expect(ci.pullRequestID).toEqual("2")
+  })
+
+  it("returns the correct id when event.json contains issue data", () => {
+    const ci = new GitHubActions({}, issueEvent)
+    expect(ci.pullRequestID).toEqual("2")
+  })
+
+  it("throws an error when event.json doesn't contain issue or pull_request data", () => {
+    const ci = new GitHubActions({}, {})
+    expect(() => {
+      // tslint:disable-next-line:no-unused-expression
+      ci.pullRequestID
+    }).toThrow()
+  })
+})
+
+describe("repoSlug", () => {
+  it("returns the correct id when event.json contains pull_request data", () => {
+    const ci = new GitHubActions({}, pullRequestEvent)
+    expect(ci.repoSlug).toEqual("danger/danger-js")
+  })
+
+  it("returns the correct id when event.json contains issue data", () => {
+    const ci = new GitHubActions({}, issueEvent)
+    expect(ci.repoSlug).toEqual("danger/danger-js")
+  })
+
+  it("throws an error when event.json doesn't contain issue or pull_request data", () => {
+    const ci = new GitHubActions({}, {})
+    expect(() => {
+      // tslint:disable-next-line:no-unused-expression
+      ci.repoSlug
+    }).toThrow()
+  })
+})


### PR DESCRIPTION
With GitHub actions you can have more events in the PR than just the simple `pull_request` one, like for example `pull_request_review` or `pull_request_review_comment`