### PR TITLE
[Maintenance] Switch to node-14 as the oldest tested environment

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": [["@babel/preset-env", { "targets": { "node": "6" }, "useBuiltIns": "usage" }]],
+  "presets": [["@babel/preset-env", { "targets": { "node": "14" }, "useBuiltIns": "usage" }]],
   "plugins": ["@babel/plugin-transform-flow-strip-types"]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": [["@babel/preset-env", { "targets": { "node": "14" }, "useBuiltIns": "usage" }]],
+  "presets": [["@babel/preset-env", { "targets": { "node": "6" }, "useBuiltIns": "usage" }]],
   "plugins": ["@babel/plugin-transform-flow-strip-types"]
 }

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,9 @@ jobs:
     steps:
       # Check out, and set up the node/ruby infra
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - actions/setup-node@v2
+        with:
+          node-version: '14'
 
       # Get local dependencies & test
       - run: yarn install

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ cache:
 matrix:
   include:
     # Normal CI test runs :D
-    - node_js: "10"
+    - node_js: "14"
 
-    - node_js: "10"
+    - node_js: "14"
       after_script:
         - echo "Validating TypeScript definition file"
         - yarn build
@@ -23,13 +23,13 @@ matrix:
         - yarn flow check
 
     # Checks every example dangerfile can run in `danger runner`.
-    - node_js: "10"
+    - node_js: "14"
       script:
         - yarn build
         - node scripts/run-fixtures.js
 
     # Runs both the CI and PR with a custom process to ensure apps like swift/rust work
-    - node_js: "10.13"
+    - node_js: "14"
       script:
         - yarn build
         - node distribution/commands/danger-ci.js --process "ruby scripts/danger_runner.rb"


### PR DESCRIPTION
`create-react-app` requires >= node-14, and our test-CI workflow requires create-react-app to succeed. See the CI failure in #1188 

This PR upgrades all the node-versions that I could find from 10, 10.3, or unspecified, to node 14.

## Alternatives

A. only upgrade the CI for that particular GitHub action workflow
B. upgrade to node-16 (14 has already been in maintenance mode for a long time)
C. upgrade to node-17 
D. upgrade to node-18 (18 won't enter LTS until October)
E. Delete the create-react-app test case

[Node Version Chart](https://nodejs.org/en/about/releases/)

We could also add an entry to our package.json `engines` to express whichever decision we make.

## Blocking

This PR Blocks: #1176, #1186, #1188, #1190, and any future PRs from going green in CI
