### PR TITLE
Minor docs improvement for GitHub Actions

### DIFF
--- a/source/ci_source/providers/GitHubActions.ts
+++ b/source/ci_source/providers/GitHubActions.ts
@@ -132,6 +132,8 @@ import { readFileSync, existsSync } from "fs"
  *     env: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  * ```
  *
+ * [GitHub automatically creates a `GITHUB_TOKEN` secret to use in your workflow](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token). You can use the `GITHUB_TOKEN` to authenticate in a workflow run.
+ *
  */
 
 export class GitHubActions implements CISource {

--- a/source/ci_source/providers/GitHubActions.ts
+++ b/source/ci_source/providers/GitHubActions.ts
@@ -24,7 +24,7 @@ import { readFileSync, existsSync } from "fs"
  *     - name: Use Node.js 10.x
  *       uses: actions/setup-node@v1
  *       with:
- *         version: 10.x
+ *         node-version: 10.x
  *     - name: install yarn
  *       run: npm install -g yarn
  *     - name: yarn install, build, and test


### PR DESCRIPTION
_Let's be honest. I'm opening this now because I wanted to be the author of 1000th issue._ 😛 

Two minor improvements:

- Add link to GitHub Actions documentation for GITHUB_TOKEN. Not understanding the GITHUB_TOKEN [cost me a fair bit of time](https://github.com/danger/danger-js/issues/856#issuecomment-583333378) recently. Hopefully adding this link to the docs will save time to other people.
- Use `node-version` instead of `version` in GitHub Action docs. [`version` is deprecated](https://github.com/actions/setup-node/blob/d123f1054346d0acb63e9c1b205df110a951f36a/action.yml#L15-L18). Support was said to be dropped in October 2019 –_although that was 4 months ago_.