### PR TITLE
Fix bold for Your Environment in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,7 +22,7 @@ Steps to reproduce the behavior:
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-** Your Environment**
+**Your Environment**
 <!--- Include as many relevant details about the environment you experienced the bug in -->
 
  | software         | version


### PR DESCRIPTION
There was an extra space after the first two stars.