### PR TITLE
fix: use new token api for apps

### DIFF
--- a/source/platforms/github/comms/checks/githubAppSupport.ts
+++ b/source/platforms/github/comms/checks/githubAppSupport.ts
@@ -23,7 +23,7 @@ const requestAccessTokenForInstallation = (appID: string, installationID: number
   const apiUrl = process.env["DANGER_GITHUB_API_BASE_URL"]
     ? process.env["DANGER_GITHUB_API_BASE_URL"]
     : "https://api.github.com"
-  const url = `${apiUrl}/installations/${installationID}/access_tokens`
+  const url = `${apiUrl}/app/installations/${installationID}/access_tokens`
   const headers = {
     Accept: "application/vnd.github.machine-man-preview+json",
     Authorization: `Bearer ${jwtForGitHubAuth(appID, key)}`,


### PR DESCRIPTION
Github is removing the old api and wants you to use the new one https://developer.github.com/changes/2020-04-15-replacing-create-installation-access-token-endpoint/. Everything is the same except the url.

I don't know how I should test this so any help is appreciated