### PR TITLE
Use full unformatted subject message

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
     "typedoc": "0.9.0",
-    "typescript": "^3.1.1",
+    "typescript": "^3.9.7",
     "typescript-json-schema": "^0.32.0"
   },
   "dependencies": {
@@ -144,6 +144,7 @@
     "fast-json-patch": "^3.0.0-1",
     "get-stdin": "^6.0.0",
     "gitlab": "^10.0.1",
+    "gitlog": "^4.0.4",
     "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.1",
     "hyperlinker": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,6 @@
     "fast-json-patch": "^3.0.0-1",
     "get-stdin": "^6.0.0",
     "gitlab": "^10.0.1",
-    "gitlog": "^4.0.4",
     "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.1",
     "hyperlinker": "^1.0.0",

--- a/source/platforms/git/_tests/localGetCommits.test.ts
+++ b/source/platforms/git/_tests/localGetCommits.test.ts
@@ -1,6 +1,5 @@
-import gitlog from "gitlog"
-
 import { localGetCommits } from "../localGetCommits"
+import { logGitCommits } from "../localLogGitCommits"
 
 const hash = "hash"
 const abbrevParentHashes = "abbrevParentHashes"
@@ -26,9 +25,9 @@ const gitLogCommitMock = {
   subject,
 }
 
-jest.mock("gitlog", () => ({
+jest.mock("../localLogGitCommits", () => ({
   __esModule: true,
-  default: jest.fn(() => [gitLogCommitMock]),
+  logGitCommits: jest.fn(() => [gitLogCommitMock]),
 }))
 
 it("generates a JSON-like commit message", () => {
@@ -37,8 +36,8 @@ it("generates a JSON-like commit message", () => {
 
   const result = localGetCommits(base, head)
 
-  expect(gitlog).toHaveBeenCalledWith({
-    repo: expect.any(String),
+  expect(logGitCommits).toHaveBeenCalledWith({
+    number: expect.any(Number),
     branch: `${base}...${head}`,
     fields: expect.any(Array),
   })

--- a/source/platforms/git/_tests/localGetCommits.test.ts
+++ b/source/platforms/git/_tests/localGetCommits.test.ts
@@ -1,10 +1,64 @@
-import { formatJSON } from "../localGetCommits"
+import gitlog from "gitlog"
+
+import { localGetCommits } from "../localGetCommits"
+
+const hash = "hash"
+const abbrevParentHashes = "abbrevParentHashes"
+const treeHash = "treeHash"
+const authorName = "authorName"
+const authorEmail = "authorEmail"
+const authorDate = "authorDate"
+const committerName = "committerName"
+const committerEmail = "committerEmail"
+const committerDate = "committerDate"
+const subject = "subject"
+
+const gitLogCommitMock = {
+  hash,
+  abbrevParentHashes,
+  treeHash,
+  authorName,
+  authorEmail,
+  authorDate,
+  committerName,
+  committerEmail,
+  committerDate,
+  subject,
+}
+
+jest.mock("gitlog", () => ({
+  __esModule: true,
+  default: jest.fn(() => [gitLogCommitMock]),
+}))
 
 it("generates a JSON-like commit message", () => {
-  expect(formatJSON).toEqual(
-    '{ "sha": "%H", "parents": "%p", "author": {"name": "%an", "email": "%ae", "date": "%ai" }, "committer": {"name": "%cn", "email": "%ce", "date": "%ci" }, "message": "%s"},'
-  )
+  const base = "base-branch"
+  const head = "head-branch"
 
-  const withoutComma = formatJSON.substring(0, formatJSON.length - 1)
-  expect(() => JSON.parse(withoutComma)).not.toThrow()
+  const result = localGetCommits(base, head)
+
+  expect(gitlog).toHaveBeenCalledWith({
+    repo: expect.any(String),
+    branch: `${base}...${head}`,
+    fields: expect.any(Array),
+  })
+
+  expect(result).toEqual([
+    {
+      sha: hash,
+      author: {
+        name: authorName,
+        email: authorEmail,
+        date: authorDate,
+      },
+      committer: {
+        name: committerName,
+        email: committerEmail,
+        date: committerDate,
+      },
+      message: subject,
+      tree: treeHash,
+      url: expect.stringContaining(hash),
+    },
+  ])
 })

--- a/source/platforms/git/_tests/localGetCommits.test.ts
+++ b/source/platforms/git/_tests/localGetCommits.test.ts
@@ -2,7 +2,7 @@ import { formatJSON } from "../localGetCommits"
 
 it("generates a JSON-like commit message", () => {
   expect(formatJSON).toEqual(
-    '{ "sha": "%H", "parents": "%p", "author": {"name": "%an", "email": "%ae", "date": "%ai" }, "committer": {"name": "%cn", "email": "%ce", "date": "%ci" }, "message": "%f"},'
+    '{ "sha": "%H", "parents": "%p", "author": {"name": "%an", "email": "%ae", "date": "%ai" }, "committer": {"name": "%cn", "email": "%ce", "date": "%ci" }, "message": "%s"},'
   )
 
   const withoutComma = formatJSON.substring(0, formatJSON.length - 1)

--- a/source/platforms/git/_tests/localLogGitCommits.test.ts
+++ b/source/platforms/git/_tests/localLogGitCommits.test.ts
@@ -1,0 +1,30 @@
+import { execFileSync } from "child_process"
+
+import { logGitCommits } from "../localLogGitCommits"
+
+const COMMAND_OUTPUT = ""
+
+jest.mock("child_process", () => ({
+  __esModule: true,
+  execFileSync: jest.fn(() => COMMAND_OUTPUT),
+}))
+
+it("get git commits from the 'git log' command", () => {
+  const options = {
+    number: 10,
+    branch: "test_branch",
+    fields: ["hash" as "hash", "subject" as "subject"],
+  }
+
+  const result = logGitCommits(options)
+
+  expect(execFileSync).toHaveBeenCalledWith("git", [
+    "log",
+    "-l0",
+    `-n ${options.number}`,
+    "--pretty=@begin@" + "\t%H\t%s" + "@end@",
+    options.branch,
+  ])
+
+  expect(result).toEqual([])
+})

--- a/source/platforms/git/localGetCommits.ts
+++ b/source/platforms/git/localGetCommits.ts
@@ -1,58 +1,52 @@
-import { debug } from "../../debug"
-import JSON5 from "json5"
+import gitlog, { GitlogOptions } from "gitlog"
 
-import { spawn } from "child_process"
 import { GitCommit } from "../../dsl/Commit"
 
-const d = debug("localGetDiff")
+export const localGetCommits = (base: string, head: string) => {
+  const options: GitlogOptions<
+    | "hash"
+    | "abbrevParentHashes"
+    | "treeHash"
+    | "authorName"
+    | "authorEmail"
+    | "authorDate"
+    | "committerName"
+    | "committerEmail"
+    | "committerDate"
+    | "subject"
+  > = {
+    repo: process.cwd(),
+    branch: `${base}...${head}`,
+    fields: [
+      "hash",
+      "abbrevParentHashes",
+      "treeHash",
+      "authorName",
+      "authorEmail",
+      "authorDate",
+      "committerName",
+      "committerEmail",
+      "committerDate",
+      "subject",
+    ],
+  }
 
-const sha = "%H"
-const parents = "%p"
-const authorName = "%an"
-const authorEmail = "%ae"
-const authorDate = "%ai"
-const committerName = "%cn"
-const committerEmail = "%ce"
-const committerDate = "%ci"
-const message = "%s" // this is subject, not message, so it'll only be one line
+  const commits: GitCommit[] = gitlog(options).map(commit => ({
+    sha: commit.hash,
+    author: {
+      name: commit.authorName,
+      email: commit.authorEmail,
+      date: commit.authorDate,
+    },
+    committer: {
+      name: commit.committerName,
+      email: commit.committerEmail,
+      date: commit.committerDate,
+    },
+    message: commit.subject,
+    tree: commit.treeHash,
+    url: "fake.danger.systems/" + commit.hash,
+  }))
 
-const author = `"author": {"name": "${authorName}", "email": "${authorEmail}", "date": "${authorDate}" }`
-const committer = `"committer": {"name": "${committerName}", "email": "${committerEmail}", "date": "${committerDate}" }`
-export const formatJSON = `{ "sha": "${sha}", "parents": "${parents}", ${author}, ${committer}, "message": "${message}"},`
-
-export const localGetCommits = (base: string, head: string) =>
-  new Promise<GitCommit[]>((resolve, reject) => {
-    const args = ["log", `${base}...${head}`, `--pretty=format:${formatJSON}`]
-    const child = spawn("git", args, { env: process.env })
-    d("> git", args.join(" "))
-    const commits: GitCommit[] = []
-
-    child.stdout.on("data", async (chunk: Buffer) => {
-      const data = chunk.toString()
-      // remove trailing comma, and wrap into an array
-      const asJSONString = `[${data.substring(0, data.length - 1)}]`
-      const parsedCommits = JSON5.parse(asJSONString)
-      const realCommits = parsedCommits.map((c: any) => ({
-        ...c,
-        parents: c.parents.split(" "),
-        url: "fake.danger.systems/" + c.sha,
-      }))
-
-      commits.push(...realCommits)
-    })
-
-    child.stderr.on("end", () => resolve(commits))
-
-    const errorParts: string[] = []
-
-    child.stderr.on("data", (chunk: Buffer) => errorParts.push(chunk.toString()))
-
-    child.on("close", code => {
-      if (code !== 0) {
-        console.error(`Could not get commits from git between ${base} and ${head}`)
-        reject(new Error(errorParts.join("")))
-      } else {
-        resolve(commits)
-      }
-    })
-  })
+  return commits
+}

--- a/source/platforms/git/localGetCommits.ts
+++ b/source/platforms/git/localGetCommits.ts
@@ -14,7 +14,7 @@ const authorDate = "%ai"
 const committerName = "%cn"
 const committerEmail = "%ce"
 const committerDate = "%ci"
-const message = "%f" // this is subject, not message, so it'll only be one line
+const message = "%s" // this is subject, not message, so it'll only be one line
 
 const author = `"author": {"name": "${authorName}", "email": "${authorEmail}", "date": "${authorDate}" }`
 const committer = `"committer": {"name": "${committerName}", "email": "${committerEmail}", "date": "${committerDate}" }`

--- a/source/platforms/git/localGetCommits.ts
+++ b/source/platforms/git/localGetCommits.ts
@@ -1,37 +1,25 @@
-import gitlog, { GitlogOptions } from "gitlog"
-
+import { logGitCommits } from "./localLogGitCommits"
 import { GitCommit } from "../../dsl/Commit"
 
 export const localGetCommits = (base: string, head: string) => {
-  const options: GitlogOptions<
-    | "hash"
-    | "abbrevParentHashes"
-    | "treeHash"
-    | "authorName"
-    | "authorEmail"
-    | "authorDate"
-    | "committerName"
-    | "committerEmail"
-    | "committerDate"
-    | "subject"
-  > = {
-    repo: process.cwd(),
+  const options = {
+    number: 100,
     branch: `${base}...${head}`,
     fields: [
-      "hash",
-      "abbrevParentHashes",
-      "treeHash",
-      "authorName",
-      "authorEmail",
-      "authorDate",
-      "committerName",
-      "committerEmail",
-      "committerDate",
-      "subject",
+      "hash" as "hash",
+      "abbrevParentHashes" as "abbrevParentHashes",
+      "treeHash" as "treeHash",
+      "authorName" as "authorName",
+      "authorEmail" as "authorEmail",
+      "authorDate" as "authorDate",
+      "committerName" as "committerName",
+      "committerEmail" as "committerEmail",
+      "committerDate" as "committerDate",
+      "subject" as "subject",
     ],
   }
 
-  const commits: GitCommit[] = gitlog(options).map(commit => ({
+  const commits: GitCommit[] = logGitCommits(options).map(commit => ({
     sha: commit.hash,
     author: {
       name: commit.authorName,

--- a/source/platforms/git/localLogGitCommits.ts
+++ b/source/platforms/git/localLogGitCommits.ts
@@ -1,0 +1,97 @@
+import { execFileSync } from "child_process"
+
+const delimiter = "\t"
+const fieldMap = {
+  hash: "%H",
+  treeHash: "%T",
+  abbrevParentHashes: "%P",
+  authorName: "%an",
+  authorEmail: "%ae",
+  authorDate: "%ai",
+  committerName: "%cn",
+  committerEmail: "%ce",
+  committerDate: "%cd",
+  subject: "%s",
+}
+
+export type GitLogOptions = {
+  number: number
+  branch: string
+  fields: Array<Partial<keyof typeof fieldMap>>
+}
+
+export type GitLogCommit = {
+  hash: string
+  treeHash: string
+  abbrevParentHashes: string
+  authorName: string
+  authorEmail: string
+  authorDate: string
+  committerName: string
+  committerEmail: string
+  committerDate: string
+  subject: string
+}
+
+const createCommandArguments = (options: GitLogOptions) => {
+  // Start constructing command
+  let command: string[] = ["log", "-l0"]
+
+  command.push(`-n ${options.number}`)
+
+  // Start of custom format
+  let prettyArgument = "--pretty=@begin@"
+
+  // Iterating through the fields and adding them to the custom format
+  if (options.fields) {
+    options.fields.forEach(field => {
+      prettyArgument += delimiter + fieldMap[field]
+    })
+  }
+
+  // Close custom format
+  prettyArgument += "@end@"
+  command.push(prettyArgument)
+
+  // Append branch (revision range) if specified
+  if (options.branch) {
+    command.push(options.branch)
+  }
+
+  return command
+}
+
+const parseCommits = (commits: string[], fields: string[]) =>
+  commits.map(rawCommit => {
+    const parts = rawCommit.split("@end@")
+    const commit = parts[0].split(delimiter)
+
+    // Remove the first empty char from the array
+    commit.shift()
+
+    const parsed = {}
+
+    commit.forEach((commitField, index) => {
+      if (!fields[index]) {
+        return
+      }
+
+      parsed[fields[index]] = commitField
+    })
+
+    return parsed as GitLogCommit
+  })
+
+export const logGitCommits = (options: GitLogOptions) => {
+  const commandArguments = createCommandArguments(options)
+
+  const stdout = execFileSync("git", commandArguments).toString()
+
+  const commits = stdout.split("@begin@")
+
+  if (commits[0] === "") {
+    commits.shift()
+  }
+
+  return parseCommits(commits, options.fields)
+}

--- a/source/runner/Executor.ts
+++ b/source/runner/Executor.ts
@@ -70,7 +70,7 @@ export interface ExecutorOptions {
 const isTests = typeof jest === "object"
 
 interface ExitCodeContainer {
-  exitCode: number
+  exitCode?: number
 }
 
 export class Executor {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3756,14 +3756,6 @@ gitlab@^10.0.1:
     randomstring "^1.1.5"
     universal-url "^2.0.0"
 
-gitlog@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/gitlog/-/gitlog-4.0.4.tgz#8da6c08748dc290eb6c2fc11e3c505fb73715564"
-  integrity sha512-jeY2kO7CVyTa6cUM7ZD2ZxIyBkna1xvW2esV/3o8tbhiUneX1UBQCH4D9aMrHgGiohBjyXbuZogyjKXslnY5Yg==
-  dependencies:
-    debug "^4.1.1"
-    tslib "^1.14.1"
-
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
@@ -8692,11 +8684,6 @@ ts-node@^8.0.2:
     make-error "^1.1.1"
     source-map-support "^0.5.6"
     yn "^3.0.0"
-
-tslib@^1.14.1:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^1.8.0:
   version "1.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1169,9 +1169,9 @@
   integrity sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ==
 
 "@types/node@^10.11.3":
-  version "10.11.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.3.tgz#c055536ac8a5e871701aa01914be5731539d01ee"
-  integrity sha512-3AvcEJAh9EMatxs+OxAlvAEs7OTy6AG94mcH1iqyVDwVVndekLxzwkWQ/Z4SDbY6GO2oyUXyWW8tQ4rENSSQVQ==
+  version "10.17.55"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.55.tgz#a147f282edec679b894d4694edb5abeb595fecbd"
+  integrity sha512-koZJ89uLZufDvToeWO5BrC4CR4OUfHnUz2qoPs/daQH6qq3IN62QFxCTZ+bKaCE0xaoCAJYE4AXre8AbghCrhg==
 
 "@types/p-limit@^2.0.0":
   version "2.0.0"
@@ -3755,6 +3755,14 @@ gitlab@^10.0.1:
     query-string "^6.8.1"
     randomstring "^1.1.5"
     universal-url "^2.0.0"
+
+gitlog@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/gitlog/-/gitlog-4.0.4.tgz#8da6c08748dc290eb6c2fc11e3c505fb73715564"
+  integrity sha512-jeY2kO7CVyTa6cUM7ZD2ZxIyBkna1xvW2esV/3o8tbhiUneX1UBQCH4D9aMrHgGiohBjyXbuZogyjKXslnY5Yg==
+  dependencies:
+    debug "^4.1.1"
+    tslib "^1.14.1"
 
 glob-parent@^3.1.0:
   version "3.1.0"
@@ -8685,6 +8693,11 @@ ts-node@^8.0.2:
     source-map-support "^0.5.6"
     yn "^3.0.0"
 
+tslib@^1.14.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
 tslib@^1.8.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.1.tgz#6946af2d1d651a7b1863b531d6e5afa41aa44eac"
@@ -8837,10 +8850,10 @@ typescript@^3.0.1:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.3.tgz#01b70247a6d3c2467f70c45795ef5ea18ce191d5"
   integrity sha512-+81MUSyX+BaSo+u2RbozuQk/UWx6hfG0a5gHu4ANEM4sU96XbuIyAB+rWBW1u70c6a5QuZfuYICn3s2UjuHUpA==
 
-typescript@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.1.tgz#3362ba9dd1e482ebb2355b02dfe8bcd19a2c7c96"
-  integrity sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ==
+typescript@^3.9.7:
+  version "3.9.9"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.9.tgz#e69905c54bc0681d0518bd4d587cc6f2d0b1a674"
+  integrity sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==
 
 uglify-js@^2.6:
   version "2.8.29"


### PR DESCRIPTION
We want to use danger js locally to check the format of conventional commits for the commit messages. Due to that, we need to have a full unformatted subject line. Similar issue is explained in https://github.com/danger/danger-js/issues/977