### PR TITLE
Use CI_API_V4_URL in GitLab if it is available

### DIFF
--- a/docs/usage/gitlab.html.md
+++ b/docs/usage/gitlab.html.md
@@ -7,10 +7,13 @@ blurb: An overview of using Danger with GitLab, and some examples
 ---
 
 To use Danger JS with GitLab: you'll need to create a new account for Danger to use, then set the following environment
-variables on your CI system:
+variable on your CI system:
+
+- `DANGER_GITLAB_API_TOKEN` = An access token for the account which will post comments
+
+If you are using a GitLab version prior to 11.7 you will also need to define the following environment variable:
 
 - `DANGER_GITLAB_HOST` = Defaults to `https://gitlab.com` but you can use it for your own url
-- `DANGER_GITLAB_API_TOKEN` = An access token for the account which will post comments
 
 Then in your Dangerfiles you will have a fully fleshed out `danger.gitlab` object to work with. For example:
 

--- a/source/platforms/gitlab/GitLabAPI.ts
+++ b/source/platforms/gitlab/GitLabAPI.ts
@@ -25,11 +25,23 @@ export interface GitLabAPICredentials {
 export function getGitLabAPICredentialsFromEnv(env: Env): GitLabAPICredentials {
   let host = "https://gitlab.com"
   const envHost = env["DANGER_GITLAB_HOST"]
+  const envCIAPI = env["CI_API_V4_URL"]
+
   if (envHost) {
     // We used to support DANGER_GITLAB_HOST being just the host e.g. "gitlab.com"
     // however it is possible to have a custom host without SSL, ensure we only add the protocol if one is not provided
     const protocolRegex = /^https?:\/\//i
     host = protocolRegex.test(envHost) ? envHost : `https://${envHost}`
+  } else if (envCIAPI) {
+    // GitLab >= v11.7 supplies the API Endpoint in an environment variable and we can work out our host value from that.
+    // See https://docs.gitlab.com/ce/ci/variables/predefined_variables.html
+    const hostRegex = /^(https?):\/\/([^\/]+)\//i
+    if (hostRegex.test(envCIAPI)) {
+      const matches = hostRegex.exec(envCIAPI)!
+      const matchProto = matches[1]
+      const matchHost = matches[2]
+      host = `${matchProto}://${matchHost}`
+    }
   }
 
   return {

--- a/source/platforms/gitlab/_tests/_gitlab_api.test.ts
+++ b/source/platforms/gitlab/_tests/_gitlab_api.test.ts
@@ -35,6 +35,18 @@ describe("GitLab API", () => {
     )
   })
 
+  it("configures host from CI_API_V4_URL", () => {
+    api = new GitLabAPI(
+      { pullRequestID: "27117", repoSlug: "gitlab-org/gitlab-ce" },
+      getGitLabAPICredentialsFromEnv({
+        CI_API_V4_URL: "https://testciapiv4url.com/api/v4",
+        DANGER_GITLAB_API_TOKEN: "FAKE_DANGER_GITLAB_API_TOKEN",
+      })
+    )
+
+    expect(api.projectURL).toBe("https://testciapiv4url.com/gitlab-org/gitlab-ce")
+  })
+
   it("projectURL is defined", () => {
     expect(api.projectURL).toBe("https://gitlab.com/gitlab-org/gitlab-ce")
   })


### PR DESCRIPTION
I'm sure there is lots of room for improvement in this change! Please suggest whatever you think is appropriate. I'm particularly feeling some hnng around the way I'm testing this change.

Basically, since GitLab 11.7 an environment variable called `CI_API_V4_URL` has been available (per  https://docs.gitlab.com/ce/ci/variables/predefined_variables.html) which contains the information that we currently supply as `DANGER_GITLAB_HOST`.

I've left `DANGER_GITLAB_HOST` dominant because some people may have unusual configs where they have done things with hostnames that we don't expect and changing the behaviour may break things for them, but for new users it should now be possible to configure the CI side of Danger by just supplying a token.