### PR TITLE
ignoreInvalidInlineComments - new option to not post invalid-inline-c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 <!-- Your comment below this -->
 
 - Added a CLI option `--noOutOfDiffComments` so that you can ignore inline-comments for lines that were not changed in
-  this PR. The comments would be ignored completely - they won't even show in the results comment. [@pinkasey]
+  the checked PR. The comments would be ignored completely - they won't even show in the results comment. [@pinkasey]
 
 <!-- Your comment above this -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@
 
 <!-- Your comment below this -->
 
-- Added a CLI option `--noOutOfDiffComments` so that you can ignore inline-comments for lines that were not changed in
-  the checked PR. The comments would be ignored completely - they won't even show in the results comment. [@pinkasey]
+- Added a CLI option `--ignoreOutOfDiffComments` so that you can ignore inline-comments for lines that were not changed
+  in the checked PR. The comments would be ignored completely - they won't even show in the results comment. [@pinkasey]
 
 <!-- Your comment above this -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 
 <!-- Your comment below this -->
 
+- Added a CLI option `--ignoreInvalidInlineComments` so that you can ignore inline-comments for invalid lines (e.g
+  unchanged lines). the comment would be ignored completely - it won't even show in the results commit. [@pinkasey]
+
 <!-- Your comment above this -->
 
 # 10.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@
 
 <!-- Your comment below this -->
 
-- Added a CLI option `--ignoreInvalidInlineComments` so that you can ignore inline-comments for invalid lines (e.g
-  unchanged lines). The comment would be ignored completely - it won't even show in the results commit. [@pinkasey]
+- Added a CLI option `--noOutOfDiffComments` so that you can ignore inline-comments for lines that were not changed in
+  this PR. The comments would be ignored completely - they won't even show in the results comment. [@pinkasey]
 
 <!-- Your comment above this -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 <!-- Your comment below this -->
 
 - Added a CLI option `--ignoreInvalidInlineComments` so that you can ignore inline-comments for invalid lines (e.g
-  unchanged lines). the comment would be ignored completely - it won't even show in the results commit. [@pinkasey]
+  unchanged lines). The comment would be ignored completely - it won't even show in the results commit. [@pinkasey]
 
 <!-- Your comment above this -->
 

--- a/source/commands/ci/runner.ts
+++ b/source/commands/ci/runner.ts
@@ -68,7 +68,7 @@ export const runRunner = async (app: SharedCLI, config?: Partial<RunnerConfig>) 
         disableGitHubChecksSupport: !app.useGithubChecks,
         failOnErrors: app.failOnErrors,
         noPublishCheck: !app.publishCheck,
-        ignoreInvalidInlineComments: app.ignoreInvalidInlineComments,
+        noOutOfDiffComments: app.noOutOfDiffComments,
       }
 
       const processName = (app.process && addSubprocessCallAguments(app.process.split(" "))) || undefined

--- a/source/commands/ci/runner.ts
+++ b/source/commands/ci/runner.ts
@@ -68,6 +68,7 @@ export const runRunner = async (app: SharedCLI, config?: Partial<RunnerConfig>) 
         disableGitHubChecksSupport: !app.useGithubChecks,
         failOnErrors: app.failOnErrors,
         noPublishCheck: !app.publishCheck,
+        ignoreInvalidInlineComments: app.ignoreInvalidInlineComments,
       }
 
       const processName = (app.process && addSubprocessCallAguments(app.process.split(" "))) || undefined

--- a/source/commands/ci/runner.ts
+++ b/source/commands/ci/runner.ts
@@ -68,7 +68,7 @@ export const runRunner = async (app: SharedCLI, config?: Partial<RunnerConfig>) 
         disableGitHubChecksSupport: !app.useGithubChecks,
         failOnErrors: app.failOnErrors,
         noPublishCheck: !app.publishCheck,
-        noOutOfDiffComments: app.noOutOfDiffComments,
+        ignoreOutOfDiffComments: app.ignoreOutOfDiffComments,
       }
 
       const processName = (app.process && addSubprocessCallAguments(app.process.split(" "))) || undefined

