### PR TITLE
Change CHANGELOG.md merge strategy to union

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# .gitattributes documentation: https://git-scm.com/docs/gitattributes
+
+# Resolve 3-way merge conflicts on the CHANGELOG.md file using the union strategy
+CHANGELOG.md merge=union


### PR DESCRIPTION
Hey 👋 

I noticed users are supposed to include changes to CHANGELOG.md on every PR. This causes unnecessary merge conflicts that we could avoid if we changed the merge strategy to "union". What this does is that whenever it finds a merge conflict, it will resolve it automatically by accepting both entries. I believe that's always the case for the CHANGELOG file.

I've been using this in other projects to auto-resolve conflicts of files and it works wonders 🤗 

For more info: https://git-scm.com/docs/gitattributes

Hope this helps! 💪 