### PR TITLE
Take commit hash from CircleCI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ x
 
 <!-- Your comment below this -->
 
+- Take commit hash from CircleCI environment variable [@valscion]
 - Fix project path with /- in GitLab MR URL [@pgoudreau]
 - When creating a new PR with `createOrUpdatePR`, add the description (as done when editing) - [@sogame]
   <!-- Your comment above this -->

--- a/source/ci_source/providers/Circle.ts
+++ b/source/ci_source/providers/Circle.ts
@@ -96,4 +96,8 @@ export class Circle implements CISource {
   get ciRunURL() {
     return this.env["CIRCLE_BUILD_URL"]
   }
+
+  get commitHash(): string {
+    return this.env.CIRCLE_SHA1
+  }
 }

--- a/source/ci_source/providers/_tests/_circle.test.ts
+++ b/source/ci_source/providers/_tests/_circle.test.ts
@@ -97,3 +97,19 @@ describe(".repoSlug", () => {
     expect(circle.repoSlug).toEqual("artsy/eigen")
   })
 })
+
+describe("commit hash", () => {
+  it("returns correct commit hash when present", () => {
+    const env = {
+      ...correctEnv,
+      CIRCLE_SHA1: "1234abc",
+    }
+    const circle = new Circle(env)
+    expect(circle.commitHash).toEqual("1234abc")
+  })
+
+  it("returns no commit hash when not present", () => {
+    const circle = new Circle(correctEnv)
+    expect(circle.commitHash).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Similar to the support of Jenkins commit hash:

https://github.com/danger/danger-js/blob/f58ee856fd7610c84a4d768d79bd063c2e78bc44/source/ci_source/providers/Jenkins.ts#L85-L87

https://github.com/danger/danger-js/blob/f58ee856fd7610c84a4d768d79bd063c2e78bc44/source/ci_source/providers/_tests/_jenkins.test.ts#L113-L127


Fixes the same problem as fixed in #905 but for CircleCI:

> Danger doesn't currently have a way to understand on which commit is
> running. To get the current commit it asks to the platform the list of
> commits on the PR and assumes that is running on the last one. This
> creates few problems when you push a new commit before Danger runs on
> the CI for the previous commit, because it will assume is running on
> the last one, but that is actually not true, and that means that both
> the status update and the commit hash in the Danger comment signature
> will be wrong.

From the CircleCI docs, `CIRCLE_SHA1` should be the correct environment variable: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables

> `CIRCLE_SHA1` — `String` — The SHA1 hash of the last commit of the current build.
