### PR TITLE
Fix type of BitBucketCloudPRDSL.created_on and updated_on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
 ## Main
 
 <!-- Your comment below this -->
-<!-- Your comment above this -->
+
+- Bitbucket Cloud: Fix type of BitBucketCloudPRDSL.created_on and updated_on. - [@hellocore]
+  <!-- Your comment above this -->
 
 # 10.6.4
 

--- a/source/dsl/BitBucketCloudDSL.ts
+++ b/source/dsl/BitBucketCloudDSL.ts
@@ -35,10 +35,10 @@ export interface BitBucketCloudPRDSL {
   description: string
   /** The pull request's current status. */
   state: "OPEN" | "MERGED" | "DECLINED" | "SUPERSEDED"
-  /** Date PR created as number of milliseconds since the unix epoch */
-  created_on: number
-  /** Date PR updated as number of milliseconds since the unix epoch */
-  updated_on: number
+  /** When the pr was created, in ISO 8601 format */
+  created_on: string
+  /** When the pr was updated, in ISO 8601 format */
+  updated_on: string
   /** The PR's source, The repo Danger is running on  */
   source: BitBucketCloudMergeRef
   /** The PR's destination */


### PR DESCRIPTION
Field `created_on` and `updated_on` of `BitBucketCloudPRDSL` should be String in ISO 8601 format instead of number.

https://github.com/danger/danger-js/blob/b87084f3859933a3e8ad5f744d0c38e34c722f4a/source/platforms/_tests/fixtures/bitbucket_cloud_pr.json#L101

https://github.com/danger/danger-js/blob/b87084f3859933a3e8ad5f744d0c38e34c722f4a/source/platforms/_tests/fixtures/bitbucket_cloud_pr.json#L236