### PR TITLE
Retrieve staging cli arg runner side

### DIFF
--- a/source/runner/dslGenerator.ts
+++ b/source/runner/dslGenerator.ts
@@ -27,6 +27,7 @@ export const jsonDSLGenerator = async (
     id: program.id,
     textOnly: program.textOnly,
     verbose: program.verbose,
+    staging: program.staging
   }
 
   const dslPlatformName = jsonDSLPlatformName(platform)


### PR DESCRIPTION
Hello,

First of all thank you for Danger, and your open source work in general 😄 

I created this pull request to fix an issue I am encountering and maybe others encounter. 
When we are working with `danger local --staging` it seems the `LocalGit` platform is first initialized with the good args (staging: true) but once we are `runner` side this arg value disappears.
The `git.modified_files` is then incorrect runner side.

###

I also have a question, exploring the codebase and debugging this issue, I found that we are building the `LocalGit` platform twice. First of all at initialization, but then we are building it again in `jsonToDSL` when platforms doesn't exists (it is the case in local mode).  Am I missing something ? Is it normal ? Shouldn't we have a "fake" platform for local and avoid rebuilding `LocalGit` ?


If my PR is not clear, don't hesitate to ask me to rephrase it. 👋 