### PR TITLE
Bitbucket Cloud: Fix bug when Danger updating inline comment with summary comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 <!-- Your comment below this -->
 
 - Bitbucket Cloud: Fix bug when Danger updating inline comment with summary comment. - [@hellocore]
-  <!-- Your comment above this -->
+
+<!-- Your comment above this -->
 
 # 10.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 
 <!-- Your comment below this -->
 
-<!-- Your comment above this -->
+- Bitbucket Cloud: Fix bug when Danger updating inline comment with summary comment. - [@hellocore]
+  <!-- Your comment above this -->
 
 # 10.4.2
 

--- a/source/platforms/BitBucketCloud.ts
+++ b/source/platforms/BitBucketCloud.ts
@@ -82,7 +82,7 @@ export class BitBucketCloud implements Platform {
    * @returns {Promise<boolean>} did it work?
    */
   deleteMainComment = async (dangerID: string): Promise<boolean> => {
-    const comments = await this.api.getDangerComments(dangerID)
+    const comments = await this.api.getDangerMainComments(dangerID)
     for (let comment of comments) {
       await this.api.deleteComment(comment.id.toString())
     }
@@ -98,7 +98,7 @@ export class BitBucketCloud implements Platform {
    * @returns {Promise<string>} the URL for the comment
    */
   async updateOrCreateComment(dangerID: string, newComment: string): Promise<string | undefined> {
-    const comments = await this.api.getDangerComments(dangerID)
+    const comments = await this.api.getDangerMainComments(dangerID)
     let issue = null
 
     if (comments.length) {

--- a/source/platforms/bitbucket_cloud/BitBucketCloudAPI.ts
+++ b/source/platforms/bitbucket_cloud/BitBucketCloudAPI.ts
@@ -214,11 +214,12 @@ export class BitBucketCloudAPI {
     return await res.text()
   }
 
-  getDangerComments = async (dangerID: string): Promise<BitBucketCloudPRComment[]> => {
+  getDangerMainComments = async (dangerID: string): Promise<BitBucketCloudPRComment[]> => {
     const comments = await this.getPullRequestComments()
     const dangerIDMessage = dangerIDToString(dangerID)
 
     return comments
+      .filter(comment => comment.inline == null)
       .filter(comment => comment.content.raw.includes(dangerIDMessage))
       .filter(comment => comment.user.uuid === this.uuid)
   }

--- a/source/platforms/bitbucket_cloud/_tests_/_bitbucket_cloud_api.test.ts
+++ b/source/platforms/bitbucket_cloud/_tests_/_bitbucket_cloud_api.test.ts
@@ -149,6 +149,24 @@ describe("API testing - BitBucket Cloud", () => {
             display_name: "name",
           },
         },
+        {
+          content: {
+            raw: `FAIL! danger-id-1; ${dangerSignaturePostfix({} as DangerResults, "1234")}`,
+          },
+          user: {
+            display_name: "name",
+            uuid: "{1234-1234-1234-1234}",
+          },
+        },
+        {
+          content: {
+            raw: "not a danger comment",
+          },
+          user: {
+            display_name: "someone",
+            uuid: "{1234-1234-1234-1235}",
+          },
+        },
       ],
     })
     const comments = await api.getDangerInlineComments("1")
@@ -173,7 +191,7 @@ describe("API testing - BitBucket Cloud", () => {
     expect(result).toEqual(["activity"])
   })
 
-  it("getDangerComments", async () => {
+  it("getDangerMainComments", async () => {
     const commitID = "e70f3d6468f61a4bef68c9e6eaba9166b096e23c"
     jsonResult = () => ({
       isLastPage: true,
@@ -189,6 +207,21 @@ describe("API testing - BitBucket Cloud", () => {
         },
         {
           content: {
+            raw:
+              "\n[//]: # (danger-id-1;)\n[//]: # (  File: dangerfile.ts;\n  Line: 5;)\n\n- :warning: Hello updates\n\n\n  ",
+          },
+          id: 1234,
+          inline: {
+            from: 5,
+            path: "dangerfile.ts",
+          },
+          user: {
+            uuid: "{1234-1234-1234-1234}",
+            display_name: "name",
+          },
+        },
+        {
+          content: {
             raw: "not a danger comment",
           },
           user: {
@@ -198,7 +231,8 @@ describe("API testing - BitBucket Cloud", () => {
         },
       ],
     })
-    const result = await api.getDangerComments("1")
+
+    const result = await api.getDangerMainComments("1")
 
     expect(api.fetch).toHaveBeenCalledWith(
       "https://api.bitbucket.org/2.0/repositories/foo/bar/pullrequests/1/comments?q=deleted=false",


### PR DESCRIPTION
When updating summary comment, Danger will call `getDangerComments` which will get all Danger's comments (including inline comment) for updating.
We need to filter inline comments out, so Danger will only update the main comment.