### PR TITLE
Fix: BitBucketServer does not encode filepath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ x
 
 <!-- Your comment below this -->
 
+- Fix danger failure on getting diff for files with spaces in file path [@HonzaMac]
+
 <!-- Your comment above this -->
 
 # 10.2.0

--- a/source/platforms/bitbucket_server/BitBucketServerAPI.ts
+++ b/source/platforms/bitbucket_server/BitBucketServerAPI.ts
@@ -134,7 +134,9 @@ export class BitBucketServerAPI implements BitBucketServerAPIDSL {
 
   getStructuredDiffForFile = async (base: string, head: string, filename: string): Promise<BitBucketServerDiff[]> => {
     const { repoSlug } = this.repoMetadata
-    const path = `rest/api/1.0/${repoSlug}/compare/diff/${filename}?withComments=false&from=${head}&to=${base}`
+    const path = `rest/api/1.0/${repoSlug}/compare/diff/${encodeURI(
+      filename
+    )}?withComments=false&from=${head}&to=${base}`
     const res = await this.get(path)
     throwIfNotOk(res)
     return (await res.json()).diffs
@@ -241,7 +243,7 @@ export class BitBucketServerAPI implements BitBucketServerAPIDSL {
 
   // The last two are "optional" in the protocol, but not really optional WRT the BBSAPI
   getFileContents = async (filePath: string, repoSlug?: string, refspec?: string) => {
-    const path = `rest/api/1.0/${repoSlug}/` + `raw/${filePath}` + `?at=${refspec}`
+    const path = `rest/api/1.0/${repoSlug}/` + `raw/${encodeURI(filePath)}` + `?at=${refspec}`
     const res = await this.get(path, undefined, true)
     if (res.status === 404) {
       return ""

--- a/source/platforms/bitbucket_server/_tests/_bitbucket_server_api.test.ts
+++ b/source/platforms/bitbucket_server/_tests/_bitbucket_server_api.test.ts
@@ -78,11 +78,11 @@ describe("API testing - BitBucket Server", () => {
 
   it("getStructuredDiffForFile", async () => {
     jsonResult = () => ({ diffs: ["diff"] })
-    const result = await api.getStructuredDiffForFile("BASE", "HEAD", "filename.txt")
+    const result = await api.getStructuredDiffForFile("BASE", "HEAD", "path with space/filename.txt")
 
     expect(api.fetch).toHaveBeenCalledWith(
       `${host}/rest/api/1.0/projects/FOO/repos/BAR/compare/diff/` +
-        `filename.txt` +
+        `path%20with%20space/filename.txt` +
         `?withComments=false&from=HEAD&to=BASE`,
       { method: "GET", body: null, headers: expectedJSONHeaders },
       undefined
@@ -272,10 +272,10 @@ describe("API testing - BitBucket Server", () => {
 
   it("getFileContents", async () => {
     textResult = "contents..."
-    const result = await api.getFileContents("path/to/foo.txt", "projects/FOO/repos/BAR", "master")
+    const result = await api.getFileContents("path/folder with space/foo.txt", "projects/FOO/repos/BAR", "master")
 
     expect(api.fetch).toHaveBeenCalledWith(
-      `${host}/rest/api/1.0/projects/FOO/repos/BAR/raw/path/to/foo.txt?at=master`,
+      `${host}/rest/api/1.0/projects/FOO/repos/BAR/raw/path/folder%20with%20space/foo.txt?at=master`,
       { method: "GET", body: null, headers: expectedJSONHeaders },
       true
     )


### PR DESCRIPTION
Escaping filePath/filename when asking for diff on bitbucket server.

Fixes #1036