### PR TITLE
Fix git.JSONDiffValue removed/added typing

### DIFF
--- a/source/dsl/GitDSL.ts
+++ b/source/dsl/GitDSL.ts
@@ -51,9 +51,9 @@ export interface JSONDiffValue {
   /** The value after the PR's applied changes */
   after: any
   /** If both before & after are arrays, then you optionally get what is added. Empty if no additional objects. */
-  added?: any[]
+  added?: any
   /** If both before & after are arrays, then you optionally get what is removed. Empty if no removed objects. */
-  removed?: any[]
+  removed?: any
 }
 
 /** A map of string keys to JSONDiffValue */


### PR DESCRIPTION
They are not actually arrays, but objects of name: value pairs.

The example from:
- https://danger.systems/js/tutorials/dependencies.html#keeping-track-of-changes-to-dependencies

```js
{
  dependencies: {
    added: ["chalk"],
    removed: [],
    after: { commander: "^2.9.0", debug: "^2.6.0", "spaced-between": "^1.1.1", typescript: "^2.2.1" },
    before: { commander: "^2.9.0", debug: "^2.6.0", typescript: "^2.2.1" },
  }
}
```