### PR TITLE
Add description when creating a pr with "createOrUpdatePR"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ x
 <!-- Your comment below this -->
 
 - Fix project path with /- in GitLab MR URL [@pgoudreau]
+- When creating a new PR with `createOrUpdatePR`, add the description (as done when editing) - [@sogame]
   <!-- Your comment above this -->
 
 # 10.1.0

--- a/source/platforms/github/GitHubUtils.ts
+++ b/source/platforms/github/GitHubUtils.ts
@@ -176,6 +176,7 @@ export const createOrUpdatePR = (pr: GitHubPRDSL | undefined, api: GitHub) => as
       owner,
       repo,
       title: config.title,
+      body: config.body,
     })
   }
 }


### PR DESCRIPTION
When updating the PR, the description is set correctly: https://github.com/danger/danger-js/blob/cad36b66045c54505ef42611e26c86e2bc64eccf/source/platforms/github/GitHubUtils.ts#L169

But it's missing when creating the PR.