### PR TITLE
Update `parse-diff` library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ x
 
 <!-- Your comment below this -->
 
+- Update `parse-diff` library - [@417-72KI]
+
   <!-- Your comment above this -->
 
 # 9.2.10

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "node-fetch": "^2.3.0",
     "override-require": "^1.1.1",
     "p-limit": "^2.1.0",
-    "parse-diff": "^0.5.1",
+    "parse-diff": "^0.7.0",
     "parse-git-config": "^2.0.3",
     "parse-github-url": "^1.0.2",
     "parse-link-header": "^1.0.1",


### PR DESCRIPTION
`parse-diff` 0.7.0 has been released.
It fundamentally resolves sergeyt/parse-diff#23, which is based on danger/danger-js#807😄