### PR TITLE
add reviewers and assignees fields for GitLab API

### DIFF
--- a/source/dsl/GitLabDSL.ts
+++ b/source/dsl/GitLabDSL.ts
@@ -106,6 +106,9 @@ export interface GitLabMRBase {
   }
   /** Who was assigned as the person to review */
   assignee?: GitLabUser
+  assignees: GitLabUser[]
+  /** Users who were added as reviewers to the MR */
+  reviewers: GitLabUser[]
   source_project_id: number
   target_project_id: number
   labels: string[]


### PR DESCRIPTION
PR closes #1164 

Add the following properties to `GitLabMRBase` interface:
- reviewers
- assignees

In the "[Get Single MR](https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr)" of Merge Requests API documentation, we can find an example of a response. Here I'm going to post just an interesting part of the response. 

```
{
  "id": 1,
  "iid": 1,
  "project_id": 3,
  "title": "test1",
  "description": "fixed login page css paddings",
  "state": "merged",
  "created_at": "2017-04-29T08:46:00Z",
  "updated_at": "2017-04-29T08:46:00Z",
  "target_branch": "master",
  "source_branch": "test1",
  "upvotes": 0,
  "downvotes": 0,
  "author": {
    "id": 1,
    "name": "Administrator",
    "username": "admin",
    "state": "active",
    "avatar_url": null,
    "web_url" : "https://gitlab.example.com/admin"
  },
  "user" : {
    "can_merge" : false
  },
  "assignee": {
    "id": 1,
    "name": "Administrator",
    "username": "admin",
    "state": "active",
    "avatar_url": null,
    "web_url" : "https://gitlab.example.com/admin"
  },
  "assignees": [{
    "name": "Miss Monserrate Beier",
    "username": "axel.block",
    "id": 12,
    "state": "active",
    "avatar_url": "http://www.gravatar.com/avatar/46f6f7dc858ada7be1853f7fb96e81da?s=80&d=identicon",
    "web_url": "https://gitlab.example.com/axel.block"
  }],
  "reviewers": [{
    "id": 2,
    "name": "Sam Bauch",
    "username": "kenyatta_oconnell",
    "state": "active",
    "avatar_url": "https://www.gravatar.com/avatar/956c92487c6f6f7616b536927e22c9a0?s=80&d=identicon",
    "web_url": "http://gitlab.example.com//kenyatta_oconnell"
  }],
// ....
```