### PR TITLE
chore: Switch from tslint to eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+source/danger.d.ts
+source/runner/_tests/fixtures/*.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,66 @@
+module.exports = {
+  env: {
+    browser: true,
+    es6: true,
+    node: true,
+  },
+  extends: ["plugin:@typescript-eslint/recommended", "plugin:jest/recommended", "prettier"],
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: "tsconfig.spec.json",
+    sourceType: "module",
+  },
+  plugins: ["eslint-plugin-jest", "eslint-plugin-jsdoc", "@typescript-eslint"],
+  rules: {
+    "@typescript-eslint/naming-convention": "error",
+    "@typescript-eslint/no-empty-function": "error",
+    "@typescript-eslint/no-unused-expressions": "error",
+
+    // Something is grumpy about these rules re: node imports - TODO
+    "@typescript-eslint/no-require-imports": "off",
+    "@typescript-eslint/no-var-requires": "off",
+
+    curly: "error",
+    "jsdoc/check-alignment": "error",
+    "jsdoc/check-indentation": "off",
+    "jsdoc/newline-after-description": "off",
+    "no-empty": "error",
+    // This is used intentionally in a bunch of ci_source/providers
+    "no-empty-function": "off",
+    "no-redeclare": "error",
+    "no-var": "error",
+    // There are a bunch of existing uses of 'let' where this rule would trigger
+    "prefer-const": "off",
+
+    // This project has a ton of interacting APIs, and sometimes it's helpful to be explicit, even if the type is trivial
+    "@typescript-eslint/no-inferrable-types": "off",
+
+    "no-unused-expressions": "off",
+    "@typescript-eslint/no-unused-expressions": "error",
+
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        // Allow function args to be unused
+        args: "none",
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+        caughtErrorsIgnorePattern: "^_",
+      },
+    ],
+
+    "jest/no-disabled-tests": "warn",
+    "jest/no-focused-tests": "error",
+    "jest/no-identical-title": "error",
+    "jest/prefer-to-have-length": "off",
+    "jest/valid-expect": "error",
+    "@typescript-eslint/no-non-null-assertion": "off",
+    // Tons of violations in the codebase
+    "@typescript-eslint/naming-convention": "off",
+    // Used liberally in the codebase
+    "@typescript-eslint/no-explicit-any": "off",
+    // This has value in communicating with other Developers even if it has no functional effect.
+    "@typescript-eslint/no-empty-interface": "off",
+  },
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "Orta.vscode-jest",
     "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint",
     "christian-kohler.path-intellisense",
     "wayou.vscode-todo-highlight"
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 <!-- Your comment below this -->
 
+- *Chore:* Switch from tslint to eslint (tslint is end-of-life) - [#1205](https://github.com/danger/danger-js/pull/1205) [@fbartho]
 
 <!-- Your comment above this -->
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # Test against this version of Node.js
 environment:
-  nodejs_version: "10"
+  nodejs_version: "12"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
       "git add"
     ],
     "*.@(ts|tsx)": [
-      "tslint --fix",
+      "eslint --fix",
       "yarn prettier --write",
       "git add"
     ]
@@ -56,8 +56,8 @@
     "test:fixtures": "node ./scripts/run-fixtures.js",
     "test:update-fixtures": "yarn test:fixtures --update",
     "test:watch": "jest --watch",
-    "lint": "tslint \"source/**/*.ts\"",
-    "lint:fix": "tslint \"source/**/*.ts\" --fix",
+    "lint": "eslint \"source/*.ts\" \"source/**/*.ts\"",
+    "lint:fix": "yarn --silent lint --fix",
     "prepublishOnly": "yarn build && yarn jest && yarn declarations && yarn build:flow-types && yarn build:pretty-types",
     "build": "shx rm -rf ./distribution && tsc -p tsconfig.production.json && madge ./distribution --circular",
     "build:fast": "tsc -p tsconfig.production.json",
@@ -114,9 +114,15 @@
     "@types/prettier": "^1.16.1",
     "@types/readline-sync": "^1.4.3",
     "@types/voca": "^1.4.0",
+    "@typescript-eslint/eslint-plugin": "^5.10.1",
+    "@typescript-eslint/parser": "^5.10.1",
     "danger-plugin-jest": "^1.0.1",
     "danger-plugin-yarn": "^1.3.1",
     "date-fns": "^1.29.0",
+    "eslint": "^8.8.0",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-jest": "^26.0.0",
+    "eslint-plugin-jsdoc": "^37.7.0",
     "flow-bin": "^0.77.0",
     "husky": "^1.0.1",
     "jest": "^24.0.0",
@@ -130,8 +136,6 @@
     "shx": "^0.3.2",
     "ts-jest": "^24.0.2",
     "ts-node": "^8.0.2",
-    "tslint": "^5.11.0",
-    "tslint-config-prettier": "^1.15.0",
     "typedoc": "0.9.0",
     "typescript": "^4.5.5",
     "typescript-json-schema": "^0.32.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
       "git add"
     ],
     "*.@(ts|tsx)": [
-      "eslint --fix",
+      "yarn lint:fix",
       "yarn prettier --write",
       "git add"
     ]
@@ -131,7 +131,7 @@
     "madge": "^3.2.0",
     "nock": "^10.0.6",
     "pkg": "^4.4.2",
-    "prettier": "^1.14.2",
+    "prettier": "^2.5.1",
     "release-it": "^13.5.2",
     "shx": "^0.3.2",
     "ts-jest": "^24.0.2",

