### PR TITLE
Simplify Bitrise repo slug lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 <!-- Your comment below this -->
 - Simplified Bitrise repo slug lookup, fixing SSH URL parsing in BitBucketServer - [@rogerluan]
+- Changed `CHANGELOG.md` merge strategy to union to avoid merge conflicts - [@rogerluan]
 - Log failure to update status also when not in verbose mode - [@rogerluan]
 <!-- Your comment above this -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ## Main
 
 <!-- Your comment below this -->
-
+- Simplified Bitrise repo slug lookup, fixing SSH URL parsing in BitBucketServer - [@rogerluan]
 <!-- Your comment above this -->
 
 # 10.6.2

--- a/source/ci_source/providers/Bitrise.ts
+++ b/source/ci_source/providers/Bitrise.ts
@@ -51,15 +51,9 @@ export class Bitrise implements CISource {
   }
 
   get isPR(): boolean {
-    const mustHave = ["GIT_REPOSITORY_URL"]
+    const mustHave = ["BITRISEIO_GIT_REPOSITORY_OWNER", "BITRISEIO_GIT_REPOSITORY_SLUG"]
     const mustBeInts = ["BITRISE_PULL_REQUEST"]
     return ensureEnvKeysExist(this.env, mustHave) && ensureEnvKeysAreInt(this.env, mustBeInts)
-  }
-
-  private _parseRepoURL(): string {
-    const repoURL = this.env.GIT_REPOSITORY_URL
-    let regexp = repoURL.startsWith("git") ? /(.+):/ : /^http(s):\/\/(www[0-9]?\.)?(.[^/:]+)\//
-    return repoURL.replace(regexp, "").replace(/.git$/, "")
   }
 
   get pullRequestID(): string {
@@ -67,7 +61,7 @@ export class Bitrise implements CISource {
   }
 
   get repoSlug(): string {
-    return this._parseRepoURL()
+    return `${this.env.BITRISEIO_GIT_REPOSITORY_OWNER}/${this.env.BITRISEIO_GIT_REPOSITORY_SLUG}`
   }
 
   get ciRunURL() {

--- a/source/ci_source/providers/_tests/_bitrise.test.ts
+++ b/source/ci_source/providers/_tests/_bitrise.test.ts
@@ -4,7 +4,8 @@ import { getCISourceForEnv } from "../../get_ci_source"
 const correctEnv = {
   BITRISE_IO: "true",
   BITRISE_PULL_REQUEST: "800",
-  GIT_REPOSITORY_URL: "https://github.com/artsy/eigen",
+  BITRISEIO_GIT_REPOSITORY_OWNER: "artsy",
+  BITRISEIO_GIT_REPOSITORY_SLUG: "eigen",
 }
 
 describe("being found when looking for CI", () => {
@@ -37,7 +38,7 @@ describe(".isPR", () => {
     expect(bitrise.isPR).toBeFalsy()
   })
 
-  const envs = ["BITRISE_PULL_REQUEST", "GIT_REPOSITORY_URL", "BITRISE_IO"]
+  const envs = ["BITRISE_PULL_REQUEST", "BITRISEIO_GIT_REPOSITORY_OWNER", "BITRISEIO_GIT_REPOSITORY_SLUG", "BITRISE_IO"]
   envs.forEach((key: string) => {
     let env = { ...correctEnv }
     env[key] = null
@@ -59,36 +60,9 @@ describe(".pullRequestID", () => {
 })
 
 describe(".repoSlug", () => {
-  it("derives it from the repo URL", () => {
+  it("derives it from the repo owner and slug", () => {
     const bitrise = new Bitrise(correctEnv)
     expect(bitrise.repoSlug).toEqual("artsy/eigen")
-  })
-
-  it("derives it from the repo URL in SSH format", () => {
-    const env = {
-      ...correctEnv,
-      GIT_REPOSITORY_URL: "git@github.com:artsy/eigen.git",
-    }
-    const bitrise = new Bitrise(env)
-    expect(bitrise.repoSlug).toEqual("artsy/eigen")
-  })
-
-  it("derives it from a long URL format", () => {
-    const env = {
-      ...correctEnv,
-      GIT_REPOSITORY_URL: "https://github.com/organization/project/subproject/repo.git",
-    }
-    const bitrise = new Bitrise(env)
-    expect(bitrise.repoSlug).toEqual("organization/project/subproject/repo")
-  })
-
-  it("derives it from a long SSH format", () => {
-    const env = {
-      ...correctEnv,
-      GIT_REPOSITORY_URL: "git@github.com:organization/project/subproject/repo.git",
-    }
-    const bitrise = new Bitrise(env)
-    expect(bitrise.repoSlug).toEqual("organization/project/subproject/repo")
   })
 })
 


### PR DESCRIPTION
Hey 👋 

I realized that we had this issue related to Bitrise https://github.com/danger/danger-js/issues/1047 and thought it was easy enough to fix. This PR removes `GIT_REPOSITORY_URL` and uses other env vars that are more user friendly to parse, removing the regex completely - which's also safer and now works for all sorts of URLs.

With my little understanding of how Danger and CI interacts, I _hope_ that simply and blindly dropping the support to `GIT_REPOSITORY_URL` won't break existing users' setups 😬 

Resolves #1047
Docs: https://devcenter.bitrise.io/builds/available-environment-variables/