### PR TITLE
Improve GitLab CI support for MRs from forks

### DIFF
--- a/source/ci_source/providers/GitLabCI.ts
+++ b/source/ci_source/providers/GitLabCI.ts
@@ -23,7 +23,7 @@ export class GitLabCI implements CISource {
   }
 
   get repoSlug(): string {
-    return this.env.CI_PROJECT_PATH
+    return this.env.CI_MERGE_REQUEST_PROJECT_PATH || this.env.CI_PROJECT_PATH
   }
 
   get commitHash(): string {


### PR DESCRIPTION
Current GitLab CI provider gets the repoSlug from the environment variable `CI_PROJECT_PATH`, which by default points to the project from where the MR is created. This works fine for MRs coming from the same project, but not for MRs coming from forks. Starting on Gitlab 11.6 there is [`CI_MERGE_REQUEST_PROJECT_PATH`](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html) environment variable that works for both cases.