--- a/scripts/create-danger-dts.ts
+++ b/scripts/create-danger-dts.ts
@@ -24,7 +24,7 @@ if (allDiagnostics.length) {
   console.log(
     "\nIf you've added something new to the DSL, and the errors are about something missing, you may need to add an interface in `source/dsl/*`."
   )
-  allDiagnostics.forEach(diagnostic => {
+  allDiagnostics.forEach((diagnostic) => {
     if (diagnostic.file) {
       let { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start!)
       let message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n")

--- a/scripts/danger-dts.ts
+++ b/scripts/danger-dts.ts
@@ -1,11 +1,7 @@
 import * as fs from "fs"
 import * as prettier from "prettier"
 
-const mapLines = (s: string, func: (s: string) => string) =>
-  s
-    .split("\n")
-    .map(func)
-    .join("\n")
+const mapLines = (s: string, func: (s: string) => string) => s.split("\n").map(func).join("\n")
 
 const createDTS = () => {
   const header = `//
@@ -23,10 +19,10 @@ import { File } from "parse-diff"
 
   const dslFiles = fs
     .readdirSync("source/dsl")
-    .filter(f => !f.startsWith("_tests"))
-    .map(f => `source/dsl/${f}`)
+    .filter((f) => !f.startsWith("_tests"))
+    .map((f) => `source/dsl/${f}`)
 
-  dslFiles.forEach(file => {
+  dslFiles.forEach((file) => {
     // Sometimes they have more stuff, in those cases
     // offer a way to crop the file.
     const content = fs.readFileSync(file).toString()
@@ -72,7 +68,7 @@ import { File } from "parse-diff"
   const chainDefs = fs.readFileSync("distribution/commands/utils/chainsmoker.d.ts", "utf8")
   const chainDefsMinusDefaultExport = chainDefs
     .split("\n")
-    .filter(line => {
+    .filter((line) => {
       return !line.startsWith("export default function")
     })
     .join("\n")
@@ -82,10 +78,10 @@ import { File } from "parse-diff"
   // Remove all JS-y bits
   fileOutput = fileOutput
     .split("\n")
-    .filter(line => {
+    .filter((line) => {
       return !line.startsWith("import") && !line.includes("* @type ")
     })
-    .filter(line => {
+    .filter((line) => {
       return !line.includes("Please don't have")
     })
     .join("\n")
@@ -94,7 +90,7 @@ import { File } from "parse-diff"
   const noRedundantExports = trimmedWhitespaceLines
     .replace(/export interface/g, "interface")
     .replace(/export type/g, "type")
-  const indentedBody = mapLines(noRedundantExports, line => (line.length ? line : ""))
+  const indentedBody = mapLines(noRedundantExports, (line) => (line.length ? line : ""))
 
   const def = header + indentedBody + footer
 

--- a/source/api/fetch.ts
+++ b/source/api/fetch.ts
@@ -63,12 +63,12 @@ export function api(
   url: string | node_fetch.Request,
   init: node_fetch.RequestInit,
   suppressErrorReporting?: boolean,
-  provessEnv: NodeJS.ProcessEnv = process.env
+  processEnv: NodeJS.ProcessEnv = process.env
 ): Promise<node_fetch.Response> {
   const isTests = typeof jest !== "undefined"
   if (isTests && !url.toString().includes("localhost")) {
     const message = `No API calls in tests please: ${url}`
-    debugger // tslint:disable-line
+    debugger
     throw new Error(message)
   }
 
@@ -79,8 +79,8 @@ export function api(
       output.push(`-X ${init.method}`)
     }
 
-    const showToken = provessEnv["DANGER_VERBOSE_SHOW_TOKEN"]
-    const token = provessEnv["DANGER_GITHUB_API_TOKEN"] || provessEnv["GITHUB_TOKEN"]
+    const showToken = processEnv["DANGER_VERBOSE_SHOW_TOKEN"]
+    const token = processEnv["DANGER_GITHUB_API_TOKEN"] || processEnv["GITHUB_TOKEN"]
 
     if (init.headers) {
       for (const prop in init.headers) {
@@ -109,7 +109,7 @@ export function api(
 
   let agent = init.agent
   const proxy =
-    provessEnv["HTTPS_PROXY"] || provessEnv["https_proxy"] || provessEnv["HTTP_PROXY"] || provessEnv["http_proxy"]
+    processEnv["HTTPS_PROXY"] || processEnv["https_proxy"] || processEnv["HTTP_PROXY"] || processEnv["http_proxy"]
 
   if (!agent && proxy) {
     let secure = url.toString().startsWith("https")

--- a/source/ci_source/get_ci_source.ts
+++ b/source/ci_source/get_ci_source.ts
@@ -30,7 +30,8 @@ export async function getCISourceForExternal(env: Env, modulePath: string): Prom
         console.error(`could not load CI provider at ${modulePath} due to ${error}`)
       }
       if (stat && stat.isFile()) {
-        const externalModule = require(path) //tslint:disable-line:no-require-imports
+        // eslint-disable-next-line
+        const externalModule = require(path) //  @typescript-eslint/no-var-requires @typescript-eslint/no-require-imports
         const moduleConstructor = externalModule.default || externalModule
         resolve(new moduleConstructor(env))
       }

--- a/source/ci_source/providers/_tests/_bamboo.test.ts
+++ b/source/ci_source/providers/_tests/_bamboo.test.ts
@@ -54,6 +54,7 @@ describe(".isPR", () => {
 
     it("needs to have a PR number", () => {
       let env = Object.assign({}, correctEnv)
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       delete env["bamboo_repository_pr_key"]
       const pipelines = new Bamboo(env)

--- a/source/ci_source/providers/_tests/_buddyWorks.test.ts
+++ b/source/ci_source/providers/_tests/_buddyWorks.test.ts
@@ -52,6 +52,7 @@ describe(".isPR", () => {
 
   it("needs to have a PR number", () => {
     const env = Object.assign({}, correctEnv)
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     delete env.BUDDY_EXECUTION_PULL_REQUEST_NO
     const buddyWorks = new BuddyWorks(env)

--- a/source/ci_source/providers/_tests/_codebuild.test.ts
+++ b/source/ci_source/providers/_tests/_codebuild.test.ts
@@ -9,7 +9,7 @@ const correctEnv = {
   DANGER_GITHUB_API_TOKEN: "xxx",
 }
 
-const setupCodeBuildSource = async (env: Object) => {
+const setupCodeBuildSource = async (env: Record<string, unknown>) => {
   const source = new CodeBuild(env)
   await source.setup()
 

--- a/source/ci_source/providers/_tests/_gitHubActions.test.ts
+++ b/source/ci_source/providers/_tests/_gitHubActions.test.ts
@@ -51,7 +51,8 @@ describe("pullRequestID", () => {
   it("throws an error when event.json doesn't contain issue or pull_request data", () => {
     const ci = new GitHubActions({}, {})
     expect(() => {
-      // tslint:disable-next-line:no-unused-expression
+      // eslint-disable-next-line no-unused-expressions
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       ci.pullRequestID
     }).toThrow()
   })
@@ -71,7 +72,8 @@ describe("repoSlug", () => {
   it("throws an error when event.json doesn't contain issue or pull_request data", () => {
     const ci = new GitHubActions({}, {})
     expect(() => {
-      // tslint:disable-next-line:no-unused-expression
+      // eslint-disable-next-line no-unused-expressions
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       ci.repoSlug
     }).toThrow()
   })

--- a/source/commands/ci/_tests/runner.test.ts
+++ b/source/commands/ci/_tests/runner.test.ts
@@ -81,6 +81,7 @@ it("passes the strictm option from args into the executor config", async () => {
 })
 
 // TODO: This occasionally fails!
+// eslint-disable-next-line jest/no-disabled-tests
 it.skip("passes the dangerID from args into the executor config", async () => {
   const customArgs = {
     ...defaultAppArgs,

--- a/source/commands/ci/runner.ts
+++ b/source/commands/ci/runner.ts
@@ -3,7 +3,7 @@ import { debug } from "../../debug"
 
 import { getPlatformForEnv, Platform } from "../../platforms/platform"
 import { Executor, ExecutorOptions } from "../../runner/Executor"
-import { runDangerSubprocess, addSubprocessCallAguments } from "../utils/runDangerSubprocess"
+import { runDangerSubprocess, addSubprocessCallArguments } from "../utils/runDangerSubprocess"
 import { SharedCLI } from "../utils/sharedDangerfileArgs"
 import getRuntimeCISource from "../utils/getRuntimeCISource"
 
@@ -73,7 +73,7 @@ export const runRunner = async (app: SharedCLI, config?: Partial<RunnerConfig>) 
         removePreviousComments: app.removePreviousComments || false,
       }
 
-      const processName = (app.process && addSubprocessCallAguments(app.process.split(" "))) || undefined
+      const processName = (app.process && addSubprocessCallArguments(app.process.split(" "))) || undefined
       const runnerCommand = processName || dangerRunToRunnerCLI(process.argv)
       d(`Preparing to run: ${runnerCommand}`)
 

--- a/source/commands/danger-runner.ts
+++ b/source/commands/danger-runner.ts
@@ -23,8 +23,6 @@ const d = debug("runner")
 
 // Given the nature of this command, it can be tricky to test, so I use a command like this:
 //
-// tslint:disable-next-line:max-line-length
-//
 // yarn build; cat source/_tests/fixtures/danger-js-pr-395.json | env DANGER_FAKE_CI="YEP" DANGER_TEST_REPO='danger/danger-js' DANGER_TEST_PR='395' node distribution/commands/danger-runner.js --text-only
 //
 // Which will build danger, then run just the dangerfile runner with a fixtured version of the JSON

--- a/source/commands/init/default-dangerfile.ts
+++ b/source/commands/init/default-dangerfile.ts
@@ -39,7 +39,7 @@ export const generateDefaultDangerfile = (state: InitState) => {
 
 export const formatDangerfile = (dangerfile: string, dangerfileState: any) => {
   if (dangerfileState.hasPrettier) {
-    // tslint:disable-next-line:no-require-imports
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { format } = require("prettier")
     // Get package settings
     const localPrettier = fs.existsSync("package.json") && JSON.parse(fs.readFileSync("package.json", "utf8")).prettier

--- a/source/commands/init/interfaces.ts
+++ b/source/commands/init/interfaces.ts
@@ -22,10 +22,10 @@ export interface InitState {
 }
 
 export interface InitUI {
-  header: (msg: String) => void
+  header: (msg: string) => void
   command: (command: string) => void
-  say: (msg: String) => void
-  pause: (secs: number) => Promise<{}>
+  say: (msg: string) => void
+  pause: (secs: number) => Promise<unknown>
   waitForReturn: () => void
   link: (name: string, href: string) => string
   askWithAnswers: (message: string, answers: string[]) => string

--- a/source/commands/init/state-setup.ts
+++ b/source/commands/init/state-setup.ts
@@ -11,14 +11,14 @@ import { getRepoSlug } from "./get-repo-slug"
 import { InitState, InitUI } from "./interfaces"
 
 export const createUI = (state: InitState, app: any): InitUI => {
-  const say = (msg: String) => console.log(msg)
+  const say = (msg: string) => console.log(msg)
   const fancyLink = (name: string, href: string) => hyperLinker(name, href)
   const inlineLink = (_name: string, href: string) => chalk.underline(href)
   const linkToUse = state.supportsHLinks ? fancyLink : inlineLink
 
   return {
     say,
-    header: (msg: String) => say(chalk.bold("\n## " + msg + "\n")),
+    header: (msg: string) => say(chalk.bold("\n## " + msg + "\n")),
     command: (command: string) => say("> " + chalk.white.bold(command) + " \n"),
     link: (name: string, href: string) => linkToUse(name, href),
     pause: async (secs: number) => new Promise(done => setTimeout(done, secs * 1000)),

--- a/source/commands/utils/_tests/dangerRunToRunnerCLI.test.ts
+++ b/source/commands/utils/_tests/dangerRunToRunnerCLI.test.ts
@@ -1,5 +1,5 @@
 import dangerRunToRunnerCLI from "../dangerRunToRunnerCLI"
-import { addSubprocessCallAguments } from "../runDangerSubprocess"
+import { addSubprocessCallArguments } from "../runDangerSubprocess"
 
 describe("it can handle the command", () => {
   it("`danger ci`", () => {
@@ -52,7 +52,7 @@ it("`danger pr --dangerfile 'myDanger file.ts'`", () => {
 
 it("Adds correct subprocess arguments", () => {
   expect(
-    addSubprocessCallAguments(
+    addSubprocessCallArguments(
       ["danger-swift"],
       ["danger", "danger-pr", "--process", "danger-swift", "--dangerfile", "File.swift"]
     )
@@ -61,9 +61,11 @@ it("Adds correct subprocess arguments", () => {
 
 describe("npx danger-ts", () => {
   it("switches to the danger in the node_mods", () => {
+    expect.assertions(1)
     // the code uses join which gives different results on windows, and I'm too lazy to add a specific test for that
     const isWindows = process.platform === "win32"
     if (!isWindows) {
+      // eslint-disable-next-line jest/no-conditional-expect
       expect(
         dangerRunToRunnerCLI([
           "/Users/ortatherox/.nvm/versions/node/v14.5.0/bin/node",
@@ -73,6 +75,10 @@ describe("npx danger-ts", () => {
         "/Users/ortatherox/.nvm/versions/node/v14.5.0/bin/node",
         "/Users/ortatherox/.npm/_npx/23085/lib/node_modules/danger-ts/node_modules/danger/distribution/commands/danger-runner.js",
       ])
+    } else {
+      console.warn("Unimplemented test on windows")
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(true).toBe(true)
     }
   })
 })

--- a/source/commands/utils/runDangerSubprocess.ts
+++ b/source/commands/utils/runDangerSubprocess.ts
@@ -19,6 +19,7 @@ const messageToSendDSL = "danger://send-dsl"
 // Sanitizes the DSL so for sending via STDOUT
 export const prepareDangerDSL = (dangerDSL: DangerDSLJSONType) => {
   if (dangerDSL.github && dangerDSL.github.api) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     delete dangerDSL.github.api
   }
@@ -27,9 +28,12 @@ export const prepareDangerDSL = (dangerDSL: DangerDSLJSONType) => {
   return JSON.stringify(dangerJSONOutput, null, "  ") + "\n"
 }
 
-export const addSubprocessCallAguments = (call: string[], args: string[] = process.argv): string[] => {
+export const addSubprocessCallArguments = (call: string[], args: string[] = process.argv): string[] => {
   return call.concat(["runner"], args.slice(1, args.length))
 }
+
+// @deprecated
+export const addSubprocessCallAguments = addSubprocessCallArguments
 
 // Runs the Danger process
 export const runDangerSubprocess = (

--- a/source/dsl/_tests/DangerResults.test.ts
+++ b/source/dsl/_tests/DangerResults.test.ts
@@ -67,7 +67,7 @@ describe("DangerInlineResults into DangerResults", () => {
 })
 
 describe("DangerResults operations", () => {
-  it("merges two results correcly", () => {
+  it("merges two results correctly", () => {
     const results = mergeResults(singleViolationSingleFileResults, multipleViolationSingleFileResults)
 
     expect(results).toMatchSnapshot()
@@ -97,7 +97,7 @@ describe("DangerResults operations", () => {
     expect(result).toEqual(true)
   })
 
-  it("find empty results", () => {
+  it("find empty results - multiple violations in a single file", () => {
     const result = isEmptyResults(multipleViolationSingleFileResults)
 
     expect(result).toEqual(false)

--- a/source/dsl/_tests/__snapshots__/DangerResults.test.ts.snap
+++ b/source/dsl/_tests/__snapshots__/DangerResults.test.ts.snap
@@ -265,7 +265,7 @@ Object {
 }
 `;
 
-exports[`DangerResults operations merges two results correcly 1`] = `
+exports[`DangerResults operations merges two results correctly 1`] = `
 Object {
   "fails": Array [
     Object {

--- a/source/platforms/BitBucketCloud.ts
+++ b/source/platforms/BitBucketCloud.ts
@@ -153,7 +153,7 @@ export class BitBucketCloud implements Platform {
 
     let state: "SUCCESSFUL" | "INPROGRESS" | "FAILED" = passed ? "SUCCESSFUL" : "FAILED"
     if (passed === "pending") {
-      state = "INPROGRESS" as "INPROGRESS"
+      state = "INPROGRESS" as const
     }
 
     let name = "Danger"

--- a/source/platforms/_tests/_bitbucket_cloud.test.ts
+++ b/source/platforms/_tests/_bitbucket_cloud.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "fs"
 const fixtures = resolve(__dirname, "fixtures")
 
 /** Returns JSON from the fixtured dir */
+// eslint-disable-next-line jest/no-export
 export const requestWithFixturedJSON = async (path: string): Promise<() => Promise<any>> => () =>
   Promise.resolve(JSON.parse(readFileSync(`${fixtures}/${path}`, {}).toString()))
 

--- a/source/platforms/_tests/_bitbucket_server.test.ts
+++ b/source/platforms/_tests/_bitbucket_server.test.ts
@@ -4,10 +4,11 @@ import { readFileSync } from "fs"
 const fixtures = resolve(__dirname, "fixtures")
 
 /** Returns JSON from the fixtured dir */
+// eslint-disable-next-line jest/no-export
 export const requestWithFixturedJSON = async (path: string): Promise<() => Promise<any>> => () =>
   Promise.resolve(JSON.parse(readFileSync(`${fixtures}/${path}`, {}).toString()))
 
-class mockBitBucketServerAPI /*tslint:disable-line*/ {
+class mockBitBucketServerAPI {
   async getPullRequestInfo() {
     const fixtures = await requestWithFixturedJSON("bitbucket_server_pr.json")
     return await fixtures()

--- a/source/platforms/_tests/_github.test.ts
+++ b/source/platforms/_tests/_github.test.ts
@@ -4,10 +4,11 @@ import { readFileSync } from "fs"
 const fixtures = resolve(__dirname, "fixtures")
 
 /** Returns JSON from the fixtured dir */
+// eslint-disable-next-line jest/no-export
 export const requestWithFixturedJSON = async (path: string): Promise<() => Promise<any>> => () =>
   Promise.resolve(JSON.parse(readFileSync(`${fixtures}/${path}`, {}).toString()))
 
-class mockGitHubAPI /*tslint:disable-line*/ {
+class mockGitHubAPI {
   async getPullRequestInfo() {
     const fixtures = await requestWithFixturedJSON("github_pr.json")
     return await fixtures()

--- a/source/platforms/_tests/_platform.test.ts
+++ b/source/platforms/_tests/_platform.test.ts
@@ -1,8 +1,7 @@
 import { getPlatformForEnv } from "../platform"
 
 it("should bail if there is no DANGER_GITHUB_API_TOKEN found", () => {
-  const e = expect as any
-  e(() => {
+  expect(() => {
     getPlatformForEnv({} as any, {} as any)
   }).toThrow("Cannot use authenticated API requests")
 })

--- a/source/platforms/_tests/_pull_request_parser.test.ts
+++ b/source/platforms/_tests/_pull_request_parser.test.ts
@@ -46,7 +46,7 @@ describe("parsing urls", () => {
     })
   })
 
-  it("handles bitbucket server PRs (overview) with dashes in name", () => {
+  it("handles bitbucket server PRs (overview) with dashes and dot in name", () => {
     expect(
       pullRequestParser("http://localhost:7990/projects/PROJ/repos/super-strong.repo_name/pull-requests/1/overview")
     ).toEqual({
@@ -189,7 +189,7 @@ describe("parsing urls", () => {
       })
     })
 
-    it("handles PRs (overview) with dashes in name", () => {
+    it("handles PRs (overview) with dashes and dot in name", () => {
       expect(
         pullRequestParser("https://bitbucket.org/project/super-strong.repo_name/pull-requests/1/overview")
       ).toEqual({

--- a/source/platforms/bitbucket_cloud/_tests_/_bitbucket_cloud_api.test.ts
+++ b/source/platforms/bitbucket_cloud/_tests_/_bitbucket_cloud_api.test.ts
@@ -254,7 +254,7 @@ describe("API testing - BitBucket Cloud", () => {
 
   it("postBuildStatus", async () => {
     const payload = {
-      state: "SUCCESSFUL" as "SUCCESSFUL",
+      state: "SUCCESSFUL" as const,
       key: "key",
       name: "name",
       url: "url",

--- a/source/platforms/bitbucket_cloud/_tests_/_bitbucket_cloud_git.test.ts
+++ b/source/platforms/bitbucket_cloud/_tests_/_bitbucket_cloud_git.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-export */
 import { bitBucketCloudRawAndDateToGitCommitAuthor } from "../BitBucketCloudGit"
 
 import { BitBucketCloud } from "../../BitBucketCloud"
@@ -162,11 +163,14 @@ describe("the dangerfile gitDSL - BitBucket Cloud", () => {
   })
 
   it("writes a JSON DSL fixture", async () => {
-    const fakeSource = new FakeCI({})
-    const dataSent = await jsonDSLGenerator(bbc, fakeSource, {} as any)
-    dataSent.settings.github.accessToken = "12345"
+    expect.assertions(1)
+    expect(async () => {
+      const fakeSource = new FakeCI({})
+      const dataSent = await jsonDSLGenerator(bbc, fakeSource, {} as any)
+      dataSent.settings.github.accessToken = "12345"
 
-    writeFileSync(pathJoin(fixtures, "bbc-dsl-input.json"), JSON.stringify(dataSent, null, "  "), "utf8")
+      writeFileSync(pathJoin(fixtures, "bbc-dsl-input.json"), JSON.stringify(dataSent, null, "  "), "utf8")
+    }).not.toThrow()
   })
 })
 

--- a/source/platforms/bitbucket_server/_tests/_bitbucket_server_git.test.ts
+++ b/source/platforms/bitbucket_server/_tests/_bitbucket_server_git.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-export */
 import { BitBucketServer } from "../../BitBucketServer"
 import { BitBucketServerAPI } from "../BitBucketServerAPI"
 
@@ -140,10 +141,13 @@ describe("the dangerfile gitDSL - BitBucket Server", () => {
   })
 
   it("writes a JSON DSL fixture", async () => {
-    const fakeSource = new FakeCI({})
-    const dataSent = await jsonDSLGenerator(bbs, fakeSource, {} as any)
-    dataSent.settings.github.accessToken = "12345"
+    expect.assertions(1)
+    expect(async () => {
+      const fakeSource = new FakeCI({})
+      const dataSent = await jsonDSLGenerator(bbs, fakeSource, {} as any)
+      dataSent.settings.github.accessToken = "12345"
 
-    writeFileSync(pathJoin(fixtures, "bbs-dsl-input.json"), JSON.stringify(dataSent, null, "  "), "utf8")
+      writeFileSync(pathJoin(fixtures, "bbs-dsl-input.json"), JSON.stringify(dataSent, null, "  "), "utf8")
+    }).not.toThrow()
   })
 })

--- a/source/platforms/git/_tests/localLogGitCommits.test.ts
+++ b/source/platforms/git/_tests/localLogGitCommits.test.ts
@@ -13,7 +13,7 @@ it("get git commits from the 'git log' command", () => {
   const options = {
     number: 10,
     branch: "test_branch",
-    fields: ["hash" as "hash", "subject" as "subject"],
+    fields: ["hash", "subject"] as const,
   }
 
   const result = logGitCommits(options)

--- a/source/platforms/git/_tests/local_dangerfile_example.ts
+++ b/source/platforms/git/_tests/local_dangerfile_example.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-var */
 // This dangerfile is for running as an integration test on CI
 
 import { DangerDSLType } from "../../../dsl/DangerDSL"

--- a/source/platforms/git/localGetCommits.ts
+++ b/source/platforms/git/localGetCommits.ts
@@ -6,17 +6,17 @@ export const localGetCommits = (base: string, head: string) => {
     number: 100,
     branch: `${base}...${head}`,
     fields: [
-      "hash" as "hash",
-      "abbrevParentHashes" as "abbrevParentHashes",
-      "treeHash" as "treeHash",
-      "authorName" as "authorName",
-      "authorEmail" as "authorEmail",
-      "authorDate" as "authorDate",
-      "committerName" as "committerName",
-      "committerEmail" as "committerEmail",
-      "committerDate" as "committerDate",
-      "subject" as "subject",
-    ],
+      "hash",
+      "abbrevParentHashes",
+      "treeHash",
+      "authorName",
+      "authorEmail",
+      "authorDate",
+      "committerName",
+      "committerEmail",
+      "committerDate",
+      "subject",
+    ] as const,
   }
 
   const commits: GitCommit[] = logGitCommits(options).map(commit => ({

--- a/source/platforms/git/localLogGitCommits.ts
+++ b/source/platforms/git/localLogGitCommits.ts
@@ -17,7 +17,7 @@ const fieldMap = {
 export type GitLogOptions = {
   number: number
   branch: string
-  fields: Array<Partial<keyof typeof fieldMap>>
+  fields: ReadonlyArray<Partial<keyof typeof fieldMap>>
 }
 
 export type GitLogCommit = {
@@ -44,7 +44,7 @@ const createCommandArguments = (options: GitLogOptions) => {
 
   // Iterating through the fields and adding them to the custom format
   if (options.fields) {
-    options.fields.forEach(field => {
+    options.fields.forEach((field) => {
       prettyArgument += delimiter + fieldMap[field]
     })
   }
@@ -61,8 +61,8 @@ const createCommandArguments = (options: GitLogOptions) => {
   return command
 }
 
-const parseCommits = (commits: string[], fields: string[]) =>
-  commits.map(rawCommit => {
+const parseCommits = (commits: readonly string[], fields: readonly string[]) =>
+  commits.map((rawCommit) => {
     const parts = rawCommit.split("@end@")
     const commit = parts[0].split(delimiter)
 

--- a/source/platforms/github/_tests/_customGitHubRequire.test.ts
+++ b/source/platforms/github/_tests/_customGitHubRequire.test.ts
@@ -14,19 +14,19 @@ import {
 } from "../customGitHubRequire"
 
 describe("shouldUseGitHubOverride", () => {
-  it("ignores module imports ", () => {
+  it("ignores module imports", () => {
     const module = "peril"
     const parent: any = { filename: "index.js" }
     expect(shouldUseGitHubOverride(module, parent)).toBeFalsy()
   })
 
-  it("ignores relative imports in other modules ", () => {
+  it("ignores relative imports in other modules", () => {
     const module = "./peril"
     const parent: any = { filename: "node_modules/danger/index.js" }
     expect(shouldUseGitHubOverride(module, parent)).toBeFalsy()
   })
 
-  it("accepts relative imports in modules with a parent that has the right prefix ", () => {
+  it("accepts relative imports in modules with a parent that has the right prefix", () => {
     const module = "./peril"
     const parent: any = { filename: dangerPrefix + "./my-import" }
     expect(shouldUseGitHubOverride(module, parent)).toBeTruthy()

--- a/source/platforms/github/_tests/_github_api.test.ts
+++ b/source/platforms/github/_tests/_github_api.test.ts
@@ -53,7 +53,7 @@ it("fileContents expects to grab PR JSON and pull out a file API call", async ()
   const info = await api.fileContents("my_path.md")
   expect(info).toEqual(
     "The All-Defector is a purported glitch in the Dilemma Prison that appears to prisoners as themselves. This gogol always defects, hence the name."
-  ) //tslint:disable-line:max-line-length
+  )
 })
 
 describe("API testing", () => {

--- a/source/platforms/github/_tests/_github_git.test.ts
+++ b/source/platforms/github/_tests/_github_git.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-export */
 import { GitHub, githubJSONToGitHubDSL, GitHubType } from "../../GitHub"
 import { GitHubAPI } from "../GitHubAPI"
 
@@ -425,7 +426,7 @@ describe("the dangerfile gitDSL", () => {
             "babel-plugin-syntax-async-functions": "^6.13.0",
             "babel-plugin-transform-flow-strip-types": "^6.8.0",
             "babel-plugin-typescript": "^2.2.0",
-          }, //tslint:disable-line:max-line-length
+          },
           before: {
             "babel-cli": "^6.16.0",
             "babel-plugin-syntax-async-functions": "^6.13.0",

--- a/source/platforms/gitlab/GitLabAPI.ts
+++ b/source/platforms/gitlab/GitLabAPI.ts
@@ -161,11 +161,11 @@ class GitLabAPI {
     const api = this.api.MergeRequestDiscussions
 
     try {
-      const result: string = await api.create(this.repoMetadata.repoSlug, this.repoMetadata.pullRequestID, content, {
+      const result = await api.create(this.repoMetadata.repoSlug, this.repoMetadata.pullRequestID, content, {
         position: position,
       })
       this.d("createMergeRequestDiscussion", result)
-      return result
+      return result as unknown as string // not sure why?
     } catch (e) {
       this.d("createMergeRequestDiscussion", e)
       throw e

--- a/source/platforms/gitlab/GitLabAPI.ts
+++ b/source/platforms/gitlab/GitLabAPI.ts
@@ -161,7 +161,6 @@ class GitLabAPI {
     const api = this.api.MergeRequestDiscussions
 
     try {
-      // @ts-ignore
       const result: string = await api.create(this.repoMetadata.repoSlug, this.repoMetadata.pullRequestID, content, {
         position: position,
       })

--- a/source/platforms/gitlab/_tests/_gitlab_api.test.ts
+++ b/source/platforms/gitlab/_tests/_gitlab_api.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import nock, { NockDefinition } from "nock"
 import { default as GitLabAPI, getGitLabAPICredentialsFromEnv } from "../GitLabAPI"
 import { resolve } from "path"

--- a/source/platforms/gitlab/_tests/_gitlab_git.test.ts
+++ b/source/platforms/gitlab/_tests/_gitlab_git.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-export */
 import { readFileSync } from "fs"
 import { join as pathJoin } from "path"
 import _ from "lodash"

--- a/source/runner/_tests/_executor.test.ts
+++ b/source/runner/_tests/_executor.test.ts
@@ -419,7 +419,7 @@ describe("setup", () => {
     platform.updateStatus = jest.fn()
 
     await exec.handleResults(emptyResults, dsl.git)
-    expect(platform.updateStatus).toBeCalledWith(true, jasmine.any(String), undefined, defaultConfig.dangerID)
+    expect(platform.updateStatus).toBeCalledWith(true, expect.any(String), undefined, defaultConfig.dangerID)
   })
 
   it("Updates the status with success for a passed results", async () => {

--- a/source/runner/_tests/fixtures/__DangerfileAsync.ts
+++ b/source/runner/_tests/fixtures/__DangerfileAsync.ts
@@ -1,5 +1,3 @@
-/* tslint-disable */
-
 const asyncAction = () =>
   new Promise(res => {
     setTimeout(() => {

--- a/source/runner/_tests/fixtures/__DangerfileTypeScript.ts
+++ b/source/runner/_tests/fixtures/__DangerfileTypeScript.ts
@@ -1,7 +1,7 @@
-// @ts-ignore
-/* tslint-disable */
+/* eslint-disable */
 
 // This doesn't exist in JS-world
 interface MyThing {}
 
+// @ts-ignore
 message("Honey, we got Types")

--- a/source/runner/dangerDSLJSON.ts
+++ b/source/runner/dangerDSLJSON.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { DangerDSLJSONType } from "../dsl/DangerDSL"
 import { GitJSONDSL } from "../dsl/GitDSL"
 import { GitHubDSL } from "../dsl/GitHubDSL"

--- a/source/runner/runners/utils/_tests/_transpiler.test.ts
+++ b/source/runner/runners/utils/_tests/_transpiler.test.ts
@@ -13,7 +13,7 @@ import * as fs from "fs"
 import * as path from "path"
 
 describe("typescriptify", () => {
-  it("removes the module option in a tsconfig ", () => {
+  it("removes the module option in a tsconfig", () => {
     const dangerfile = `import {a} from 'lodash'; a()`
     const fakeTSConfig = {
       compilerOptions: {

--- a/source/runner/runners/utils/transpiler.ts
+++ b/source/runner/runners/utils/transpiler.ts
@@ -30,14 +30,14 @@ export const checkForNodeModules = () => {
   }
 
   try {
-    require.resolve("typescript") // tslint:disable-line
+    require.resolve("typescript")
     hasNativeTypeScript = true && !disableTsc
   } catch (e) {
     d("Does not have TypeScript set up")
   }
 
   const checkForBabel = (prefix: BabelPackagePrefix) => {
-    require.resolve(`${prefix}core`) // tslint:disable-line
+    require.resolve(`${prefix}core`)
     babelPackagePrefix = prefix
     hasBabel = true
   }
@@ -56,16 +56,16 @@ export const checkForNodeModules = () => {
 
   if (hasBabel) {
     // @babel/polyfill is a direct dependency of Danger.
-    require("@babel/polyfill") // tslint:disable-line
+    require("@babel/polyfill")
     try {
-      require.resolve(`${babelPackagePrefix}plugin-transform-typescript`) // tslint:disable-line
+      require.resolve(`${babelPackagePrefix}plugin-transform-typescript`)
       hasBabelTypeScript = true
     } catch (e) {
       d("Does not have Babel 7 TypeScript set up")
     }
 
     try {
-      require.resolve(`${babelPackagePrefix}plugin-transform-flow-strip-types`) // tslint:disable-line
+      require.resolve(`${babelPackagePrefix}plugin-transform-flow-strip-types`)
       hasFlow = true
     } catch (e) {
       d("Does not have Flow set up")
@@ -120,7 +120,7 @@ export const lookupTSConfig = (dir: string): string | null => {
 }
 
 export const typescriptify = (content: string, dir: string): string => {
-  const ts = require("typescript") // tslint:disable-line
+  const ts = require("typescript")
 
   // Support custom TSC options, but also fallback to defaults
   let compilerOptions: any
@@ -157,7 +157,7 @@ const sanitizeTSConfig = (config: any) => {
 }
 
 export const babelify = (content: string, filename: string, extraPlugins: string[]): string => {
-  const babel = require(`${babelPackagePrefix}core`) // tslint:disable-line
+  const babel = require(`${babelPackagePrefix}core`)
   // Since Babel 7, it is recommended to use `transformSync`.
   // For older versions, we fallback to `transform`.
   // @see https://babeljs.io/docs/en/babel-core#transform

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["scripts", "node_modules", "distribution", "types"]
+  "exclude": ["node_modules", "distribution", "types"]
 }

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["scripts", "node_modules", "distribution", "types"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -762,6 +762,44 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@es-joy/jsdoccomment@~0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@es-joy/jsdoccomment/-/jsdoccomment-0.18.0.tgz#2532b2ecb8576d694011b157c447ed6b12534c70"
+  integrity sha512-TjT8KJULV4I6ZiwIoKr6eMs+XpRejqwJ/VA+QPDeFGe9j6bZFKmMJ81EeFsGm6JNZhnzm37aoxVROmTh2PZoyA==
+  dependencies:
+    comment-parser "1.3.0"
+    esquery "^1.4.0"
+    jsdoc-type-pratt-parser "~2.2.2"
+
+"@eslint/eslintrc@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.0.5.tgz#33f1b838dbf1f923bfa517e008362b78ddbbf318"
+  integrity sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.3.2"
+    espree "^9.2.0"
+    globals "^13.9.0"
+    ignore "^4.0.6"
+    import-fresh "^3.2.1"
+    js-yaml "^4.1.0"
+    minimatch "^3.0.4"
+    strip-json-comments "^3.1.1"
+
+"@humanwhocodes/config-array@^0.9.2":
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.3.tgz#f2564c744b387775b436418491f15fce6601f63e"
+  integrity sha512-3xSMlXHh03hCcCmFc0rbKp3Ivt2PFEJnQUJDDMTJQ2wkECZWdq4GePs2ctc5H8zV+cHPaq8k2vU8mrQjA6iHdQ==
+  dependencies:
+    "@humanwhocodes/object-schema" "^1.2.1"
+    debug "^4.1.1"
+    minimatch "^3.0.4"
+
+"@humanwhocodes/object-schema@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
+  integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
+
 "@iarna/toml@2.2.3":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.3.tgz#f060bf6eaafae4d56a7dac618980838b0696e2ab"
@@ -1092,6 +1130,11 @@
   dependencies:
     "@types/jest-diff" "*"
 
+"@types/json-schema@^7.0.9":
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
+  integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
+
 "@types/json5@^0.0.30":
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.30.tgz#44cb52f32a809734ca562e685c6473b5754a7818"
@@ -1238,6 +1281,86 @@
   resolved "https://registry.yarnpkg.com/@types/voca/-/voca-1.4.0.tgz#59d93132e411f13fbaacb166a2047464c463535a"
   integrity sha512-LdffYbNO8Mg06oPouDq13XwarZbYEvLHMCeV04B/LYl2o6miyg4qBa3YduIZcNhK8/r3Soq0a1tCDeprkBXTIQ==
 
+"@typescript-eslint/eslint-plugin@^5.10.1":
+  version "5.10.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.2.tgz#f8c1d59fc37bd6d9d11c97267fdfe722c4777152"
+  integrity sha512-4W/9lLuE+v27O/oe7hXJKjNtBLnZE8tQAFpapdxwSVHqtmIoPB1gph3+ahNwVuNL37BX7YQHyGF9Xv6XCnIX2Q==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.10.2"
+    "@typescript-eslint/type-utils" "5.10.2"
+    "@typescript-eslint/utils" "5.10.2"
+    debug "^4.3.2"
+    functional-red-black-tree "^1.0.1"
+    ignore "^5.1.8"
+    regexpp "^3.2.0"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/parser@^5.10.1":
+  version "5.10.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.10.2.tgz#b6076d27cc5499ce3f2c625f5ccde946ecb7db9a"
+  integrity sha512-JaNYGkaQVhP6HNF+lkdOr2cAs2wdSZBoalE22uYWq8IEv/OVH0RksSGydk+sW8cLoSeYmC+OHvRyv2i4AQ7Czg==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.10.2"
+    "@typescript-eslint/types" "5.10.2"
+    "@typescript-eslint/typescript-estree" "5.10.2"
+    debug "^4.3.2"
+
+"@typescript-eslint/scope-manager@5.10.2":
+  version "5.10.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.10.2.tgz#92c0bc935ec00f3d8638cdffb3d0e70c9b879639"
+  integrity sha512-39Tm6f4RoZoVUWBYr3ekS75TYgpr5Y+X0xLZxXqcZNDWZdJdYbKd3q2IR4V9y5NxxiPu/jxJ8XP7EgHiEQtFnw==
+  dependencies:
+    "@typescript-eslint/types" "5.10.2"
+    "@typescript-eslint/visitor-keys" "5.10.2"
+
+"@typescript-eslint/type-utils@5.10.2":
+  version "5.10.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.10.2.tgz#ad5acdf98a7d2ab030bea81f17da457519101ceb"
+  integrity sha512-uRKSvw/Ccs5FYEoXW04Z5VfzF2iiZcx8Fu7DGIB7RHozuP0VbKNzP1KfZkHBTM75pCpsWxIthEH1B33dmGBKHw==
+  dependencies:
+    "@typescript-eslint/utils" "5.10.2"
+    debug "^4.3.2"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/types@5.10.2":
+  version "5.10.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.10.2.tgz#604d15d795c4601fffba6ecb4587ff9fdec68ce8"
+  integrity sha512-Qfp0qk/5j2Rz3p3/WhWgu4S1JtMcPgFLnmAKAW061uXxKSa7VWKZsDXVaMXh2N60CX9h6YLaBoy9PJAfCOjk3w==
+
+"@typescript-eslint/typescript-estree@5.10.2":
+  version "5.10.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.2.tgz#810906056cd3ddcb35aa333fdbbef3713b0fe4a7"
+  integrity sha512-WHHw6a9vvZls6JkTgGljwCsMkv8wu8XU8WaYKeYhxhWXH/atZeiMW6uDFPLZOvzNOGmuSMvHtZKd6AuC8PrwKQ==
+  dependencies:
+    "@typescript-eslint/types" "5.10.2"
+    "@typescript-eslint/visitor-keys" "5.10.2"
+    debug "^4.3.2"
+    globby "^11.0.4"
+    is-glob "^4.0.3"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@5.10.2", "@typescript-eslint/utils@^5.10.0":
+  version "5.10.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.10.2.tgz#1fcd37547c32c648ab11aea7173ec30060ee87a8"
+  integrity sha512-vuJaBeig1NnBRkf7q9tgMLREiYD7zsMrsN1DA3wcoMDvr3BTFiIpKjGiYZoKPllfEwN7spUjv7ZqD+JhbVjEPg==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@typescript-eslint/scope-manager" "5.10.2"
+    "@typescript-eslint/types" "5.10.2"
+    "@typescript-eslint/typescript-estree" "5.10.2"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+
+"@typescript-eslint/visitor-keys@5.10.2":
+  version "5.10.2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.2.tgz#fdbf272d8e61c045d865bd6c8b41bea73d222f3d"
+  integrity sha512-zHIhYGGGrFJvvyfwHk5M08C5B5K4bewkm+rrvNTKk1/S15YHR+SA/QUF8ZWscXSfEaB8Nn2puZj+iHcoxVOD/Q==
+  dependencies:
+    "@typescript-eslint/types" "5.10.2"
+    eslint-visitor-keys "^3.0.0"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -1265,10 +1388,20 @@ acorn-globals@^4.0.0:
   dependencies:
     acorn "^5.0.0"
 
+acorn-jsx@^5.3.1:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
+  integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
+
 acorn@^5.0.0, acorn@^5.1.2:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
   integrity sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==
+
+acorn@^8.7.0:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
+  integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
 address@^1.0.1:
   version "1.0.3"
@@ -1292,7 +1425,7 @@ ajv@^5.1.0:
     json-schema-traverse "^0.3.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^6.12.3:
+ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -1453,6 +1586,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 args@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/args/-/args-2.6.1.tgz#b2590ed4168cd31b62444199bdc5166bb1920c2f"
@@ -1610,15 +1748,6 @@ aws4@^1.8.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
-
-babel-code-frame@^6.22.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
-  integrity sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=
-  dependencies:
-    chalk "^1.1.3"
-    esutils "^2.0.2"
-    js-tokens "^3.0.2"
 
 babel-jest@^24.0.0:
   version "24.0.0"
@@ -1889,7 +2018,7 @@ buffer@^5.5.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
-builtin-modules@^1.0.0, builtin-modules@^1.1.1:
+builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
   integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
@@ -2093,6 +2222,14 @@ chalk@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
   integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+chalk@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
@@ -2326,11 +2463,6 @@ commander@^2.11.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
   integrity sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==
 
-commander@^2.12.1, commander@^2.6.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
-  integrity sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==
-
 commander@^2.14.1, commander@^2.15.1:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
@@ -2340,6 +2472,11 @@ commander@^2.18.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+
+commander@^2.6.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
+  integrity sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==
 
 commander@^2.8.1, commander@^2.9.0:
   version "2.9.0"
@@ -2359,6 +2496,11 @@ commander@~2.8.1:
   integrity sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=
   dependencies:
     graceful-readlink ">= 1.0.0"
+
+comment-parser@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.3.0.tgz#68beb7dbe0849295309b376406730cd16c719c44"
+  integrity sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -2537,6 +2679,15 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+cross-spawn@^7.0.2:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 cryptiles@3.x.x:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
@@ -2643,6 +2794,13 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.3.2, debug@^4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+  dependencies:
+    ms "2.1.2"
+
 debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
@@ -2715,7 +2873,7 @@ deep-extend@~0.4.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
   integrity sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=
 
-deep-is@~0.1.3:
+deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
@@ -2926,7 +3084,7 @@ diff-sequences@^24.0.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.0.0.tgz#cdf8e27ed20d8b8d3caccb4e0c0d8fe31a173013"
   integrity sha512-46OkIuVGBBnrC0soO/4LHu5LHGHx0uhP65OVz8XOrAJpqiCB2aVIuESvjI1F9oqebuvY8lekS1pt6TN7vt7qsw==
 
-diff@^3.1.0, diff@^3.2.0:
+diff@^3.1.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
@@ -2937,6 +3095,13 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
+
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+  dependencies:
+    esutils "^2.0.2"
 
 domexception@^1.0.0:
   version "1.0.0"
@@ -3104,6 +3269,11 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
 escodegen@^1.14.1:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
@@ -3140,6 +3310,115 @@ escodegen@^1.9.0:
   optionalDependencies:
     source-map "~0.5.6"
 
+eslint-config-prettier@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
+  integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
+
+eslint-plugin-jest@^26.0.0:
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-26.0.0.tgz#f83a25a23ab90ce5b375b1d44389b8c391be5ce8"
+  integrity sha512-Fvs0YgJ/nw9FTrnqTuMGVrkozkd07jkQzWm0ajqyHlfcsdkxGfAuv30fgfWHOnHiCr9+1YQ365CcDX7vrNhqQg==
+  dependencies:
+    "@typescript-eslint/utils" "^5.10.0"
+
+eslint-plugin-jsdoc@^37.7.0:
+  version "37.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.7.0.tgz#975d9f18cb0520dde7a2b0db5f4421dfee3fdd17"
+  integrity sha512-vzy3/ltXoGtabRnjLogaEmhGxxIv5B8HK5MJLIrdxFJUvhBppZjuVuLr71DjIBi0jg6bFomwkYKjojt29cN8PA==
+  dependencies:
+    "@es-joy/jsdoccomment" "~0.18.0"
+    comment-parser "1.3.0"
+    debug "^4.3.3"
+    escape-string-regexp "^4.0.0"
+    esquery "^1.4.0"
+    regextras "^0.8.0"
+    semver "^7.3.5"
+    spdx-expression-parse "^3.0.1"
+
+eslint-scope@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^4.1.1"
+
+eslint-scope@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.0.tgz#c1f6ea30ac583031f203d65c73e723b01298f153"
+  integrity sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^5.2.0"
+
+eslint-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
+  dependencies:
+    eslint-visitor-keys "^2.0.0"
+
+eslint-visitor-keys@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
+  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
+
+eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.1.0, eslint-visitor-keys@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz#6fbb166a6798ee5991358bc2daa1ba76cc1254a1"
+  integrity sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==
+
+eslint@^8.8.0:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.8.0.tgz#9762b49abad0cb4952539ffdb0a046392e571a2d"
+  integrity sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==
+  dependencies:
+    "@eslint/eslintrc" "^1.0.5"
+    "@humanwhocodes/config-array" "^0.9.2"
+    ajv "^6.10.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.3.2"
+    doctrine "^3.0.0"
+    escape-string-regexp "^4.0.0"
+    eslint-scope "^7.1.0"
+    eslint-utils "^3.0.0"
+    eslint-visitor-keys "^3.2.0"
+    espree "^9.3.0"
+    esquery "^1.4.0"
+    esutils "^2.0.2"
+    fast-deep-equal "^3.1.3"
+    file-entry-cache "^6.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^6.0.1"
+    globals "^13.6.0"
+    ignore "^5.2.0"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    js-yaml "^4.1.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash.merge "^4.6.2"
+    minimatch "^3.0.4"
+    natural-compare "^1.4.0"
+    optionator "^0.9.1"
+    regexpp "^3.2.0"
+    strip-ansi "^6.0.1"
+    strip-json-comments "^3.1.0"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
+
+espree@^9.2.0, espree@^9.3.0:
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.3.0.tgz#c1240d79183b72aaee6ccfa5a90bc9111df085a8"
+  integrity sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==
+  dependencies:
+    acorn "^8.7.0"
+    acorn-jsx "^5.3.1"
+    eslint-visitor-keys "^3.1.0"
+
 esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
@@ -3165,15 +3444,34 @@ esprima@~1.0.4:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.0.4.tgz#9f557e08fc3b4d26ece9dd34f8fbf476b62585ad"
   integrity sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=
 
+esquery@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
+  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
+  dependencies:
+    estraverse "^5.1.0"
+
+esrecurse@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
+  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
+  dependencies:
+    estraverse "^5.2.0"
+
 estraverse@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
   integrity sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=
 
-estraverse@^4.2.0:
+estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
+
+estraverse@^5.1.0, estraverse@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
+  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -3398,7 +3696,7 @@ fast-deep-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
   integrity sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -3441,7 +3739,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@~2.0.6:
+fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -3474,6 +3772,13 @@ figures@^3.0.0:
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
   dependencies:
     escape-string-regexp "^1.0.5"
+
+file-entry-cache@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
+  integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
+  dependencies:
+    flat-cache "^3.0.4"
 
 file-exists@~1.0.0:
   version "1.0.0"
@@ -3560,12 +3865,25 @@ find@0.2.6:
   dependencies:
     traverse-chain "~0.1.0"
 
+flat-cache@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
+  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
+  dependencies:
+    flatted "^3.1.0"
+    rimraf "^3.0.2"
+
 flat@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/flat/-/flat-4.1.0.tgz#090bec8b05e39cba309747f1d588f04dbaf98db2"
   integrity sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==
   dependencies:
     is-buffer "~2.0.3"
+
+flatted@^3.1.0:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
+  integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
 flatten@^1.0.2:
   version "1.0.2"
@@ -3718,6 +4036,11 @@ function-bind@^1.0.2, function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -3854,6 +4177,13 @@ glob-parent@^5.1.0, glob-parent@^5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
+glob-parent@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
+  dependencies:
+    is-glob "^4.0.3"
+
 glob@^7.0.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
@@ -3914,6 +4244,13 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
   integrity sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==
 
+globals@^13.6.0, globals@^13.9.0:
+  version "13.12.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.12.0.tgz#4d733760304230a0082ed96e21e5c565f898089e"
+  integrity sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==
+  dependencies:
+    type-fest "^0.20.2"
+
 globby@11.0.0:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.0.tgz#56fd0e9f0d4f8fb0c456f1ab0dee96e1380bc154"
@@ -3926,7 +4263,7 @@ globby@11.0.0:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-globby@^11.0.0:
+globby@^11.0.0, globby@^11.0.4:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -4300,12 +4637,17 @@ ieee754@^1.1.13:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
+ignore@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
 ignore@^5.1.4:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
 
-ignore@^5.2.0:
+ignore@^5.1.8, ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
@@ -4316,6 +4658,14 @@ import-cwd@3.0.0:
   integrity sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==
   dependencies:
     import-from "^3.0.0"
+
+import-fresh@^3.0.0, import-fresh@^3.2.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
+  integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
 
 import-fresh@^3.1.0:
   version "3.2.1"
@@ -4627,7 +4977,7 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
-is-glob@^4.0.1:
+is-glob@^4.0.1, is-glob@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -5269,7 +5619,7 @@ js-levenshtein@^1.1.3:
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.3.tgz#3ef627df48ec8cf24bacf05c0f184ff30ef413c5"
   integrity sha512-/812MXr9RBtMObviZ8gQBhHO8MOrGj8HlEE+4ccMTElNA/6I3u39u+bhny55Lk921yn44nSZFy9naNLElL5wgQ==
 
-js-tokens@^3.0.0, js-tokens@^3.0.2:
+js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
@@ -5287,7 +5637,7 @@ js-yaml@^3.12.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^3.7.0, js-yaml@^3.9.0:
+js-yaml@^3.9.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   integrity sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==
@@ -5295,10 +5645,22 @@ js-yaml@^3.7.0, js-yaml@^3.9.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
+
+jsdoc-type-pratt-parser@~2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.2.tgz#a85e407ac502b444dc23333aa4d6d0dc83f76187"
+  integrity sha512-zRokSWcPLSWkoNzsWn9pq7YYSwDhKyEe+cJYT2qaPqLOOJb5sFSi46BPj81vP+e8chvCNdQL9RG86Bi9EI6MDw==
 
 jsdom@^11.5.1:
   version "11.5.1"
@@ -5369,6 +5731,11 @@ json-schema@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
   integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
 json-stable-stringify@^1.0.1:
   version "1.0.1"
@@ -5569,6 +5936,14 @@ leven@^2.1.0:
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
   integrity sha1-wuep93IJTe6dNCAq6KzORoeHVYA=
 
+levn@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+  dependencies:
+    prelude-ls "^1.2.1"
+    type-check "~0.4.0"
+
 levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
@@ -5766,6 +6141,11 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
 lodash.once@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
@@ -5859,6 +6239,13 @@ lru-cache@^4.0.0, lru-cache@^4.0.1:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
+
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
 
 macos-release@^2.2.0:
   version "2.3.0"
@@ -6224,6 +6611,11 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
 ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
@@ -6582,6 +6974,18 @@ optionator@^0.8.1:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
     word-wrap "~1.2.3"
+
+optionator@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
+  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
+  dependencies:
+    deep-is "^0.1.3"
+    fast-levenshtein "^2.0.6"
+    levn "^0.4.1"
+    prelude-ls "^1.2.1"
+    type-check "^0.4.0"
+    word-wrap "^1.2.3"
 
 ora@4.0.3:
   version "4.0.3"
@@ -7114,6 +7518,11 @@ precinct@^4.1.0:
     module-definition "^2.2.4"
     node-source-walk "^3.3.0"
 
+prelude-ls@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -7478,6 +7887,11 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
+regexpp@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
+  integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
+
 regexpu-core@^4.1.3, regexpu-core@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.2.0.tgz#a3744fa03806cffe146dea4421a3e73bdcc47b1d"
@@ -7489,6 +7903,11 @@ regexpu-core@^4.1.3, regexpu-core@^4.2.0:
     regjsparser "^0.3.0"
     unicode-match-property-ecmascript "^1.0.4"
     unicode-match-property-value-ecmascript "^1.0.2"
+
+regextras@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/regextras/-/regextras-0.8.0.tgz#ec0f99853d4912839321172f608b544814b02217"
+  integrity sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==
 
 registry-auth-token@^3.0.1:
   version "3.3.1"
@@ -7844,6 +8263,13 @@ rimraf@^2.6.2:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@~2.2.0:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
@@ -7992,6 +8418,13 @@ semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
 
 send@0.15.3:
   version "0.15.3"
@@ -8283,6 +8716,14 @@ spdx-expression-parse@^3.0.0:
     spdx-exceptions "^2.1.0"
     spdx-license-ids "^3.0.0"
 
+spdx-expression-parse@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679"
+  integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
 spdx-license-ids@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
@@ -8519,6 +8960,11 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
+strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
@@ -8670,6 +9116,11 @@ test-exclude@^5.0.0:
     read-pkg-up "^4.0.0"
     require-main-filename "^1.0.1"
 
+text-table@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+  integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
 throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
@@ -8812,43 +9263,15 @@ ts-node@^8.0.2:
     source-map-support "^0.5.6"
     yn "^3.0.0"
 
-tslib@^1.8.0:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.1.tgz#6946af2d1d651a7b1863b531d6e5afa41aa44eac"
-  integrity sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw=
-
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
-tslint-config-prettier@^1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.15.0.tgz#76b9714399004ab6831fdcf76d89b73691c812cf"
-  integrity sha512-06CgrHJxJmNYVgsmeMoa1KXzQRoOdvfkqnJth6XUkNeOz707qxN0WfxfhYwhL5kXHHbYJRby2bqAPKwThlZPhw==
-
-tslint@^5.11.0:
-  version "5.11.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.11.0.tgz#98f30c02eae3cde7006201e4c33cb08b48581eed"
-  integrity sha1-mPMMAurjzecAYgHkwzywi0hYHu0=
-  dependencies:
-    babel-code-frame "^6.22.0"
-    builtin-modules "^1.1.1"
-    chalk "^2.3.0"
-    commander "^2.12.1"
-    diff "^3.2.0"
-    glob "^7.1.1"
-    js-yaml "^3.7.0"
-    minimatch "^3.0.4"
-    resolve "^1.3.2"
-    semver "^5.3.0"
-    tslib "^1.8.0"
-    tsutils "^2.27.2"
-
-tsutils@^2.27.2:
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.28.0.tgz#6bd71e160828f9d019b6f4e844742228f85169a1"
-  integrity sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==
+tsutils@^3.21.0:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
+  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
 
@@ -8863,6 +9286,13 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+type-check@^0.4.0, type-check@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
+  dependencies:
+    prelude-ls "^1.2.1"
 
 type-check@~0.3.2:
   version "0.3.2"
@@ -8885,6 +9315,11 @@ type-fest@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
+
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
 type-fest@^0.8.1:
   version "0.8.1"
@@ -9226,6 +9661,11 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+v8-compile-cache@^2.0.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
+  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
+
 validate-npm-package-license@^3.0.1:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338"
@@ -9402,7 +9842,7 @@ windows-release@^3.1.0:
   dependencies:
     execa "^1.0.0"
 
-word-wrap@~1.2.3:
+word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
@@ -9492,6 +9932,11 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@1.8.3, yaml@^1.7.2:
   version "1.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7538,10 +7538,10 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier@^1.14.2:
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
-  integrity sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==
+prettier@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
+  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
 
 pretty-format@^23.6.0:
   version "23.6.0"


### PR DESCRIPTION
tslint is end-of-life, and warns when you install it. Additionally, the version we were on didn't support 'import type' expressions, as well as optional-chaining & null coalescing when I tried to use those in #1204

This PR does update a bunch of tslint-disable comments, but otherwise tries to minimally change runtime source in danger-js. If we want to tighten the eslint rules, I'd be super supportive, but I didn't want to cause a ton of thrash, so mostly the rules that are enabled are the ones that don't trigger on tons of existing code.

This PR also upgrades prettier, because that was needed to handle `readonly string[]` arguments.

**Be aware** this PR drops testing support for node 10 in AppVeyor -- https://github.com/danger/danger-js/pull/1205/commits/b66f86f5e38eb46adbb3b4a8ab945bbc45265816 [`@typescript-eslint` doesn't support node 10](https://ci.appveyor.com/project/orta/danger-js/builds/42418823)