### PR TITLE
Fix a small bug in the protocol matching regex for DANGER_GITLAB_HOST

### DIFF
--- a/source/platforms/gitlab/GitLabAPI.ts
+++ b/source/platforms/gitlab/GitLabAPI.ts
@@ -28,7 +28,7 @@ export function getGitLabAPICredentialsFromEnv(env: Env): GitLabAPICredentials {
   if (envHost) {
     // We used to support DANGER_GITLAB_HOST being just the host e.g. "gitlab.com"
     // however it is possible to have a custom host without SSL, ensure we only add the protocol if one is not provided
-    const protocolRegex = /^http(s)*?:\/\//i
+    const protocolRegex = /^https?:\/\//i
     host = protocolRegex.test(envHost) ? envHost : `https://${envHost}`
   }
 


### PR DESCRIPTION
Not a biggie but I'm about to change this to use the CI_API_V4_URL if DANGER_GITLAB_HOST isn't defined (so that the default behaviour isn't changed) and I spotted this needed fixing first. 