### PR TITLE
Fix project path with /- in GitLab MR URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ x
 
 <!-- Your comment below this -->
 
-<!-- Your comment above this -->
+- Fix project path with /- in GitLab MR URL [@pgoudreau]
+  <!-- Your comment above this -->
 
 # 10.1.0
 

--- a/source/platforms/_tests/_pull_request_parser.test.ts
+++ b/source/platforms/_tests/_pull_request_parser.test.ts
@@ -108,6 +108,60 @@ describe("parsing urls", () => {
         })
       })
     })
+
+    describe("with /-", () => {
+      describe(".com", () => {
+        it("handles PRs-", () => {
+          expect(pullRequestParser("https://gitlab.com/GROUP/PROJ/-/merge_requests/123")).toEqual({
+            pullRequestNumber: "123",
+            repo: "GROUP/PROJ",
+            platform: "GitLab",
+          })
+        })
+
+        it("handles PRs sub-pages-", () => {
+          expect(pullRequestParser("https://gitlab.com/GROUP/PROJ/-/merge_requests/123/commits")).toEqual({
+            pullRequestNumber: "123",
+            repo: "GROUP/PROJ",
+            platform: "GitLab",
+          })
+        })
+
+        it("handles sub-groups", () => {
+          expect(pullRequestParser("https://gitlab.com/GROUP/SUBGROUP/PROJ/-/merge_requests/123")).toEqual({
+            pullRequestNumber: "123",
+            repo: "GROUP/SUBGROUP/PROJ",
+            platform: "GitLab",
+          })
+        })
+      })
+
+      describe("CE/EE", () => {
+        it("handles PRs", () => {
+          expect(pullRequestParser("https://localdomain/GROUP/PROJ/-/merge_requests/123")).toEqual({
+            pullRequestNumber: "123",
+            repo: "GROUP/PROJ",
+            platform: "GitLab",
+          })
+        })
+
+        it("handles PRs sub-pages", () => {
+          expect(pullRequestParser("https://localdomain/GROUP/PROJ/-/merge_requests/123/commits")).toEqual({
+            pullRequestNumber: "123",
+            repo: "GROUP/PROJ",
+            platform: "GitLab",
+          })
+        })
+
+        it("handles sub-groups", () => {
+          expect(pullRequestParser("https://localdomain/GROUP/SUBGROUP/PROJ/-/merge_requests/123")).toEqual({
+            pullRequestNumber: "123",
+            repo: "GROUP/SUBGROUP/PROJ",
+            platform: "GitLab",
+          })
+        })
+      })
+    })
   })
 
   describe("Bitbucket Cloud", () => {

--- a/source/platforms/pullRequestParser.ts
+++ b/source/platforms/pullRequestParser.ts
@@ -50,7 +50,7 @@ export function pullRequestParser(address: string): PullRequestParts | null {
       if (parts) {
         return {
           platform: GitLab.name,
-          repo: parts[1],
+          repo: parts[1].replace(/\/-$/, ""),
           pullRequestNumber: parts[2],
         }
       }


### PR DESCRIPTION
I ran into the same problem using danger with GitLab so I tried to use a non-capturing group in the regex but the repo group is too generic and ended up using replace.
fixes #1028