### PR TITLE
add options 'newComment' and 'removePreviousComments'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 <!-- Your comment below this -->
 
+- Adds options `newComment` and `removePreviousComments` - [@davidhouweling]
+
 <!-- Your comment above this -->
 
 # 10.5.4

--- a/source/commands/ci/_tests/runner.test.ts
+++ b/source/commands/ci/_tests/runner.test.ts
@@ -93,3 +93,27 @@ it.skip("passes the dangerID from args into the executor config", async () => {
   const executor: Executor = mockRunDangerSubprocess.mock.calls[0][2]
   expect(executor.options.dangerID).toEqual("test-danger-run")
 })
+
+it("sets removePreviousComments to false by default", async () => {
+  await runRunner(defaultAppArgs as SharedCLI, { platform, source })
+
+  // Pull the executor out of the call to runDangerSubprocess
+  const executor: Executor = mockRunDangerSubprocess.mock.calls[0][2]
+  expect(executor.ciSource).toEqual(source)
+  expect(executor.platform).toEqual(platform)
+  expect(executor.options.removePreviousComments).toEqual(false)
+})
+
+it("passes removePreviousComments option if requested", async () => {
+  const customArgs = {
+    ...defaultAppArgs,
+    removePreviousComments: true,
+  } as SharedCLI
+  await runRunner(customArgs, { platform, source })
+
+  // Pull the executor out of the call to runDangerSubprocess
+  const executor: Executor = mockRunDangerSubprocess.mock.calls[0][2]
+  expect(executor.ciSource).toEqual(source)
+  expect(executor.platform).toEqual(platform)
+  expect(executor.options.removePreviousComments).toEqual(true)
+})

--- a/source/commands/ci/_tests/runner.test.ts
+++ b/source/commands/ci/_tests/runner.test.ts
@@ -94,6 +94,30 @@ it.skip("passes the dangerID from args into the executor config", async () => {
   expect(executor.options.dangerID).toEqual("test-danger-run")
 })
 
+it("sets newComment to false by default", async () => {
+  await runRunner(defaultAppArgs as SharedCLI, { platform, source })
+
+  // Pull the executor out of the call to runDangerSubprocess
+  const executor: Executor = mockRunDangerSubprocess.mock.calls[0][2]
+  expect(executor.ciSource).toEqual(source)
+  expect(executor.platform).toEqual(platform)
+  expect(executor.options.newComment).toEqual(false)
+})
+
+it("passes newComment option if requested", async () => {
+  const customArgs = {
+    ...defaultAppArgs,
+    newComment: true,
+  } as SharedCLI
+  await runRunner(customArgs, { platform, source })
+
+  // Pull the executor out of the call to runDangerSubprocess
+  const executor: Executor = mockRunDangerSubprocess.mock.calls[0][2]
+  expect(executor.ciSource).toEqual(source)
+  expect(executor.platform).toEqual(platform)
+  expect(executor.options.newComment).toEqual(true)
+})
+
 it("sets removePreviousComments to false by default", async () => {
   await runRunner(defaultAppArgs as SharedCLI, { platform, source })
 

--- a/source/commands/ci/runner.ts
+++ b/source/commands/ci/runner.ts
@@ -69,6 +69,7 @@ export const runRunner = async (app: SharedCLI, config?: Partial<RunnerConfig>) 
         failOnErrors: app.failOnErrors,
         noPublishCheck: !app.publishCheck,
         ignoreOutOfDiffComments: app.ignoreOutOfDiffComments,
+        newComment: app.newComment || false,
         removePreviousComments: app.removePreviousComments || false,
       }
 

--- a/source/commands/ci/runner.ts
+++ b/source/commands/ci/runner.ts
@@ -69,6 +69,7 @@ export const runRunner = async (app: SharedCLI, config?: Partial<RunnerConfig>) 
         failOnErrors: app.failOnErrors,
         noPublishCheck: !app.publishCheck,
         ignoreOutOfDiffComments: app.ignoreOutOfDiffComments,
+        removePreviousComments: app.removePreviousComments || false,
       }
 
       const processName = (app.process && addSubprocessCallAguments(app.process.split(" "))) || undefined

