### PR TITLE
If no case is matched, use platform name.

### DIFF
--- a/source/runner/dslGenerator.ts
+++ b/source/runner/dslGenerator.ts
@@ -54,7 +54,8 @@ const jsonDSLPlatformName = (platform: Platform): string => {
     case "GitLab":
       return "gitlab"
     case "GitHub":
-    default:
       return "github"
+    default:
+      return platform.name.split(" ").join("_")
   }
 }


### PR DESCRIPTION
When i use `danger local`. The platform name is `github` cause default case is `github`. I prefer to use platform name as default case.