### PR TITLE
Add debug messages for "createLabel" and "addLabels" failures in "createOrAddLabel"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ x
 
 <!-- Your comment below this -->
 
+- Don't fail when using `createOrAddLabel` if label fails to be created or added - [@sogame]
+
 <!-- Your comment above this -->
 
 # 9.3.0

--- a/source/platforms/github/GitHubUtils.ts
+++ b/source/platforms/github/GitHubUtils.ts
@@ -203,23 +203,31 @@ export const createOrAddLabel = (pr: GitHubPRDSL | undefined, api: GitHub) => as
   // Create the label if it doesn't exist yet
   if (!label) {
     d("no label found, creating a new one for this repo")
-    await api.issues.createLabel({
-      owner: config.owner,
-      repo: config.repo,
-      name: labelConfig.name,
-      color: labelConfig.color,
-      description: labelConfig.description,
-    })
+    try {
+      await api.issues.createLabel({
+        owner: config.owner,
+        repo: config.repo,
+        name: labelConfig.name,
+        color: labelConfig.color,
+        description: labelConfig.description,
+      })
+    } catch (e) {
+      d("api.issues.createLabel gave an error", e)
+    }
   }
 
   d("adding a label to this pr")
   // Then add the label
-  await api.issues.addLabels({
-    owner: config.owner,
-    repo: config.repo,
-    issue_number: config.id,
-    labels: [labelConfig.name],
-  })
+  try {
+    await api.issues.addLabels({
+      owner: config.owner,
+      repo: config.repo,
+      issue_number: config.id,
+      labels: [labelConfig.name],
+    })
+  } catch (e) {
+    d("api.issues.addLabels gave an error", e)
+  }
 }
 
 export default utils


### PR DESCRIPTION
When using `createOrAddLabel` sometimes I'm getting a failure:

```
RequestError [HttpError]: Validation Failed: {"resource":"Label","code":"already_exists","field":"name"}
 ```

Indeed the label already exists, and looking at the code for [createOrAddLabel](https://github.com/danger/danger-js/blob/04c33453b3216b24718df571235064bbc7e659ab/source/platforms/github/GitHubUtils.ts#L198) I think this could only happen if `api.issues.listLabelsForRepo` throws an exception.

I think it would be useful to add try/catch statements and debug messages when calling `api.issues.createLabel` and `api.issues.addLabels` to get more information and avoid Danger failing when these requests fail (same as done for `api.issues.listLabelsForRepo`).