### PR TITLE
fix: change JSON patch implementation for memory improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ x
 
 <!-- Your comment below this -->
 
+- Changed JSON patch implementation for better memory performance. [@dkundel] **Breaking:** `JSONPatchForFile` will
+  return a different order of operations than previously. It will also return a `path` with the index of the element
+  inserted into an array for `add` operations.
+
 <!-- Your comment above this -->
 
 # 9.3.1
@@ -1729,6 +1733,7 @@ Not usable for others, only stubs of classes etc. - [@orta]
 [@danielrosenwasser]: https://github.com/DanielRosenwasser
 [@davidbrunow]: https://github.com/davidbrunow
 [@dfalling]: https://github.com/dfalling
+[@dkundel]: https://github.com/dkundel
 [@f-meloni]: https://github.com/f-meloni
 [@fbartho]: https://github.com/fbartho
 [@fwal]: https://github.com/fwal

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "chalk": "^2.3.0",
     "commander": "^2.18.0",
     "debug": "^4.1.1",
+    "fast-json-patch": "^3.0.0-1",
     "get-stdin": "^6.0.0",
     "gitlab": "^10.0.1",
     "http-proxy-agent": "^2.1.0",
@@ -169,7 +170,6 @@
     "prettyjson": "^1.2.1",
     "readline-sync": "^1.4.9",
     "require-from-string": "^2.0.2",
-    "rfc6902": "^3.0.1",
     "supports-hyperlinks": "^1.0.1"
   },
   "optionalDependencies": {},

--- a/source/platforms/git/gitJSONToGitDSL.ts
+++ b/source/platforms/git/gitJSONToGitDSL.ts
@@ -6,7 +6,7 @@ import isobject from "lodash.isobject"
 import keys from "lodash.keys"
 import memoize from "lodash.memoize"
 
-import * as jsonDiff from "rfc6902"
+import * as jsonDiff from "fast-json-patch"
 import jsonpointer from "jsonpointer"
 import JSON5 from "json5"
 
@@ -88,7 +88,7 @@ export const gitJSONToGitDSL = (gitJSONRep: GitJSONDSL, config: GitJSONToGitDSLC
     return {
       before: baseFile === "" ? null : baseJSON,
       after: headFile === "" ? null : headJSON,
-      diff: jsonDiff.createPatch(baseJSON, headJSON) as JSONPatchOperation[],
+      diff: jsonDiff.compare(baseJSON, headJSON) as JSONPatchOperation[],
     }
   }
 

--- a/source/platforms/github/_tests/_github_git.test.ts
+++ b/source/platforms/github/_tests/_github_git.test.ts
@@ -222,7 +222,7 @@ describe("the dangerfile gitDSL", () => {
       expect(empty).toEqual({
         before: before,
         after: null,
-        diff: [{ op: "remove", path: "/a" }, { op: "remove", path: "/b" }, { op: "remove", path: "/c" }],
+        diff: [{ op: "remove", path: "/c" }, { op: "remove", path: "/b" }, { op: "remove", path: "/a" }],
       })
     })
 
@@ -251,9 +251,9 @@ describe("the dangerfile gitDSL", () => {
         before,
         after,
         diff: [
-          { op: "replace", path: "/a", value: "o, world" },
+          { op: "add", path: "/c/3", value: "four" },
           { op: "replace", path: "/b", value: 3 },
-          { op: "add", path: "/c/-", value: "four" },
+          { op: "replace", path: "/a", value: "o, world" },
         ],
       })
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3892,6 +3892,11 @@ fast-glob@^3.0.3:
     merge2 "^1.3.0"
     micromatch "^4.0.2"
 
+fast-json-patch@^3.0.0-1:
+  version "3.0.0-1"
+  resolved "https://registry.yarnpkg.com/fast-json-patch/-/fast-json-patch-3.0.0-1.tgz#4c68f2e7acfbab6d29d1719c44be51899c93dabb"
+  integrity sha512-6pdFb07cknxvPzCeLsFHStEy+MysPJPgZQ9LbQ/2O67unQF93SNqfdSqnPPl71YMHX+AD8gbl7iuoGFzHEdDuw==
+
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -8341,11 +8346,6 @@ reusify@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
-
-rfc6902@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/rfc6902/-/rfc6902-3.0.1.tgz#03a3d38329dbc266fbc92aa7fc14546d7839e89f"
-  integrity sha512-a4t5OlaOgAejBg48/lkyQMcV6EWpljjSjmXAtSXLhw83x1OhlcVGLMLf//GoUSpHsWt8x/7oxaf5FEGM9QH/iQ==
 
 right-align@^0.1.1:
   version "0.1.3"


### PR DESCRIPTION
I've done some digging into #985 and here's the outcome.

**Actual Issue**:
The issue seems to be in the algorithm that the `rfc6902` library is using for Arrays. Since it's recursive it will run out of memory when it encounters an array that is too big. 

**Possible Solution**:
I found in this issue https://github.com/chbrown/rfc6902/issues/39 an alternative library (`fast-json-patch`) that could be used. It seems to work against my use case and according to [these benchmarks](https://github.com/Starcounter-Jack/JSON-Patch#performance) it should be significantly more performant.

**Breaking Change**:
As you can see in the updated tests, there are two changes to the output format compared to the other implementation:
1. Order of operations is different
2. `path` for insertions in arrays ends with new index of item instead of `-`. For example: `/pixels/99` instead of `/pixels/-`. I checked the actual standard and this behavior seems to be up to the actual standard: https://tools.ietf.org/html/rfc6902#appendix-A.2

Let me know what you think.