### PR TITLE
Add missing contributor url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1755,6 +1755,7 @@ Not usable for others, only stubs of classes etc. - [@orta]
 [@sebinsua]: https://github.com/sebinsua
 [@sgtcoolguy]: https://github.com/sgtcoolguy
 [@sharkysharks]: https://github.com/sharkysharks
+[@sogame]: https://github.com/sogame
 [@stevemoser]: https://github.com/stevemoser
 [@stevenp]: https://github.com/stevenp
 [@sunshinejr]: https://github.com/sunshinejr


### PR DESCRIPTION
Just realised about the comment at the top of `changelog.md` to add the contributor url  😅 