### PR TITLE
Fix Typos across danger-js Repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ x
 
 - Update `parse-diff` library - [@417-72KI]
 - Fix repository slug in Jenkins provider - [sandratatarevicova]
+- Fix Typos across danger-js Repo - [@yohix]
 
   <!-- Your comment above this -->
 

--- a/source/ci_source/providers/Codefresh.ts
+++ b/source/ci_source/providers/Codefresh.ts
@@ -25,7 +25,7 @@ import { ensureEnvKeysExist, ensureEnvKeysAreInt } from "../ci_source_helpers"
  *            - success
  *  ```
  *
- *  The `failOnErrors` option is required in order to ensure that the step fails properly when Danger fails. If you don't wnat this behavior, you can remove this option.
+ *  The `failOnErrors` option is required in order to ensure that the step fails properly when Danger fails. If you don't want this behavior, you can remove this option.
  *
  *  Don't forget to add the `DANGER_GITHUB_API_TOKEN` variable to your pipeline settings so that Danger can properly post comments to your pull request.
  *

--- a/source/danger-incoming-process-schema.json
+++ b/source/danger-incoming-process-schema.json
@@ -27,7 +27,7 @@
                     "type": "number"
                 },
                 "committer": {
-                    "description": "The author of the commit, assumed to be the person who commited/merged the code into a project.",
+                    "description": "The author of the commit, assumed to be the person who committed/merged the code into a project.",
                     "properties": {
                         "displayName": {
                             "description": "The display name of the commit committer",

--- a/source/danger.d.ts
+++ b/source/danger.d.ts
@@ -118,7 +118,7 @@ interface BitBucketCloudCommit {
     user: BitBucketCloudUser
   }
 
-  /** When the commit was commited to the project, in ISO 8601 format */
+  /** When the commit was committed to the project, in ISO 8601 format */
   date: string
   /** The commit's message */
   message: string
@@ -301,7 +301,7 @@ interface BitBucketServerCommit {
   }
   /** The UNIX timestamp for when the commit was authored */
   authorTimestamp: number
-  /** The author of the commit, assumed to be the person who commited/merged the code into a project. */
+  /** The author of the commit, assumed to be the person who committed/merged the code into a project. */
   committer: {
     /** The id of the commit committer */
     name: string
@@ -310,7 +310,7 @@ interface BitBucketServerCommit {
     /** The email of the commit committer */
     emailAddress: string
   }
-  /** When the commit was commited to the project */
+  /** When the commit was committed to the project */
   committerTimestamp: number
   /** The commit's message */
   message: string
@@ -324,9 +324,9 @@ interface BitBucketServerCommit {
 }
 
 interface BitBucketServerDiff {
-  /** The file refrence when moved */
+  /** The file reference when moved */
   destination?: BitBucketServerFile
-  /** The original file refrence */
+  /** The original file reference */
   source?: BitBucketServerFile
   /** A set of diff changes */
   hunks: BitBucketServerHunk[]
@@ -1735,7 +1735,7 @@ declare function message(message: MarkdownString, file?: string, line?: number):
 /**
  * Adds a message to the Danger table, the only difference between this
  * and warn is the default emoji which shows in the table.
- * You can also specifiy a custom emoji to show in the table for each message
+ * You can also specify a custom emoji to show in the table for each message
  *
  * @param {MarkdownString} message the String to output
  * @param {{file?: string, line?: string, icon?: MarkdownString}} [opts]

--- a/source/dsl/BitBucketCloudDSL.ts
+++ b/source/dsl/BitBucketCloudDSL.ts
@@ -114,7 +114,7 @@ export interface BitBucketCloudCommit {
     user: BitBucketCloudUser
   }
 
-  /** When the commit was commited to the project, in ISO 8601 format */
+  /** When the commit was committed to the project, in ISO 8601 format */
   date: string
   /** The commit's message */
   message: string

--- a/source/dsl/BitBucketServerDSL.ts
+++ b/source/dsl/BitBucketServerDSL.ts
@@ -128,7 +128,7 @@ export interface BitBucketServerCommit {
   }
   /** The UNIX timestamp for when the commit was authored */
   authorTimestamp: number
-  /** The author of the commit, assumed to be the person who commited/merged the code into a project. */
+  /** The author of the commit, assumed to be the person who committed/merged the code into a project. */
   committer: {
     /** The id of the commit committer */
     name: string
@@ -137,7 +137,7 @@ export interface BitBucketServerCommit {
     /** The email of the commit committer */
     emailAddress: string
   }
-  /** When the commit was commited to the project */
+  /** When the commit was committed to the project */
   committerTimestamp: number
   /** The commit's message */
   message: string
@@ -151,9 +151,9 @@ export interface BitBucketServerCommit {
 }
 
 export interface BitBucketServerDiff {
-  /** The file refrence when moved */
+  /** The file reference when moved */
   destination?: BitBucketServerFile
-  /** The original file refrence */
+  /** The original file reference */
   source?: BitBucketServerFile
   /** A set of diff changes */
   hunks: BitBucketServerHunk[]


### PR DESCRIPTION
**Fix Typos across danger-js Repo**

```
danger-js/source/ci_source/providers/Codefresh.ts:28:122: "wnat" is a misspelling of "want"
danger-js/source/danger-incoming-process-schema.json:30:91: "commited" is a misspelling of "committed"
danger-js/source/danger.d.ts:121:26: "commited" is a misspelling of "committed"
danger-js/source/danger.d.ts:304:61: "commited" is a misspelling of "committed"
danger-js/source/danger.d.ts:313:26: "commited" is a misspelling of "committed"
danger-js/source/danger.d.ts:327:15: "refrence" is a misspelling of "reference"
danger-js/source/danger.d.ts:329:24: "refrence" is a misspelling of "reference"
danger-js/source/danger.d.ts:1738:16: "specifiy" is a misspelling of "specify"
danger-js/source/dsl/BitBucketCloudDSL.ts:117:26: "commited" is a misspelling of "committed"
danger-js/source/dsl/BitBucketServerDSL.ts:131:61: "commited" is a misspelling of "committed"
danger-js/source/dsl/BitBucketServerDSL.ts:140:26: "commited" is a misspelling of "committed"
danger-js/source/dsl/BitBucketServerDSL.ts:154:15: "refrence" is a misspelling of "reference"
danger-js/source/dsl/BitBucketServerDSL.ts:156:24: "refrence" is a misspelling of "reference"
```