--- a/source/commands/utils/sharedDangerfileArgs.ts
+++ b/source/commands/utils/sharedDangerfileArgs.ts
@@ -29,6 +29,8 @@ export interface SharedCLI extends program.CommanderStatic {
   useGithubChecks: boolean
   /** Ignore inline-comments that are in lines which were not changed */
   ignoreOutOfDiffComments: boolean
+  /** Makes Danger post a new comment instead of editing its previous one */
+  newComment?: boolean
   /** Removes all previous comment and create a new one in the end of the list */
   removePreviousComments?: boolean
 }
@@ -48,6 +50,7 @@ export default (command: any) =>
     .option("-f, --failOnErrors", "Fail if there are fails in the danger report", false)
     .option("--use-github-checks", "Use GitHub Checks", false)
     .option("--ignoreOutOfDiffComments", "Ignore inline-comments that are in lines which were not changed", false)
+    .option("--newComment", "Makes Danger post a new comment instead of editing its previous one", false)
     .option(
       "--removePreviousComments",
       "Removes all previous comment and create a new one in the end of the list",

--- a/source/commands/utils/sharedDangerfileArgs.ts
+++ b/source/commands/utils/sharedDangerfileArgs.ts
@@ -29,6 +29,8 @@ export interface SharedCLI extends program.CommanderStatic {
   useGithubChecks: boolean
   /** Ignore inline-comments that are in lines which were not changed */
   ignoreOutOfDiffComments: boolean
+  /** Removes all previous comment and create a new one in the end of the list */
+  removePreviousComments?: boolean
 }
 
 export default (command: any) =>
@@ -46,3 +48,8 @@ export default (command: any) =>
     .option("-f, --failOnErrors", "Fail if there are fails in the danger report", false)
     .option("--use-github-checks", "Use GitHub Checks", false)
     .option("--ignoreOutOfDiffComments", "Ignore inline-comments that are in lines which were not changed", false)
+    .option(
+      "--removePreviousComments",
+      "Removes all previous comment and create a new one in the end of the list",
+      false
+    )

--- a/source/runner/Executor.ts
+++ b/source/runner/Executor.ts
@@ -60,6 +60,8 @@ export interface ExecutorOptions {
   noPublishCheck?: boolean
   /** Ignore inline-comments that are in lines which were not changed */
   ignoreOutOfDiffComments: boolean
+  /** Makes Danger post a new comment instead of editing its previous one */
+  newComment?: boolean
   /** Removes all previous comment and create a new one in the end of the list */
   removePreviousComments?: boolean
 }
@@ -312,7 +314,11 @@ export class Executor {
           comment = githubResultsTemplate(dangerID, mergedResults, commitID)
         }
 
-        issueURL = await this.platform.updateOrCreateComment(dangerID, comment)
+        if (this.options.newComment) {
+          issueURL = await this.platform.createComment(dangerID, comment)
+        } else {
+          issueURL = await this.platform.updateOrCreateComment(dangerID, comment)
+        }
         this.log(`Feedback: ${issueURL}`)
       }
     }

--- a/source/runner/_tests/_executor.test.ts
+++ b/source/runner/_tests/_executor.test.ts
@@ -167,14 +167,22 @@ describe("setup", () => {
     expect(platform.updateOrCreateComment).toBeCalled()
   })
 
