### PR TITLE
Update micromatch to resolve critical audit dependency vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "lodash.mapvalues": "^4.6.0",
     "lodash.memoize": "^4.1.2",
     "memfs-or-file-map-to-github-branch": "^1.1.0",
-    "micromatch": "^3.1.10",
+    "micromatch": "^4.0.4",
     "node-cleanup": "^2.1.2",
     "node-fetch": "2.6.1",
     "override-require": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5952,6 +5952,14 @@ micromatch@^4.0.2:
     braces "^3.0.1"
     picomatch "^2.0.5"
 
+micromatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
+  integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.2.3"
+
 mime-db@1.40.0:
   version "1.40.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
@@ -6917,6 +6925,11 @@ picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
+picomatch@^2.2.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
+  integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
[Related issue](https://github.com/danger/danger-js/issues/1154)

Updates micromatch major dependency version which does not have the vulnerability.
> yarn audit --level critical --groups dependencies

Note that micromatch >= 4.0.0 requires Node 8.6*

* [https://github.com/micromatch/micromatch/blob/master/CHANGELOG.md#400---2019-03-20](https://github.com/micromatch/micromatch/blob/master/CHANGELOG.md#400---2019-03-20)