### PR TITLE
Fix danger local message when branch is not master

### DIFF
--- a/source/commands/danger-local.ts
+++ b/source/commands/danger-local.ts
@@ -33,6 +33,6 @@ localPlatform.validateThereAreChanges().then(changes => {
     // try to find the CI danger is running on and use that.
     runRunner(app, { source: fakeSource, platform: localPlatform, additionalEnvVars: { DANGER_LOCAL_NO_CI: "yep" } })
   } else {
-    console.log("No git changes detected between head and master.")
+    console.log(`No git changes detected between head and ${base}.`)
   }
 })


### PR DESCRIPTION
The message when there are no changes had a hardcoded value of `master` instead of using the value of `base`, which coudl have been changed with the command line options.