### PR TITLE
Remove implict git add when running pre-commit hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,13 +30,11 @@
   },
   "lint-staged": {
     "*.@(json|md)": [
-      "yarn prettier --write",
-      "git add"
+      "yarn prettier --write"
     ],
     "*.@(ts|tsx)": [
       "yarn lint:fix",
-      "yarn prettier --write",
-      "git add"
+      "yarn prettier --write"
     ]
   },
   "pkg": {


### PR DESCRIPTION
This breaks the intended behavior of adding to commit unstaged changes.

I strive for atomic commits:
- https://www.freshconsulting.com/insights/blog/atomic-commits/

so, I make changes, `git add -p` to stage commits for intended commit, and then do `git commit`. now the `pre-commit` hook will override my `git add -p` staging adding **all** modified files to commit.

this is unexpected and even hidden, so wouldn't even know something override my staging.

combining lint-stage update to v10, would have the best experience as it will automatically stage the changes, made in scripts ran by lint staged:
- https://github.com/okonet/lint-staged#v10