### PR TITLE
Fix Bitrise's `ciRunURL` underlying env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ## Main
 
 <!-- Your comment below this -->
-
+- Fixed Bitrise's `ciRunURL` underlying env var - [@rogerluan]
 <!-- Your comment above this -->
 
 # 10.6.2

--- a/source/ci_source/providers/Bitrise.ts
+++ b/source/ci_source/providers/Bitrise.ts
@@ -71,10 +71,12 @@ export class Bitrise implements CISource {
   }
 
   get ciRunURL() {
-    return this.env.BITRISE_PULL_REQUEST
+    return this.env.BITRISE_BUILD_URL
   }
 
   get commitHash() {
     return this.env.BITRISE_GIT_COMMIT
   }
 }
+
+// See https://devcenter.bitrise.io/builds/available-environment-variables/


### PR DESCRIPTION
Hey 👋 

During some debugging process I realized that this env var is probably wrong, based on what it means and what other similar CI files are using as env var values 😊 So here's the fix!

I also added a handy link at the bottom of the file, copying `GitLabCI.ts` and `Travis.ts` 📜 

