### PR TITLE
Add url to Danger local commits

### DIFF
--- a/source/platforms/git/localGetCommits.ts
+++ b/source/platforms/git/localGetCommits.ts
@@ -35,6 +35,7 @@ export const localGetCommits = (base: string, head: string) =>
       const realCommits = parsedCommits.map((c: any) => ({
         ...c,
         parents: c.parents.split(" "),
+        url: "fake.danger.systems/" + c.sha,
       }))
 
       commits.push(...realCommits)


### PR DESCRIPTION
👋🏻 ,
Is been a while since my last PR here :)

I've added just a small change to be sure there is always a URL, also on the fake json returned by `danger local`.

Given we have it not nil on Danger-Swift I think this should be populated for all the platforms https://github.com/danger/swift/blob/master/Sources/Danger/GitDSL.swift#L57