### PR TITLE
Bump node engine to 14

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # Test against this version of Node.js
 environment:
-  nodejs_version: "12"
+  nodejs_version: "14"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   },
   "homepage": "https://github.com/danger/danger-js#readme",
   "engines": {
-    "node": ">=10"
+    "node": ">=14.13.1"
   },
   "devDependencies": {
     "@babel/cli": "7.1.2",


### PR DESCRIPTION
This reflects what is running on CI. and also some of the current dependences already require that version.

Using `14.13.1` for `lint-staged ^12`:
- https://github.com/okonet/lint-staged#v12

See:
- https://github.com/danger/danger-js/pull/1260

See https://github.com/danger/danger-js/pull/1252#issuecomment-1071070403