-  it("Updates or Creates comments for warnings", async () => {
+  it("Creates comments (rather than update or create) for warnings when newComment option is passed", async () => {
     const platform = new FakePlatform()
-    const exec = new Executor(new FakeCI({}), platform, inlineRunner, defaultConfig, new FakeProcces())
+    const exec = new Executor(
+      new FakeCI({}),
+      platform,
+      inlineRunner,
+      { ...defaultConfig, newComment: true },
+      new FakeProcces()
+    )
     const dsl = await defaultDsl(platform)
+    platform.createComment = jest.fn()
     platform.updateOrCreateComment = jest.fn()
 
     await exec.handleResults(warnResults, dsl.git)
-    expect(platform.updateOrCreateComment).toBeCalled()
+    expect(platform.createComment).toBeCalled()
+    expect(platform.updateOrCreateComment).not.toBeCalled()
   })
 
   it("Updates or Creates comments for warnings, without GitDSL", async () => {
@@ -184,6 +192,23 @@ describe("setup", () => {
 
     await exec.handleResults(warnResults)
     expect(platform.updateOrCreateComment).toBeCalled()
+  })
+
+  it("Creates comments (rather than update or create) for warnings, without GitDSL, when newComment option is passed", async () => {
+    const platform = new FakePlatform()
+    const exec = new Executor(
+      new FakeCI({}),
+      platform,
+      inlineRunner,
+      { ...defaultConfig, newComment: true },
+      new FakeProcces()
+    )
+    platform.createComment = jest.fn()
+    platform.updateOrCreateComment = jest.fn()
+
+    await exec.handleResults(warnResults)
+    expect(platform.createComment).toBeCalled()
+    expect(platform.updateOrCreateComment).not.toBeCalled()
   })
 
   it("Sends inline comments and returns regular results for failures", async () => {
@@ -201,6 +226,7 @@ describe("setup", () => {
     const exec = new Executor(new FakeCI({}), platform, inlineRunner, defaultConfig, new FakeProcces())
     const dsl = await defaultDsl(platform)
     platform.createInlineComment = jest.fn()
+    platform.createComment = jest.fn()
     platform.updateOrCreateComment = jest.fn()
 
     await exec.handleResults(inlineWarnResults, dsl.git)
@@ -213,9 +239,11 @@ describe("setup", () => {
     const exec = new Executor(new FakeCI({}), platform, inlineRunner, config, new FakeProcces())
     const dsl = await defaultDsl(platform)
     platform.createInlineComment = jest.fn().mockReturnValue(new Promise<any>((_, reject) => reject()))
+    platform.createComment = jest.fn()
     platform.updateOrCreateComment = jest.fn()
 
     await exec.handleResults(inlineWarnResults, dsl.git)
+    expect(platform.createComment).not.toBeCalled()
     expect(platform.updateOrCreateComment).not.toBeCalled()
   })
 
@@ -369,6 +397,7 @@ describe("setup", () => {
     const platform = new FakePlatform()
     const exec = new Executor(new FakeCI({}), platform, inlineRunner, defaultConfig, new FakeProcces())
     const dsl = await defaultDsl(platform)
+    platform.createComment = jest.fn()
     platform.updateOrCreateComment = jest.fn()
     platform.updateStatus = jest.fn()
 
@@ -380,6 +409,7 @@ describe("setup", () => {
     const platform = new FakePlatform()
     const exec = new Executor(new FakeCI({}), platform, inlineRunner, defaultConfig, new FakeProcces())
     const dsl = await defaultDsl(platform)
+    platform.createComment = jest.fn()
     platform.updateOrCreateComment = jest.fn()
     platform.updateStatus = jest.fn()
 
@@ -396,6 +426,7 @@ describe("setup", () => {
     const platform = new FakePlatform()
     const exec = new Executor(new FakeCI({}), platform, inlineRunner, defaultConfig, new FakeProcces())
     const dsl = await defaultDsl(platform)
+    platform.createComment = jest.fn()
     platform.updateOrCreateComment = jest.fn()
     platform.updateStatus = jest.fn()
 
@@ -415,6 +446,7 @@ describe("setup", () => {
 
     const exec = new Executor(ci, platform, inlineRunner, defaultConfig, new FakeProcces())
     const dsl = await defaultDsl(platform)
+    platform.createComment = jest.fn()
     platform.updateOrCreateComment = jest.fn()
     platform.updateStatus = jest.fn()
 
@@ -434,6 +466,7 @@ describe("setup", () => {
 
     const exec = new Executor(ci, platform, inlineRunner, config, new FakeProcces())
     const dsl = await defaultDsl(platform)
+    platform.createComment = jest.fn()
     platform.updateOrCreateComment = jest.fn()
     platform.updateStatus = jest.fn()
 


### PR DESCRIPTION
This PR adds options `newComment` and `removePreviousComments`.

This is [very loosely] based on the options available in the [Ruby implementation](https://github.com/danger/danger/blob/108e82ab793cc48a2756b9881a94e01cce57d353/lib/danger/commands/runner.rb#L67-L68).

This PR resolves #547.

Note to reviewers, would be good to sanity check that this the implementation is as expected as I simply did the code change purely based on what I thought the description of the options implied.
