### PR TITLE
Use pagination when fetching existing labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ x
 <!-- Your comment below this -->
 
 - Pass process arguments back to the original process [@f-meloni]
+- When fetching existing labels in `createOrAddLabel` use pagination to fetch them all - [@sogame]
 
 <!-- Your comment above this -->
 

--- a/source/platforms/github/GitHubUtils.ts
+++ b/source/platforms/github/GitHubUtils.ts
@@ -194,8 +194,8 @@ export const createOrAddLabel = (pr: GitHubPRDSL | undefined, api: GitHub) => as
   d("Checking for existing labels")
   let label: any = null
   try {
-    const existingLabels = await api.issues.listLabelsForRepo({ owner: config.owner, repo: config.repo })
-    label = existingLabels.data.find((l: any) => l.name == labelConfig.name)
+    const existingLabels = await api.paginate('GET /repos/:owner/:repo/labels', { owner: config.owner, repo: config.repo })
+    label = existingLabels.find((l: any) => l.name == labelConfig.name)
   } catch (e) {
     d("api.issues.getLabels gave an error", e)
   }


### PR DESCRIPTION
`listLabelsForRepo` has a limit of 100 items, that means that if a repo has more than 100 labels using `createOrAddLabel` can try to create an already existing label.

This PR replaces `listLabelsForRepo` with an endpoint request following all pages.