--- a/source/commands/danger-process.ts
+++ b/source/commands/danger-process.ts
@@ -95,7 +95,7 @@ getRuntimeCISource(app).then(source => {
             passURLForDSL: app.passURLForDSL || false,
             disableGitHubChecksSupport: !app.useGithubChecks,
             failOnErrors: app.failOnErrors,
-            ignoreInvalidInlineComments: app.ignoreInvalidInlineComments,
+            noOutOfDiffComments: app.noOutOfDiffComments,
           }
 
           d("Exec config: ", execConfig)

--- a/source/commands/danger-process.ts
+++ b/source/commands/danger-process.ts
@@ -95,6 +95,7 @@ getRuntimeCISource(app).then(source => {
             passURLForDSL: app.passURLForDSL || false,
             disableGitHubChecksSupport: !app.useGithubChecks,
             failOnErrors: app.failOnErrors,
+            ignoreInvalidInlineComments: app.ignoreInvalidInlineComments,
           }
 
           d("Exec config: ", execConfig)

--- a/source/commands/danger-process.ts
+++ b/source/commands/danger-process.ts
@@ -95,7 +95,7 @@ getRuntimeCISource(app).then(source => {
             passURLForDSL: app.passURLForDSL || false,
             disableGitHubChecksSupport: !app.useGithubChecks,
             failOnErrors: app.failOnErrors,
-            noOutOfDiffComments: app.noOutOfDiffComments,
+            ignoreOutOfDiffComments: app.ignoreOutOfDiffComments,
           }
 
           d("Exec config: ", execConfig)

--- a/source/commands/utils/sharedDangerfileArgs.ts
+++ b/source/commands/utils/sharedDangerfileArgs.ts
@@ -28,7 +28,7 @@ export interface SharedCLI extends program.CommanderStatic {
   /** Use GitHub Checks */
   useGithubChecks: boolean
   /** Ignore inline-comments that are in lines which were not changed */
-  noOutOfDiffComments: boolean
+  ignoreOutOfDiffComments: boolean
 }
 
 export default (command: any) =>
@@ -45,4 +45,4 @@ export default (command: any) =>
     .option("-u, --passURLForDSL", "[dev] Use a custom URL to send the Danger DSL into the sub-process")
     .option("-f, --failOnErrors", "Fail if there are fails in the danger report", false)
     .option("--use-github-checks", "Use GitHub Checks", false)
-    .option("--noOutOfDiffComments", "Ignore inline-comments that are in lines which were not changed", false)
+    .option("--ignoreOutOfDiffComments", "Ignore inline-comments that are in lines which were not changed", false)

--- a/source/commands/utils/sharedDangerfileArgs.ts
+++ b/source/commands/utils/sharedDangerfileArgs.ts
@@ -27,7 +27,7 @@ export interface SharedCLI extends program.CommanderStatic {
   failOnErrors: boolean
   /** Use GitHub Checks */
   useGithubChecks: boolean
-  /** Ignore Inline-Comments where the specified line was not changed */
+  /** Ignore invalid inline-comments, for instance a comment with a line that was not changed */
   ignoreInvalidInlineComments: boolean
 }
 
@@ -45,3 +45,8 @@ export default (command: any) =>
     .option("-u, --passURLForDSL", "[dev] Use a custom URL to send the Danger DSL into the sub-process")
     .option("-f, --failOnErrors", "Fail if there are fails in the danger report", false)
     .option("--use-github-checks", "Use GitHub Checks", false)
+    .option(
+      "-iiic, --ignoreInvalidInlineComments",
+      "Ignore invalid inline-comments, for instance a comment with a line that was not changed",
+      false
+    )

--- a/source/commands/utils/sharedDangerfileArgs.ts
+++ b/source/commands/utils/sharedDangerfileArgs.ts
@@ -28,7 +28,7 @@ export interface SharedCLI extends program.CommanderStatic {
   /** Use GitHub Checks */
   useGithubChecks: boolean
   /** Ignore invalid inline-comments, for instance a comment with a line that was not changed */
-  ignoreInvalidInlineComments: boolean
+  noOutOfDiffComments: boolean
 }
 
 export default (command: any) =>
@@ -46,7 +46,7 @@ export default (command: any) =>
     .option("-f, --failOnErrors", "Fail if there are fails in the danger report", false)
     .option("--use-github-checks", "Use GitHub Checks", false)
     .option(
-      "-iiic, --ignoreInvalidInlineComments",
+      "--noOutOfDiffComments",
       "Ignore invalid inline-comments, for instance a comment with a line that was not changed",
       false
     )

--- a/source/commands/utils/sharedDangerfileArgs.ts
+++ b/source/commands/utils/sharedDangerfileArgs.ts
@@ -27,6 +27,8 @@ export interface SharedCLI extends program.CommanderStatic {
   failOnErrors: boolean
   /** Use GitHub Checks */
   useGithubChecks: boolean
+  /** Ignore Inline-Comments where the specified line was not changed */
+  ignoreInvalidInlineComments: boolean
 }
 
 export default (command: any) =>

--- a/source/commands/utils/sharedDangerfileArgs.ts
+++ b/source/commands/utils/sharedDangerfileArgs.ts
@@ -27,7 +27,7 @@ export interface SharedCLI extends program.CommanderStatic {
   failOnErrors: boolean
   /** Use GitHub Checks */
   useGithubChecks: boolean
-  /** Ignore invalid inline-comments, for instance a comment with a line that was not changed */
+  /** Ignore inline-comments that are in lines which were not changed */
   noOutOfDiffComments: boolean
 }
 
@@ -45,8 +45,4 @@ export default (command: any) =>
     .option("-u, --passURLForDSL", "[dev] Use a custom URL to send the Danger DSL into the sub-process")
     .option("-f, --failOnErrors", "Fail if there are fails in the danger report", false)
     .option("--use-github-checks", "Use GitHub Checks", false)
-    .option(
-      "--noOutOfDiffComments",
-      "Ignore invalid inline-comments, for instance a comment with a line that was not changed",
-      false
-    )
+    .option("--noOutOfDiffComments", "Ignore inline-comments that are in lines which were not changed", false)

--- a/source/runner/Executor.ts
+++ b/source/runner/Executor.ts
@@ -58,6 +58,8 @@ export interface ExecutorOptions {
   failOnErrors?: boolean
   /** Dont add danger check to PR */
   noPublishCheck?: boolean
+  /** Ignore Inline-Comments where the specified line was not changed */
+  ignoreInvalidInlineComments: boolean
 }
 // This is still badly named, maybe it really should just be runner?
 
@@ -277,7 +279,8 @@ export class Executor {
       if (git !== undefined) {
         const previousComments = await this.platform.getInlineComments(dangerID)
         const inline = inlineResults(results)
-        const inlineLeftovers = await this.sendInlineComments(inline, git, previousComments)
+        let inlineLeftovers = await this.sendInlineComments(inline, git, previousComments)
+        inlineLeftovers = this.options.ignoreInvalidInlineComments ? emptyDangerResults : inlineLeftovers
         mergedResults = sortResults(mergeResults(mergedResults, inlineLeftovers))
       }
 

--- a/source/runner/Executor.ts
+++ b/source/runner/Executor.ts
@@ -59,7 +59,7 @@ export interface ExecutorOptions {
   /** Dont add danger check to PR */
   noPublishCheck?: boolean
   /** Ignore inline-comments that are in lines which were not changed */
-  noOutOfDiffComments: boolean
+  ignoreOutOfDiffComments: boolean
 }
 // This is still badly named, maybe it really should just be runner?
 
@@ -280,7 +280,7 @@ export class Executor {
         const previousComments = await this.platform.getInlineComments(dangerID)
         const inline = inlineResults(results)
         let inlineLeftovers = await this.sendInlineComments(inline, git, previousComments)
-        inlineLeftovers = this.options.noOutOfDiffComments ? emptyDangerResults : inlineLeftovers
+        inlineLeftovers = this.options.ignoreOutOfDiffComments ? emptyDangerResults : inlineLeftovers
         mergedResults = sortResults(mergeResults(mergedResults, inlineLeftovers))
       }
 

--- a/source/runner/Executor.ts
+++ b/source/runner/Executor.ts
@@ -58,7 +58,7 @@ export interface ExecutorOptions {
   failOnErrors?: boolean
   /** Dont add danger check to PR */
   noPublishCheck?: boolean
-  /** Ignore Inline-Comments where the specified line was not changed */
+  /** Ignore invalid inline-comments, for instance a comment with a line that was not changed */
   ignoreInvalidInlineComments: boolean
 }
 // This is still badly named, maybe it really should just be runner?

--- a/source/runner/Executor.ts
+++ b/source/runner/Executor.ts
@@ -58,7 +58,7 @@ export interface ExecutorOptions {
   failOnErrors?: boolean
   /** Dont add danger check to PR */
   noPublishCheck?: boolean
-  /** Ignore invalid inline-comments, for instance a comment with a line that was not changed */
+  /** Ignore inline-comments that are in lines which were not changed */
   noOutOfDiffComments: boolean
 }
 // This is still badly named, maybe it really should just be runner?

--- a/source/runner/Executor.ts
+++ b/source/runner/Executor.ts
@@ -59,7 +59,7 @@ export interface ExecutorOptions {
   /** Dont add danger check to PR */
   noPublishCheck?: boolean
   /** Ignore invalid inline-comments, for instance a comment with a line that was not changed */
-  ignoreInvalidInlineComments: boolean
+  noOutOfDiffComments: boolean
 }
 // This is still badly named, maybe it really should just be runner?
 
@@ -280,7 +280,7 @@ export class Executor {
         const previousComments = await this.platform.getInlineComments(dangerID)
         const inline = inlineResults(results)
         let inlineLeftovers = await this.sendInlineComments(inline, git, previousComments)
-        inlineLeftovers = this.options.ignoreInvalidInlineComments ? emptyDangerResults : inlineLeftovers
+        inlineLeftovers = this.options.noOutOfDiffComments ? emptyDangerResults : inlineLeftovers
         mergedResults = sortResults(mergeResults(mergedResults, inlineLeftovers))
       }
 

--- a/source/runner/_tests/_executor.test.ts
+++ b/source/runner/_tests/_executor.test.ts
@@ -27,7 +27,7 @@ const defaultConfig: ExecutorOptions = {
   passURLForDSL: false,
   failOnErrors: false,
   noPublishCheck: false,
-  ignoreInvalidInlineComments: false,
+  noOutOfDiffComments: false,
 }
 
 class FakeProcces {
@@ -121,7 +121,7 @@ describe("setup", () => {
       dangerID: "123",
       passURLForDSL: false,
       failOnErrors: true,
-      ignoreInvalidInlineComments: false,
+      noOutOfDiffComments: false,
     }
     const exec = new Executor(new FakeCI({}), platform, inlineRunner, strictConfig, new FakeProcces())
     const dsl = await defaultDsl(platform)
@@ -191,9 +191,9 @@ describe("setup", () => {
     expect(platform.createInlineComment).toBeCalled()
   })
 
-  it("Invalid inline comment is ignored if ignoreInvalidInlineComments is true", async () => {
+  it("Invalid inline comment is ignored if noOutOfDiffComments is true", async () => {
     const platform = new FakePlatform()
-    const config = Object.assign({}, defaultConfig, { ignoreInvalidInlineComments: true })
+    const config = Object.assign({}, defaultConfig, { noOutOfDiffComments: true })
     const exec = new Executor(new FakeCI({}), platform, inlineRunner, config, new FakeProcces())
     const dsl = await defaultDsl(platform)
     platform.createInlineComment = jest.fn().mockReturnValue(new Promise<any>((_, reject) => reject()))

--- a/source/runner/_tests/_executor.test.ts
+++ b/source/runner/_tests/_executor.test.ts
@@ -27,6 +27,7 @@ const defaultConfig: ExecutorOptions = {
   passURLForDSL: false,
   failOnErrors: false,
   noPublishCheck: false,
+  ignoreInvalidInlineComments: false,
 }
 
 class FakeProcces {
@@ -120,6 +121,7 @@ describe("setup", () => {
       dangerID: "123",
       passURLForDSL: false,
       failOnErrors: true,
+      ignoreInvalidInlineComments: false,
     }
     const exec = new Executor(new FakeCI({}), platform, inlineRunner, strictConfig, new FakeProcces())
     const dsl = await defaultDsl(platform)
@@ -172,9 +174,7 @@ describe("setup", () => {
     const platform = new FakePlatform()
     const exec = new Executor(new FakeCI({}), platform, inlineRunner, defaultConfig, new FakeProcces())
     const dsl = await defaultDsl(platform)
-    const apiFailureMock = jest.fn().mockReturnValue(
-      new Promise<any>((_, reject) => reject())
-    )
+    const apiFailureMock = jest.fn().mockReturnValue(new Promise<any>((_, reject) => reject()))
     platform.createInlineComment = apiFailureMock
 
     let results = await exec.sendInlineComments(singleViolationSingleFileResults, dsl.git, [])
@@ -270,10 +270,7 @@ describe("setup", () => {
     const dsl = await defaultDsl(platform)
     const previousResults = {
       fails: [],
-      warnings: [
-        { message: "1", file: "1.swift", line: 1 },
-        { message: "2", file: "2.swift", line: 2 },
-      ],
+      warnings: [{ message: "1", file: "1.swift", line: 1 }, { message: "2", file: "2.swift", line: 2 }],
       messages: [],
       markdowns: [],
     }
@@ -297,19 +294,13 @@ describe("setup", () => {
     const dsl = await defaultDsl(platform)
     const previousResults = {
       fails: [],
-      warnings: [
-        { message: "1", file: "1.swift", line: 1 },
-        { message: "2", file: "2.swift", line: 2 },
-      ],
+      warnings: [{ message: "1", file: "1.swift", line: 1 }, { message: "2", file: "2.swift", line: 2 }],
       messages: [],
       markdowns: [],
     }
     const newResults = {
       fails: [],
-      warnings: [
-        { message: "1", file: "1.swift", line: 2 },
-        { message: "2", file: "2.swift", line: 3 },
-      ],
+      warnings: [{ message: "1", file: "1.swift", line: 2 }, { message: "2", file: "2.swift", line: 3 }],
       messages: [],
       markdowns: [],
     }

--- a/source/runner/_tests/_executor.test.ts
+++ b/source/runner/_tests/_executor.test.ts
@@ -27,7 +27,7 @@ const defaultConfig: ExecutorOptions = {
   passURLForDSL: false,
   failOnErrors: false,
   noPublishCheck: false,
-  noOutOfDiffComments: false,
+  ignoreOutOfDiffComments: false,
 }
 
 class FakeProcces {
@@ -121,7 +121,7 @@ describe("setup", () => {
       dangerID: "123",
       passURLForDSL: false,
       failOnErrors: true,
-      noOutOfDiffComments: false,
+      ignoreOutOfDiffComments: false,
     }
     const exec = new Executor(new FakeCI({}), platform, inlineRunner, strictConfig, new FakeProcces())
     const dsl = await defaultDsl(platform)
@@ -191,9 +191,9 @@ describe("setup", () => {
     expect(platform.createInlineComment).toBeCalled()
   })
 
-  it("Invalid inline comment is ignored if noOutOfDiffComments is true", async () => {
+  it("Invalid inline comment is ignored if ignoreOutOfDiffComments is true", async () => {
     const platform = new FakePlatform()
-    const config = Object.assign({}, defaultConfig, { noOutOfDiffComments: true })
+    const config = Object.assign({}, defaultConfig, { ignoreOutOfDiffComments: true })
     const exec = new Executor(new FakeCI({}), platform, inlineRunner, config, new FakeProcces())
     const dsl = await defaultDsl(platform)
     platform.createInlineComment = jest.fn().mockReturnValue(new Promise<any>((_, reject) => reject()))


### PR DESCRIPTION
…omments in main results comment

**Motivation for this feature:**
My Dangerfile scans all changed files entirely*, and often finds warnings in lines that have not changed.
I want to ignore these warnings.
So I can do this in my own Dangerfile, but I thought this feature would be useful.
If you agree - I can add unit-tests.


\* My dangerfile runs a static analysis tool (detekt, for kotlin), and publishes the result. that's why it often finds warnings in unchanged lines.