### PR TITLE
Use gitlab project ID instead of project name

### DIFF
--- a/docs/usage/gitlab.html.md
+++ b/docs/usage/gitlab.html.md
@@ -11,6 +11,10 @@ variable on your CI system:
 
 - `DANGER_GITLAB_API_TOKEN` = An access token for the account which will post comments
 
+You will need also to add an environment variable for your gitlab project id:
+
+- `DANGER_GITLAB_PROJECT_ID` = Gitlab project id can be found in (Settings -> General). if not defined, project name will be used instead
+
 If you are using a GitLab version prior to 11.7 you will also need to define the following environment variable:
 
 - `DANGER_GITLAB_HOST` = Defaults to `https://gitlab.com` but you can use it for your own url

--- a/source/danger-incoming-process-schema.json
+++ b/source/danger-incoming-process-schema.json
@@ -1189,7 +1189,7 @@
                     "type": "string"
                 },
                 "repoSlug": {
-                    "description": "A path like \"artsy/eigen\"",
+                    "description": "Project ID \"624\" or a path like \"artsy/eigen\"",
                     "type": "string"
                 }
             },

--- a/source/platforms/gitlab/_tests/_gitlab_api.test.ts
+++ b/source/platforms/gitlab/_tests/_gitlab_api.test.ts
@@ -6,7 +6,7 @@ import { readFileSync } from "fs"
 const nockBack = nock.back
 nockBack.fixtures = __dirname + "/fixtures"
 
-// We're testing https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/27117
+// We're testing https://gitlab.com/456/merge_requests/27117
 // This has been chosen because it is already merged and publicly available, it's unlikely to change
 
 /** Returns a fixture. */
