### PR TITLE
fix: replace regex to a long url repos approach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ x
 ## Master
 
 <!-- Your comment below this -->
-
+- Replace regex to a long url repos approach on Bitrise [@lucasmpaim]
 - Pass process arguments back to the original process [@f-meloni]
 - When fetching existing labels in `createOrAddLabel` use pagination to fetch them all - [@sogame]
 

--- a/source/ci_source/providers/Bitrise.ts
+++ b/source/ci_source/providers/Bitrise.ts
@@ -58,9 +58,8 @@ export class Bitrise implements CISource {
 
   private _parseRepoURL(): string {
     const repoURL = this.env.GIT_REPOSITORY_URL
-    const regexp = new RegExp("([/:])([^/]+/[^/.]+)(?:.git)?$")
-    const matches = repoURL.match(regexp)
-    return matches ? matches[2] : ""
+    let regexp = repoURL.startsWith("git") ? /(.+):/ : /^http(s):\/\/(www[0-9]?\.)?(.[^/:]+)\//
+    return repoURL.replace(regexp, "").replace(/.git$/, "")
   }
 
   get pullRequestID(): string {

--- a/source/ci_source/providers/_tests/_bitrise.test.ts
+++ b/source/ci_source/providers/_tests/_bitrise.test.ts
@@ -72,6 +72,24 @@ describe(".repoSlug", () => {
     const bitrise = new Bitrise(env)
     expect(bitrise.repoSlug).toEqual("artsy/eigen")
   })
+
+  it("derives it from a long URL format", () => {
+    const env = {
+      ...correctEnv,
+      GIT_REPOSITORY_URL: "https://github.com/organization/project/subproject/repo.git",
+    }
+    const bitrise = new Bitrise(env)
+    expect(bitrise.repoSlug).toEqual("organization/project/subproject/repo")
+  })
+
+  it("derives it from a long SSH format", () => {
+    const env = {
+      ...correctEnv,
+      GIT_REPOSITORY_URL: "git@github.com:organization/project/subproject/repo.git",
+    }
+    const bitrise = new Bitrise(env)
+    expect(bitrise.repoSlug).toEqual("organization/project/subproject/repo")
+  })
 })
 
 describe("commit hash", () => {


### PR DESCRIPTION
My repository URL have a long url, the current approach get a wrong repo name, that consider only the last 2 parts of url, like:

"https://github.com/artsy/eigen" => "artsy/eigen" => OK
"git@github.com:artsy/eigen.git" => "artsy/eigen" => OK
"https://github.com/organization/project/subproject/repo.git" => "subproject/repo" => wrong

When we have more than 2 levels to repository, this get a wrong `repoSlug` (this is possible on some git servers like: gitlab).
