### PR TITLE
Fix "@octokit/rest" deprecation warning when using ".issues.addLabels()"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ x
 - Update `parse-diff` library - [@417-72KI]
 - Fix repository slug in Jenkins provider - [sandratatarevicova]
 - Fix Typos across danger-js Repo - [@yohix]
+- Fix `@octokit/rest` deprecation warning when using `.issues.addLabels()` - [@sogame]
 
   <!-- Your comment above this -->
 

--- a/source/platforms/github/GitHubUtils.ts
+++ b/source/platforms/github/GitHubUtils.ts
@@ -217,7 +217,7 @@ export const createOrAddLabel = (pr: GitHubPRDSL | undefined, api: GitHub) => as
   await api.issues.addLabels({
     owner: config.owner,
     repo: config.repo,
-    number: config.id,
+    issue_number: config.id,
     labels: [labelConfig.name],
   })
 }


### PR DESCRIPTION
When adding a label using `danger.github.utils.createOrAddLabel` the following message appears in the CI logs:

```
Deprecation: [@octokit/rest] "number" parameter is deprecated for ".issues.addLabels()". Use "issue_number" instead
```

This change should prevent it.