### PR TITLE
Upgrade node-fetch to 2.6.1 to fix GHSA-w7rc-rwvf-8q5r

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Improved `tsconfig.json` file lookup strategy: it now looks for it starting from the location of the danger file.
   #1068 [@igorbek](https://github.com/igorbek)
+- Upgrade node-fetch to 2.6.1 to fix GHSA-w7rc-rwvf-8q5r. #1071 [@hmcc](https://github.com/hmcc)
 
 <!-- Your comment above this -->
 
@@ -1778,6 +1779,7 @@ Not usable for others, only stubs of classes etc. - [@orta]
 [@fbartho]: https://github.com/fbartho
 [@fwal]: https://github.com/fwal
 [@happylinks]: https://github.com/happylinks
+[@hmcc]: https://github.com/hmcc
 [@hongrich]: https://github.com/hongrich
 [@hellocore]: https://github.com/HelloCore
 [@imorente]: https://github.com/imorente

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "memfs-or-file-map-to-github-branch": "^1.1.0",
     "micromatch": "^3.1.10",
     "node-cleanup": "^2.1.2",
-    "node-fetch": "^2.3.0",
+    "node-fetch": "2.6.1",
     "override-require": "^1.1.1",
     "p-limit": "^2.1.0",
     "parse-diff": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6219,6 +6219,11 @@ node-cleanup@^2.1.2:
   resolved "https://registry.yarnpkg.com/node-cleanup/-/node-cleanup-2.1.2.tgz#7ac19abd297e09a7f72a71545d951b517e4dde2c"
   integrity sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=
 
+node-fetch@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-fetch@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.1.tgz#899cb3d0a3c92f952c47f1b876f4c8aeabd400d5"


### PR DESCRIPTION
Fixes https://github.com/danger/danger-js/issues/1070

Output of `yarn why node-fetch` is now:

```
yarn why v1.22.4
[1/4] Why do we have the module "node-fetch"...?
[2/4] Initialising dependency graph...
[3/4] Finding dependency...
[4/4] Calculating file sizes...
=> Found "node-fetch@2.6.1"
info Has been hoisted to "node-fetch"
info This module exists because it's specified in "dependencies".
info Disk size without dependencies: "180KB"
info Disk size with unique dependencies: "180KB"
info Disk size with transitive dependencies: "180KB"
info Number of shared dependencies: 0
=> Found "danger-plugin-yarn#node-fetch@1.7.1"
info This module exists because "danger-plugin-yarn" depends on it.
info Disk size without dependencies: "172KB"
info Disk size with unique dependencies: "228KB"
info Disk size with transitive dependencies: "640KB"
info Number of shared dependencies: 3
=> Found "@octokit/request#node-fetch@2.3.0"
info This module exists because "@octokit#request" depends on it.
info Disk size without dependencies: "172KB"
info Disk size with unique dependencies: "172KB"
info Disk size with transitive dependencies: "172KB"
info Number of shared dependencies: 0
=> Found "@octokit/rest#node-fetch@2.3.0"
info Reasons this module exists
   - "@octokit#rest#@octokit#request" depends on it
   - Hoisted from "@octokit#rest#@octokit#request#node-fetch"
info Disk size without dependencies: "172KB"
info Disk size with unique dependencies: "172KB"
info Disk size with transitive dependencies: "172KB"
info Number of shared dependencies: 0
=> Found "ky-universal#node-fetch@2.3.0"
info This module exists because "gitlab#ky-universal" depends on it.
info Disk size without dependencies: "172KB"
info Disk size with unique dependencies: "172KB"
info Disk size with transitive dependencies: "172KB"
info Number of shared dependencies: 0
Done in 0.55s.
```