### PR TITLE
Fix repository slug in Jenkins provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ x
 <!-- Your comment below this -->
 
 - Update `parse-diff` library - [@417-72KI]
+- Fix repository slug in Jenkins provider - [sandratatarevicova]
 
   <!-- Your comment above this -->
 

--- a/source/ci_source/providers/Jenkins.ts
+++ b/source/ci_source/providers/Jenkins.ts
@@ -75,7 +75,7 @@ export class Jenkins implements CISource {
 
       return result.repo
     }
-    return this.env.ghprbGhRepository || this.env.gitlabTargetNamespace + "/" + this.env.gitlabTargetRepoName
+    return this.env.ghprbGhRepository || new URL(this.env.GIT_URL_1).pathname.replace(/^\/(.*)\.git$/, "$1")
   }
 
   get ciRunURL() {


### PR DESCRIPTION
Jenkins provider [generates repository slug](https://github.com/danger/danger-js/blob/master/source/ci_source/providers/Jenkins.ts#L69) based on environment variables from [Jenkins GitLab plugin](https://github.com/jenkinsci/gitlab-plugin/). The repository slug is set to `this.env.gitlabTargetNamespace + "/" + this.env.gitlabTargetRepoName` which does not work when the repository name does not match the repository path. I have checked the Jenkins GitLab plugin and it, unfortunately, does not read the repository path from GitLab API. It seems that the Jenkins GitLab plugin is not maintained very well - there are 18 open pull requests and some of them are quite old, so I used environment variable `GIT_URL_1` which is used by Jenkins provider in `danger/danger` as well.