### PR TITLE
adding bamboo support (working with bitbucket server)

### DIFF
--- a/source/ci_source/providers/Bamboo.ts
+++ b/source/ci_source/providers/Bamboo.ts
@@ -1,0 +1,63 @@
+import { Env, CISource } from "../ci_source"
+import { ensureEnvKeysExist, ensureEnvKeysAreInt } from "../ci_source_helpers"
+
+/**
+ * ### CI Setup
+ *
+ * Install dependencies and add a danger step to your `bitbucket-pipelines.yml`.
+ * For improving the performance, you may need to cache `node_modules`.
+ *
+ * ```yml
+ * image: node:10.15.0
+ * pipelines:
+ *   pull-requests:
+ *     "**":
+ *       - step:
+ *           caches:
+ *             - node
+ *           script:
+ *             - export LANG="C.UTF-8"
+ *             - yarn install
+ *             - yarn danger ci
+ * definitions:
+ *   caches:
+ *     node: node_modules
+ * ```
+ *
+ * ### Token Setup
+ *
+ * You can either add `DANGER_BITBUCKETCLOUD_USERNAME`, `DANGER_BITBUCKETCLOUD_PASSWORD`
+ * or add `DANGER_BITBUCKETCLOUD_OAUTH_KEY`, `DANGER_BITBUCKETCLOUD_OAUTH_SECRET`
+ * -
+ */
+
+export class Bamboo implements CISource {
+  constructor(private readonly env: Env) {}
+
+  get name(): string {
+    return "bamboo"
+  }
+
+  get isCI(): boolean {
+    return ensureEnvKeysExist(this.env, ["bamboo_buildPlanName", "bamboo_planRepository_repositoryUrl"])
+  }
+
+  get isPR(): boolean {
+    const mustHave = ["bamboo_inject_prId", "bamboo_planRepository_repositoryUrl", "bamboo_buildPlanName"]
+    const mustBeInts = ["bamboo_inject_prId"]
+    return ensureEnvKeysExist(this.env, mustHave) && ensureEnvKeysAreInt(this.env, mustBeInts)
+  }
+
+  get pullRequestID(): string {
+    return `${this.env.bamboo_inject_prId}`
+  }
+
+  get repoSlug(): string {
+    //ssh://git@bt01.cliplister.com:7999/clfr30/bc3_complete.git
+    // bamboo_inject_slug="projects/CLFR30/repos/bc3_complete" \
+
+    const [, project, slug] = this.env.bamboo_planRepository_repositoryUrl.match(/\/(\w+)\/(\w+(?:.git)?)$/)
+
+    return `projects/${project}/repos/${slug.replace(/\.[^.]+$/, "")}`
+  }
+}

--- a/source/ci_source/providers/_tests/_bamboo.test.ts
+++ b/source/ci_source/providers/_tests/_bamboo.test.ts
@@ -1,0 +1,70 @@
+import { Bamboo } from "../Bamboo"
+import { getCISourceForEnv } from "../../get_ci_source"
+
+const correctEnv = {
+  bamboo_buildPlanName: "My Build Plan",
+  bamboo_inject_prId: "1234",
+  bamboo_planRepository_repositoryUrl: "ssh://git@bitbucket.mycompany.com:7999/my_project/my_repository.git",
+}
+
+describe("being found when looking for CI", () => {
+  it("finds Bamboo with the right ENV", () => {
+    const ci = getCISourceForEnv(correctEnv)
+    expect(ci).toBeInstanceOf(Bamboo)
+  })
+})
+
+describe(".isCI", () => {
+  it("validates when all Bamboo environment vars are set", () => {
+    const pipelines = new Bamboo(correctEnv)
+    expect(pipelines.isCI).toBeTruthy()
+  })
+
+  it("does not validate without josh", () => {
+    const pipelines = new Bamboo({})
+    expect(pipelines.isCI).toBeFalsy()
+  })
+})
+
+describe(".isPR", () => {
+  it("validates when all Bamboo environment vars are set", () => {
+    const pipelines = new Bamboo(correctEnv)
+    expect(pipelines.isPR).toBeTruthy()
+  })
+
+  it("does not validate outside of Bamboo", () => {
+    const pipelines = new Bamboo({})
+    expect(pipelines.isPR).toBeFalsy()
+  })
+
+  Object.keys(correctEnv).forEach((key: string) => {
+    let env = Object.assign({}, correctEnv)
+    env[key] = null
+
+    it(`does not validate when ${key} is missing`, () => {
+      const pipelines = new Bamboo(env)
+      expect(pipelines.isPR).toBeFalsy()
+    })
+
+    it("needs to have a PR number", () => {
+      let env = Object.assign({}, correctEnv)
+      delete env["bamboo_inject_prId"]
+      const pipelines = new Bamboo(env)
+      expect(pipelines.isPR).toBeFalsy()
+    })
+  })
+})
+
+describe(".pullRequestID", () => {
+  it("pulls it out of the env", () => {
+    const pipelines = new Bamboo({ bamboo_inject_prId: "800" })
+    expect(pipelines.pullRequestID).toEqual("800")
+  })
+})
+
+describe(".repoSlug", () => {
+  it("derives it from the PR Url", () => {
+    const pipelines = new Bamboo(correctEnv)
+    expect(pipelines.repoSlug).toEqual("projects/my_project/repos/my_repository")
+  })
+})

--- a/source/ci_source/providers/index.ts
+++ b/source/ci_source/providers/index.ts
@@ -1,4 +1,5 @@
 import { AppCenter } from "./AppCenter"
+import { Bamboo } from "./Bamboo"
 import { Bitrise } from "./Bitrise"
 import { BuddyBuild } from "./BuddyBuild"
 import { BuddyWorks } from "./BuddyWorks"
@@ -52,6 +53,7 @@ const providers = [
   AppCenter,
   BitbucketPipelines,
   Cirrus,
+  Bamboo,
 ]
 
 // Mainly used for Dangerfile linting
@@ -78,7 +80,8 @@ const realProviders = [
   CodeBuild,
   Codefresh,
   AppCenter,
-  Cirrus
+  Cirrus,
+  Bamboo,
 ]
 
 export { providers, realProviders }


### PR DESCRIPTION
In the absence of repository systems beside bitbucket i could not validate the regex used for getting the repository slug (looks like it should work with github as well)