### PR TITLE
Fix: Updates `parse-link-header` for CVE-2021-23490

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@
 
 # 10.8.0
 
-- Feature: `danger local --outputJSON` for https://github.com/danger/danger-js/pull/1177] [@orta]
+- Feature: `danger local --outputJSON` for [#1177](https://github.com/danger/danger-js/pull/1177) [@orta]
 - Fix: Updates `jsonpointer` for [#1174](https://github.com/danger/danger-js/pull/1174) [@unfernandito]
+- Fix: Updates `parse-link-header` for CVE-2021-23490 [#1190](https://github.com/danger/danger-js/pull/1190) [@fbartho]
 
 # 10.7.1
 

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "parse-diff": "^0.7.0",
     "parse-git-config": "^2.0.3",
     "parse-github-url": "^1.0.2",
-    "parse-link-header": "^1.0.1",
+    "parse-link-header": "^2.0.0",
     "pinpoint": "^1.1.0",
     "prettyjson": "^1.2.1",
     "readline-sync": "^1.4.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5305,10 +5305,10 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
-jsonpointer@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
-  integrity sha1-T9kss04OnbPInIYi7PUfm5eMbLk=
+jsonpointer@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-5.0.0.tgz#f802669a524ec4805fa7389eadbc9921d5dc8072"
+  integrity sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==
 
 jsonwebtoken@^8.4.0:
   version "8.4.0"
@@ -6790,10 +6790,10 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
-parse-link-header@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/parse-link-header/-/parse-link-header-1.0.1.tgz#bedfe0d2118aeb84be75e7b025419ec8a61140a7"
-  integrity sha1-vt/g0hGK64S+deewJUGeyKYRQKc=
+parse-link-header@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parse-link-header/-/parse-link-header-2.0.0.tgz#949353e284f8aa01f2ac857a98f692b57733f6b7"
+  integrity sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==
   dependencies:
     xtend "~4.0.1"
 


### PR DESCRIPTION
![Screenshot of Dependabot's Security Alert in my repo](https://user-images.githubusercontent.com/209712/148464285-05d54396-f001-4b3e-b4f5-8bacc48ba923.png)

**Note: This PR is green, locally. It just fails in CI because of the Node-10 failure that is resolved in #1189**