### PR TITLE
Add ability to ouput results as JSON

### DIFF
--- a/source/commands/ci/runner.ts
+++ b/source/commands/ci/runner.ts
@@ -62,7 +62,7 @@ export const runRunner = async (app: SharedCLI, config?: Partial<RunnerConfig>) 
       const execConfig: ExecutorOptions = {
         stdoutOnly: !platform.supportsCommenting() || app.textOnly,
         verbose: app.verbose,
-        jsonOnly: false,
+        jsonOnly: app.outputJSON,
         dangerID: app.id || "Danger",
         passURLForDSL: app.passURLForDSL || false,
         disableGitHubChecksSupport: !app.useGithubChecks,

--- a/source/commands/danger-local.ts
+++ b/source/commands/danger-local.ts
@@ -19,6 +19,7 @@ program
   .description("Runs danger without PR metadata, useful for git hooks.")
   .option("-s, --staging", "Just use staged changes.")
   .option("-b, --base [branch_name]", "Use a different base branch")
+  .option("-j, --outputJSON", "Outputs the resulting JSON to STDOUT")
   .allowUnknownOption(true)
 setSharedArgs(program).parse(process.argv)
 

--- a/source/commands/utils/sharedDangerfileArgs.ts
+++ b/source/commands/utils/sharedDangerfileArgs.ts
@@ -33,6 +33,8 @@ export interface SharedCLI extends program.CommanderStatic {
   newComment?: boolean
   /** Removes all previous comment and create a new one in the end of the list */
   removePreviousComments?: boolean
+  /** Output JSON to STDOUT */
+  outputJSON: boolean
 }
 
 export default (command: any) =>


### PR DESCRIPTION
This adds the `--outputJSON` parameter so the resulting JSON can be used locally or on CI for further automations.

#### Example usage: `danger local --outputJSON`

#### STDOUT Output
```json
{
  "fails": [],
  "warnings": [],
  "messages": [    
    {
      "message": "foobar"
    }
  ],
  "markdowns": []
}
```