### PR TITLE
BitBucket Server: use REST API for raw file requests

### DIFF
--- a/source/platforms/bitbucket_server/BitBucketServerAPI.ts
+++ b/source/platforms/bitbucket_server/BitBucketServerAPI.ts
@@ -241,7 +241,7 @@ export class BitBucketServerAPI implements BitBucketServerAPIDSL {
 
   // The last two are "optional" in the protocol, but not really optional WRT the BBSAPI
   getFileContents = async (filePath: string, repoSlug?: string, refspec?: string) => {
-    const path = `${repoSlug}/` + `raw/${filePath}` + `?at=${refspec}`
+    const path = `rest/api/1.0/${repoSlug}/` + `raw/${filePath}` + `?at=${refspec}`
     const res = await this.get(path, undefined, true)
     if (res.status === 404) {
       return ""

--- a/source/platforms/bitbucket_server/_tests/_bitbucket_server_api.test.ts
+++ b/source/platforms/bitbucket_server/_tests/_bitbucket_server_api.test.ts
@@ -275,7 +275,7 @@ describe("API testing - BitBucket Server", () => {
     const result = await api.getFileContents("path/to/foo.txt", "projects/FOO/repos/BAR", "master")
 
     expect(api.fetch).toHaveBeenCalledWith(
-      `${host}/projects/FOO/repos/BAR/raw/path/to/foo.txt?at=master`,
+      `${host}/rest/api/1.0/projects/FOO/repos/BAR/raw/path/to/foo.txt?at=master`,
       { method: "GET", body: null, headers: expectedJSONHeaders },
       true
     )


### PR DESCRIPTION
User centric request is changed to REST API request.
More details https://docs.atlassian.com/bitbucket-server/rest/6.10.0/bitbucket-rest.html#idp329