### PR TITLE
Log failure to update status also when not in verbose mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ## Main
 
 <!-- Your comment below this -->
-
+- Log failure to update status also when not in verbose mode - [@rogerluan]
 <!-- Your comment above this -->
 
 # 10.6.2

--- a/source/runner/Executor.ts
+++ b/source/runner/Executor.ts
@@ -342,7 +342,7 @@ export class Executor {
     const urlForInfo = issueURL || this.ciSource.ciRunURL
     const successPosting = await this.platform.updateStatus(passed, messageForResults(results), urlForInfo, dangerID)
 
-    if (!successPosting && this.options.verbose) {
+    if (!successPosting) {
       this.log("Could not add a commit status, the GitHub token for Danger does not have access rights.")
       this.log("If the build fails, then danger will use a failing exit code.")
     }


### PR DESCRIPTION
Hey 👋 

I faced this issue and was really annoyed that I had to update my CI to include a `--verbose` just so I could start debugging the issue. IMO this should be a required log - if something's wrong, it should just say it right away instead of happily printing "no issues ✅ " and then silently not updating the PR 😿 

Hope this makes sense 🙏 Cheers!