### PR TITLE
Add env variable to disable transpiling with typescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@
 
 <!-- Your comment below this -->
 
-<!-- Your comment above this -->
+- Add `DANGER_DISABLE_TSC` environment variable to disable transpiling with tsc, providing a way to force transpiling
+  with Babel - [@ozzieorca]
+  <!-- Your comment above this -->
 
 # 10.5.4
 

--- a/source/runner/runners/utils/transpiler.ts
+++ b/source/runner/runners/utils/transpiler.ts
@@ -9,6 +9,7 @@ const enum BabelPackagePrefix {
 }
 
 const disableTranspilation = process.env.DANGER_DISABLE_TRANSPILATION === "true"
+const disableTsc = process.env.DANGER_DISABLE_TSC === "true"
 
 let hasNativeTypeScript = false
 let hasBabel = false
@@ -30,7 +31,7 @@ export const checkForNodeModules = () => {
 
   try {
     require.resolve("typescript") // tslint:disable-line
-    hasNativeTypeScript = true
+    hasNativeTypeScript = true && !disableTsc
   } catch (e) {
     d("Does not have TypeScript set up")
   }


### PR DESCRIPTION
- Allows developer to force TS to be compiled with babel

I'm having trouble using `tsc` to compile `dangerfile.ts` and it's currently throwing `SyntaxError: Cannot use import statement outside a module`.

My workflow runs all `.ts` files through Babel only, uses `tsc` as a linter only, and I have `target` set to `esnext` in my `tsconfig.json` file:
```json
{
    "compilerOptions": {
        "target": "esnext",
        ...
    },
}
```

Danger seems to be transpiling with `tsc` but `node` can't execute its output since the target is so high. This PR adds the `DANGER_DISABLE_TSC` flag for a developer to skip `tsc` and use Babel.

Idk if this is desired to be added to this project and I'm open to other implementations. Maybe the logic should be less about disabling tsc and more about forcing Babel. Or maybe a more robust solution to specify a specific transpiler would be better such as `DANGER_TRANSPILATION=off|babel|tsc`.