### PR TITLE
Accept lowercase proxy env variables

### DIFF
--- a/source/api/_tests/fetch.test.ts
+++ b/source/api/_tests/fetch.test.ts
@@ -3,6 +3,7 @@ import * as node_fetch from "node-fetch"
 
 import { api } from "../fetch"
 import HttpProxyAgent from "http-proxy-agent"
+import HttpsProxyAgent from "http-proxy-agent"
 
 interface ResponseMock {
   body?: any
@@ -118,15 +119,50 @@ describe("fetch", () => {
     expect(await response.text()).toBe(body)
   })
 
-  it("sets proxy agent", async () => {
+  it("sets proxy agent when HTTPS_PROXY env variable is defined", async () => {
     const proxyUrl = "http://localhost:30002/"
-    process.env["HTTP_PROXY"] = proxyUrl
 
     await proxy.start()
     await server.start({})
 
     let options: node_fetch.RequestInit = { agent: undefined }
-    await api(url, options)
+    await api(url, options, true, { HTTPS_PROXY: proxyUrl })
+    let agent = options.agent as HttpsProxyAgent
+    expect(agent.proxy.href).toBe(proxyUrl)
+  })
+
+  it("sets proxy agent when https_proxy env variable is defined", async () => {
+    const proxyUrl = "http://localhost:30002/"
+
+    await proxy.start()
+    await server.start({})
+
+    let options: node_fetch.RequestInit = { agent: undefined }
+    await api(url, options, true, { https_proxy: proxyUrl })
+    let agent = options.agent as HttpsProxyAgent
+    expect(agent.proxy.href).toBe(proxyUrl)
+  })
+
+  it("sets proxy agent when HTTP_PROXY env variable is defined", async () => {
+    const proxyUrl = "http://localhost:30002/"
+
+    await proxy.start()
+    await server.start({})
+
+    let options: node_fetch.RequestInit = { agent: undefined }
+    await api(url, options, true, { HTTP_PROXY: proxyUrl })
+    let agent = options.agent as HttpProxyAgent
+    expect(agent.proxy.href).toBe(proxyUrl)
+  })
+
+  it("sets proxy agent when http_proxy env variable is defined", async () => {
+    const proxyUrl = "http://localhost:30002/"
+
+    await proxy.start()
+    await server.start({})
+
+    let options: node_fetch.RequestInit = { agent: undefined }
+    await api(url, options, true, { http_proxy: proxyUrl })
     let agent = options.agent as HttpProxyAgent
     expect(agent.proxy.href).toBe(proxyUrl)
   })

--- a/source/api/fetch.ts
+++ b/source/api/fetch.ts
@@ -62,7 +62,8 @@ export async function retryableFetch(
 export function api(
   url: string | node_fetch.Request,
   init: node_fetch.RequestInit,
-  suppressErrorReporting?: boolean
+  suppressErrorReporting?: boolean,
+  provessEnv: NodeJS.ProcessEnv = process.env
 ): Promise<node_fetch.Response> {
   const isTests = typeof jest !== "undefined"
   if (isTests && !url.toString().includes("localhost")) {
@@ -78,8 +79,8 @@ export function api(
       output.push(`-X ${init.method}`)
     }
 
-    const showToken = process.env["DANGER_VERBOSE_SHOW_TOKEN"]
-    const token = process.env["DANGER_GITHUB_API_TOKEN"] || process.env["GITHUB_TOKEN"]
+    const showToken = provessEnv["DANGER_VERBOSE_SHOW_TOKEN"]
+    const token = provessEnv["DANGER_GITHUB_API_TOKEN"] || provessEnv["GITHUB_TOKEN"]
 
     if (init.headers) {
       for (const prop in init.headers) {
@@ -107,7 +108,8 @@ export function api(
   }
 
   let agent = init.agent
-  const proxy = process.env["HTTPS_PROXY"] || process.env["HTTP_PROXY"]
+  const proxy =
+    provessEnv["HTTPS_PROXY"] || provessEnv["https_proxy"] || provessEnv["HTTP_PROXY"] || provessEnv["http_proxy"]
 
   if (!agent && proxy) {
     let secure = url.toString().startsWith("https")


### PR DESCRIPTION
The proxy env variable is often used as lowercase string, then I think makes sense to automatically accept both.