@@ -27,7 +27,7 @@ describe("GitLab API", () => {
 
   beforeEach(() => {
     api = new GitLabAPI(
-      { pullRequestID: "27117", repoSlug: "gitlab-org/gitlab-ce" },
+      { pullRequestID: "27117", repoSlug: "456" },
       getGitLabAPICredentialsFromEnv({
         DANGER_GITLAB_HOST: "gitlab.com",
         DANGER_GITLAB_API_TOKEN: "FAKE_DANGER_GITLAB_API_TOKEN",
@@ -37,22 +37,22 @@ describe("GitLab API", () => {
 
   it("configures host from CI_API_V4_URL", () => {
     api = new GitLabAPI(
-      { pullRequestID: "27117", repoSlug: "gitlab-org/gitlab-ce" },
+      { pullRequestID: "27117", repoSlug: "456" },
       getGitLabAPICredentialsFromEnv({
         CI_API_V4_URL: "https://testciapiv4url.com/api/v4",
         DANGER_GITLAB_API_TOKEN: "FAKE_DANGER_GITLAB_API_TOKEN",
       })
     )
 
-    expect(api.projectURL).toBe("https://testciapiv4url.com/gitlab-org/gitlab-ce")
+    expect(api.projectURL).toBe("https://testciapiv4url.com/456")
   })
 
   it("projectURL is defined", () => {
-    expect(api.projectURL).toBe("https://gitlab.com/gitlab-org/gitlab-ce")
+    expect(api.projectURL).toBe("https://gitlab.com/456")
   })
 
   it("mergeRequestURL is defined", () => {
-    expect(api.mergeRequestURL).toBe("https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/27117")
+    expect(api.mergeRequestURL).toBe("https://gitlab.com/456/merge_requests/27117")
   })
 
   const sanitizeUserResponse = (nocks: NockDefinition[]): NockDefinition[] => {

--- a/source/platforms/gitlab/_tests/fixtures/getMergeRequestChanges.json
+++ b/source/platforms/gitlab/_tests/fixtures/getMergeRequestChanges.json
@@ -2,7 +2,7 @@
   {
     "scope": "https://gitlab.com:443",
     "method": "GET",
-    "path": "/api/v4/projects/gitlab-org%2Fgitlab-ce/merge_requests/27117/changes",
+    "path": "/api/v4/projects/456/merge_requests/27117/changes",
     "body": "",
     "status": 200,
     "response": {
@@ -58,7 +58,12 @@
       ],
       "source_project_id": 13083,
       "target_project_id": 13083,
-      "labels": ["Danger bot", "Plan", "backend", "backstage"],
+      "labels": [
+        "Danger bot",
+        "Plan",
+        "backend",
+        "backstage"
+      ],
       "work_in_progress": false,
       "milestone": {
         "id": 655280,

--- a/source/platforms/gitlab/_tests/fixtures/getMergeRequestCommits.json
+++ b/source/platforms/gitlab/_tests/fixtures/getMergeRequestCommits.json
@@ -2,7 +2,7 @@
   {
     "scope": "https://gitlab.com:443",
     "method": "GET",
-    "path": "/api/v4/projects/gitlab-org%2Fgitlab-ce/merge_requests/27117/commits",
+    "path": "/api/v4/projects/456/merge_requests/27117/commits",
     "body": "",
     "status": 200,
     "response": [
@@ -51,7 +51,7 @@
       "Etag",
       "W/\"478bcb3a3b56ea7180c04159ff3adea5\"",
       "Link",
-      "<https://gitlab.com/api/v4/projects/gitlab-org%2Fgitlab-ce/merge_requests/27117/commits?id=gitlab-org%2Fgitlab-ce&merge_request_iid=27117&page=1&per_page=>; rel=\"first\", <https://gitlab.com/api/v4/projects/gitlab-org%2Fgitlab-ce/merge_requests/27117/commits?id=gitlab-org%2Fgitlab-ce&merge_request_iid=27117&page=1&per_page=>; rel=\"last\"",
+      "<https://gitlab.com/api/v4/projects/456/merge_requests/27117/commits?id=456&merge_request_iid=27117&page=1&per_page=>; rel=\"first\", <https://gitlab.com/api/v4/projects/456/merge_requests/27117/commits?id=456&merge_request_iid=27117&page=1&per_page=>; rel=\"last\"",
       "Vary",
       "Origin",
       "X-Content-Type-Options",

--- a/source/platforms/gitlab/_tests/fixtures/getMergeRequestInfo.json
+++ b/source/platforms/gitlab/_tests/fixtures/getMergeRequestInfo.json
@@ -2,7 +2,7 @@
   {
     "scope": "https://gitlab.com:443",
     "method": "GET",
-    "path": "/api/v4/projects/gitlab-org%2Fgitlab-ce/merge_requests/27117",
+    "path": "/api/v4/projects/456/merge_requests/27117",
     "body": "",
     "status": 200,
     "response": {

--- a/source/platforms/gitlab/_tests/fixtures/getMergeRequestInlineNotes.json
+++ b/source/platforms/gitlab/_tests/fixtures/getMergeRequestInlineNotes.json
@@ -2,7 +2,7 @@
   {
     "scope": "https://gitlab.com:443",
     "method": "GET",
-    "path": "/api/v4/projects/gitlab-org%2Fgitlab-ce/merge_requests/27117/notes",
+    "path": "/api/v4/projects/456/merge_requests/27117/notes",
     "body": "",
     "status": 200,
     "response": [
@@ -356,7 +356,7 @@
       "Etag",
       "W/\"edab8aad8eea37dd376785c34c7c250f\"",
       "Link",
-      "<https://gitlab.com/api/v4/projects/gitlab-org%2Fgitlab-ce/merge_requests/27117/notes?id=gitlab-org%2Fgitlab-ce&noteable_id=27117&order_by=created_at&page=1&per_page=20&sort=desc>; rel=\"first\", <https://gitlab.com/api/v4/projects/gitlab-org%2Fgitlab-ce/merge_requests/27117/notes?id=gitlab-org%2Fgitlab-ce&noteable_id=27117&order_by=created_at&page=1&per_page=20&sort=desc>; rel=\"last\"",
+      "<https://gitlab.com/api/v4/projects/456/merge_requests/27117/notes?id=456&noteable_id=27117&order_by=created_at&page=1&per_page=20&sort=desc>; rel=\"first\", <https://gitlab.com/api/v4/projects/456/merge_requests/27117/notes?id=456&noteable_id=27117&order_by=created_at&page=1&per_page=20&sort=desc>; rel=\"last\"",
       "Vary",
       "Origin",
       "X-Content-Type-Options",

--- a/source/platforms/gitlab/_tests/fixtures/getMergeRequestNotes.json
+++ b/source/platforms/gitlab/_tests/fixtures/getMergeRequestNotes.json
@@ -2,7 +2,7 @@
   {
     "scope": "https://gitlab.com:443",
     "method": "GET",
-    "path": "/api/v4/projects/gitlab-org%2Fgitlab-ce/merge_requests/27117/notes",
+    "path": "/api/v4/projects/456/merge_requests/27117/notes",
     "body": "",
     "status": 200,
     "response": [
@@ -356,7 +356,7 @@
       "Etag",
       "W/\"edab8aad8eea37dd376785c34c7c250f\"",
       "Link",
-      "<https://gitlab.com/api/v4/projects/gitlab-org%2Fgitlab-ce/merge_requests/27117/notes?id=gitlab-org%2Fgitlab-ce&noteable_id=27117&order_by=created_at&page=1&per_page=20&sort=desc>; rel=\"first\", <https://gitlab.com/api/v4/projects/gitlab-org%2Fgitlab-ce/merge_requests/27117/notes?id=gitlab-org%2Fgitlab-ce&noteable_id=27117&order_by=created_at&page=1&per_page=20&sort=desc>; rel=\"last\"",
+      "<https://gitlab.com/api/v4/projects/456/merge_requests/27117/notes?id=456&noteable_id=27117&order_by=created_at&page=1&per_page=20&sort=desc>; rel=\"first\", <https://gitlab.com/api/v4/projects/456/merge_requests/27117/notes?id=456&noteable_id=27117&order_by=created_at&page=1&per_page=20&sort=desc>; rel=\"last\"",
       "Vary",
       "Origin",
       "X-Content-Type-Options",

--- a/source/platforms/platform.ts
+++ b/source/platforms/platform.ts
@@ -132,10 +132,11 @@ export function getPlatformForEnv(env: Env, source: CISource): Platform {
 
   // GitLab
   if (env["DANGER_GITLAB_API_TOKEN"] || env["DANGER_PR_PLATFORM"] === GitLab.name) {
+    const repoSlug = env["DANGER_GITLAB_PROJECT_ID"] ? env["DANGER_GITLAB_PROJECT_ID"] : source.repoSlug
     const api = new GitLabAPI(
       {
         pullRequestID: source.pullRequestID,
-        repoSlug: source.repoSlug,
+        repoSlug: repoSlug,
       },
       getGitLabAPICredentialsFromEnv(env)
     )


### PR DESCRIPTION
#969  Here i added an environment variable for gitlab project id called `DANGER_GITLAB_PROJECT_ID`
Add added some doc about that. and updated GitlabAPI unit tests.
Project name will be used if project id variable  is not defined (so no breaking changes).
