### PR TITLE
Build package after bumping version

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -5,7 +5,8 @@
   },
   "buildCommand": "yarn package",
   "hooks": {
-    "before:bump": "yarn declarations; yarn build:schemas; yarn package",
+    "before:bump": "yarn declarations; yarn build:schemas",
+    "after:bump": "yarn package",
     "after:release": "VERSION=${version} scripts/create-homebrew-tap-pr.sh"
   }
 }


### PR DESCRIPTION
The package was being built before the version was bumped. Fixes #1170.