### PR TITLE
Lookup tsconfig.json from location of dangerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 
 <!-- Your comment below this -->
 
+- Improved `tsconfig.json` file lookup strategy: it now looks for it starting from the location of the danger file.
+  #1068 [@igorbek](https://github.com/igorbek)
+
 <!-- Your comment above this -->
 
 # 10.3.1

--- a/source/runner/runners/utils/_tests/_transpiler.test.ts
+++ b/source/runner/runners/utils/_tests/_transpiler.test.ts
@@ -2,9 +2,14 @@ jest.mock("fs", () => ({
   readFileSync: jest.fn(),
   existsSync: jest.fn(),
 }))
+jest.mock("path", () => {
+  const path = jest.requireActual("path")
+  return { ...path, resolve: jest.fn(path.resolve) }
+})
 
-import { typescriptify } from "../transpiler"
+import { typescriptify, lookupTSConfig, dirContains } from "../transpiler"
 import * as fs from "fs"
+import * as path from "path"
 
 describe("typescriptify", () => {
   it("removes the module option in a tsconfig ", () => {
@@ -15,9 +20,50 @@ describe("typescriptify", () => {
         module: "es2015",
       },
     }
-    const fsMock = fs.readFileSync as any
+    const fsMock = fs.readFileSync as jest.Mock
     fsMock.mockImplementationOnce(() => JSON.stringify(fakeTSConfig))
 
-    expect(typescriptify(dangerfile)).not.toContain("import")
+    expect(typescriptify(dangerfile, "/a/b")).not.toContain("import")
+  })
+})
+
+describe("lookupTSConfig", () => {
+  function setup(cwd: string, configDir: string) {
+    // mock path.resolve to be relative to cwd
+    const actualPath = jest.requireActual("path") as typeof path
+    const resolve = path.resolve as jest.Mock
+    resolve.mockImplementation((p: string = "") => actualPath.resolve(cwd, p))
+
+    const existsSync = fs.existsSync as jest.Mock
+    const tsconfigPath = path.resolve(path.join(configDir, "tsconfig.json"))
+    existsSync.mockImplementation((f: string) => path.resolve(f) === tsconfigPath)
+  }
+
+  it("can find in the same folder as dangerfile", () => {
+    setup("/a", "/c")
+    expect(lookupTSConfig("/c")).toBe("/c/tsconfig.json")
+  })
+
+  it("can find in a parent folder", () => {
+    setup("/a", "/a/b")
+    expect(lookupTSConfig("./b/c")).toBe("/a/b/tsconfig.json")
+  })
+
+  it("can find in the working dir", () => {
+    setup("/a", "/a")
+    expect(lookupTSConfig("/c")).toBe("tsconfig.json")
+  })
+
+  it("cannot find in a directory higher than current", () => {
+    setup("/a/b", "/a")
+    expect(lookupTSConfig("/a/b/c")).toBe(null)
+  })
+})
+
+describe("dirContains", () => {
+  it("identifies what directory contains", () => {
+    expect(dirContains("/a", "/a/b")).toBe(true)
+    expect(dirContains("/a/b", "/a")).toBe(false)
+    expect(dirContains("/a", "/a")).toBe(true)
   })
 })

--- a/source/runner/runners/utils/_tests/_transpiler.test.ts
+++ b/source/runner/runners/utils/_tests/_transpiler.test.ts
@@ -56,7 +56,7 @@ describe("lookupTSConfig", () => {
 
   it("can find in a parent folder", () => {
     setup("/a", "/a/b")
-    expect(lookupTSConfig(n("./b/c"))).toBe(n("/a/b/tsconfig.json"))
+    expect(lookupTSConfig(n("./b/c"))).toBe(n("b/tsconfig.json"))
   })
 
   it("can find in the working dir", () => {

--- a/source/runner/runners/utils/transpiler.ts
+++ b/source/runner/runners/utils/transpiler.ts
@@ -97,7 +97,6 @@ export const lookupTSConfig = (dir: string): string | null => {
   dir = path.resolve(dir)
 
   if (rootDir === dir) {
-    console.log("return", rootDir, dir)
     return null
   }
 
@@ -111,7 +110,7 @@ export const lookupTSConfig = (dir: string): string | null => {
   do {
     filepath = path.join(dir, filename)
     if (fs.existsSync(filepath)) {
-      return filepath
+      return path.relative(rootDir, filepath)
     }
     dir = path.dirname(dir)
   } while (dirContains(rootDir, dir))

--- a/source/runner/runners/utils/transpiler.ts
+++ b/source/runner/runners/utils/transpiler.ts
@@ -74,15 +74,59 @@ export const checkForNodeModules = () => {
   hasChecked = true
 }
 
+export const dirContains = (rootDir: string, dir: string): boolean => {
+  const relative = path.relative(rootDir, dir)
+  // on win32, relative can refer to a different drive
+  if (path.isAbsolute(relative)) {
+    return false
+  }
+  return !relative.startsWith("..")
+}
+
 // Now that we have a sense of what exists inside the users' node modules
 
-export const typescriptify = (content: string): string => {
+export const lookupTSConfig = (dir: string): string | null => {
+  const filename = "tsconfig.json"
+  let filepath = path.join(dir, filename)
+
+  if (fs.existsSync(filepath)) {
+    return filepath
+  }
+
+  const rootDir = path.resolve()
+  dir = path.resolve(dir)
+
+  if (rootDir === dir) {
+    console.log("return", rootDir, dir)
+    return null
+  }
+
+  // if root dir is disconnected, we only check in the root
+  if (!dirContains(rootDir, dir)) {
+    filepath = filename
+    return fs.existsSync(filepath) ? filepath : null
+  }
+
+  dir = path.dirname(dir)
+  do {
+    filepath = path.join(dir, filename)
+    if (fs.existsSync(filepath)) {
+      return filepath
+    }
+    dir = path.dirname(dir)
+  } while (dirContains(rootDir, dir))
+
+  return null
+}
+
+export const typescriptify = (content: string, dir: string): string => {
   const ts = require("typescript") // tslint:disable-line
 
   // Support custom TSC options, but also fallback to defaults
   let compilerOptions: any
-  if (fs.existsSync("tsconfig.json")) {
-    compilerOptions = JSON5.parse(fs.readFileSync("tsconfig.json", "utf8"))
+  const tsConfigPath = lookupTSConfig(dir)
+  if (tsConfigPath) {
+    compilerOptions = JSON5.parse(fs.readFileSync(tsConfigPath, "utf8"))
   } else {
     compilerOptions = ts.getDefaultCompilerOptions()
   }
@@ -152,7 +196,7 @@ export default (code: string, filename: string) => {
 
   let result = code
   if (hasNativeTypeScript && filetype.startsWith(".ts")) {
-    result = typescriptify(code)
+    result = typescriptify(code, path.dirname(filename))
   } else if (hasBabel && hasBabelTypeScript && filetype.startsWith(".ts")) {
     result = babelify(code, filename, [`${babelPackagePrefix}plugin-transform-typescript`])
   } else if (hasBabel && filetype.startsWith(".js")) {


### PR DESCRIPTION
Closes #1067 

Now ts transpiler looks for `tsconfig.json` file starting from the location of the danger file. If the current directory is an ancestor of that location, it climbs up to it and returns the first found config file. Otherwise only additionally checks the current working directory.

cc @orta 