### PR TITLE
Release 10.8.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,9 @@ jobs:
     steps:
       # Check out, and set up the node/ruby infra
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - actions/setup-node@v2
+        with:
+          node-version: '14'
 
       # Get local dependencies & test
       - run: yarn install

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       # Check out, and set up the node/ruby infra
       - uses: actions/checkout@v1
-      - actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
           node-version: '14'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ cache:
 matrix:
   include:
     # Normal CI test runs :D
-    - node_js: "10"
+    - node_js: "14"
 
-    - node_js: "10"
+    - node_js: "14"
       after_script:
         - echo "Validating TypeScript definition file"
         - yarn build
@@ -23,13 +23,13 @@ matrix:
         - yarn flow check
 
     # Checks every example dangerfile can run in `danger runner`.
-    - node_js: "10"
+    - node_js: "14"
       script:
         - yarn build
         - node scripts/run-fixtures.js
 
     # Runs both the CI and PR with a custom process to ensure apps like swift/rust work
-    - node_js: "10.13"
+    - node_js: "14"
       script:
         - yarn build
         - node distribution/commands/danger-ci.js --process "ruby scripts/danger_runner.rb"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@
 
 # 10.8.0
 
-- Feature: `danger local --outputJSON` for https://github.com/danger/danger-js/pull/1177] [@orta]
+- Feature: `danger local --outputJSON` for [#1177](https://github.com/danger/danger-js/pull/1177) [@orta]
 - Fix: Updates `jsonpointer` for [#1174](https://github.com/danger/danger-js/pull/1174) [@unfernandito]
+- Fix: Updates `parse-link-header` for CVE-2021-23490 [#1190](https://github.com/danger/danger-js/pull/1190) [@fbartho]
 
 # 10.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
 
 <!-- Your comment above this -->
 
+# 10.8.0
+
+- Feature: `danger local --outputJSON` for https://github.com/danger/danger-js/pull/1177] [@orta]
+- Fix: Updates `jsonpointer` for [#1174](https://github.com/danger/danger-js/pull/1174) [@unfernandito]
+
 # 10.7.1
 
 - Updates micromatch dependencies for CVE-2021-23440

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "parse-diff": "^0.7.0",
     "parse-git-config": "^2.0.3",
     "parse-github-url": "^1.0.2",
-    "parse-link-header": "^1.0.1",
+    "parse-link-header": "^2.0.0",
     "pinpoint": "^1.1.0",
     "prettyjson": "^1.2.1",
     "readline-sync": "^1.4.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danger",
-  "version": "10.7.1",
+  "version": "10.8.0",
   "description": "Unit tests for Team Culture",
   "main": "distribution/danger.js",
   "typings": "distribution/danger.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5305,10 +5305,10 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
-jsonpointer@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
-  integrity sha1-T9kss04OnbPInIYi7PUfm5eMbLk=
+jsonpointer@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-5.0.0.tgz#f802669a524ec4805fa7389eadbc9921d5dc8072"
+  integrity sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==
 
 jsonwebtoken@^8.4.0:
   version "8.4.0"
@@ -6790,10 +6790,10 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
-parse-link-header@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/parse-link-header/-/parse-link-header-1.0.1.tgz#bedfe0d2118aeb84be75e7b025419ec8a61140a7"
-  integrity sha1-vt/g0hGK64S+deewJUGeyKYRQKc=
+parse-link-header@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parse-link-header/-/parse-link-header-2.0.0.tgz#949353e284f8aa01f2ac857a98f692b57733f6b7"
+  integrity sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==
   dependencies:
     xtend "~4.0.1"
 


### PR DESCRIPTION
I don't have permission to push directly to the `main` as specified in the [Contributing Guidelines](https://github.com/danger/danger-js/blob/main/CONTRIBUTING.md#releasing-a-new-version-of-danger)

This means I can neither update the Changelog directly, nor can I tag the release. Sorry for making work for you @orta!