### PR TITLE
add path pattern filter option to linesOfCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 <!-- Your comment below this -->
 
+- Add support for a file path filter when calculation lines of code - [@melvinvermeer]
+
 <!-- Your comment above this -->
 
 # 10.5.4

--- a/source/dsl/GitDSL.ts
+++ b/source/dsl/GitDSL.ts
@@ -186,5 +186,5 @@ export interface GitDSL extends GitJSONDSL {
   /**
    * Offers the overall lines of code added/removed in the diff
    */
-  linesOfCode(): Promise<number | null>
+  linesOfCode(pattern?: string): Promise<number | null>
 }

--- a/source/dsl/GitDSL.ts
+++ b/source/dsl/GitDSL.ts
@@ -185,6 +185,8 @@ export interface GitDSL extends GitJSONDSL {
 
   /**
    * Offers the overall lines of code added/removed in the diff
+   *
+   * @param {string} pattern an option glob pattern to filer files that will considered for lines of code.
    */
   linesOfCode(pattern?: string): Promise<number | null>
 }

--- a/source/platforms/github/_tests/_github_git.test.ts
+++ b/source/platforms/github/_tests/_github_git.test.ts
@@ -102,6 +102,16 @@ describe("the dangerfile gitDSL", () => {
     ])
   })
 
+  it("counts the lines of code", async () => {
+    const loc = await gitDSL.linesOfCode()
+    expect(loc).toBe(1151)
+  })
+
+  it("allows the lines of code to be filtered by file path", async () => {
+    const loc = await gitDSL.linesOfCode("lib/**")
+    expect(loc).toBe(720)
+  })
+
   it("show diff chunks for a specific file", async () => {
     const { chunks } = (await gitDSL.structuredDiffForFile("tsconfig.json"))!
 


### PR DESCRIPTION
# Filter linesOfCode with glob pattern

When checking linesOfCode of a PR some teams might only want to include the `./src` folder in the count. Or exclude the `*.json` files.

This PR adds the optional parameter `pattern` to the `linesOfCode` function. If provided, only file paths that match the glob pattern will be included in the resulting count. If omitted, the behavior remains unchanged. 

### TODO

I'm aware that there is stuff to be done before merging this PR. Just opening as draft to get input on the idea.

- [x] Add to Changelog 
- [x] Documentation (https://danger.systems/js/reference.html) (automated)
- [x] JS doc
- [x] Unit tests



