### PR TITLE
Fix Node.js version to build docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-slim
+FROM node:14-slim
 
 LABEL maintainer="Orta Therox"
 LABEL "com.github.actions.name"="Danger JS Action"


### PR DESCRIPTION
On v11.0.4, building docker image is failed as below.

```
$ docker image build .
[+] Building 201.9s (9/9) FINISHED
 => [internal] load build definition from Dockerfile                                        0.0s
 => => transferring dockerfile: 564B                                                        0.0s
 => [internal] load .dockerignore                                                           0.0s
 => => transferring context: 2B                                                             0.0s
 => [internal] load metadata for docker.io/library/node:12-slim                           189.4s
 => [auth] library/node:pull token for registry-1.docker.io                                 0.0s
 => [1/4] FROM docker.io/library/node:12-slim@sha256:c28ca4124ac84ff1e72ee68abfe70aa4cc86f  9.4s
 => => resolve docker.io/library/node:12-slim@sha256:c28ca4124ac84ff1e72ee68abfe70aa4cc86f  0.0s
 => => sha256:c28ca4124ac84ff1e72ee68abfe70aa4cc86f499c1ef20408dc2d35af1058ac1 776B / 776B  0.0s
 => => sha256:b8922ead40512613bedabb3a930b3a8069dae988f50c30b3b06cd81a469f 1.37kB / 1.37kB  0.0s
 => => sha256:9b792ac6810e5c2cc2e28612129101c1ea2922cf322b708e8f08a93905a0 6.94kB / 6.94kB  0.0s
 => => sha256:b5b0e172ab63b10d88fbdbb73cc3d8e7009291ecb7e8c069750245277c 24.20MB / 24.20MB  5.1s
 => => sha256:8bd3f5a20b90c0e84cc65ea4a9172a51b7b5c0b9a097fa88d7102cac91 22.57MB / 22.57MB  5.2s
 => => sha256:3a665e454db5bb98a702660a6db59d14ca11984612bdc76b753732342135 4.17kB / 4.17kB  0.9s
 => => sha256:45013ee4878f2d36efd91adeb4912c7758d53bd4a2ff7d832f3bc153d6f4 2.79MB / 2.79MB  2.1s
 => => sha256:42a4482331385c806f0929ed421e6fa381b24ebd0c0642992457db1ed33e1472 463B / 463B  2.7s
 => => extracting sha256:8bd3f5a20b90c0e84cc65ea4a9172a51b7b5c0b9a097fa88d7102cac91cddf2c   1.3s
 => => extracting sha256:3a665e454db5bb98a702660a6db59d14ca11984612bdc76b7537323421356c16   0.0s
 => => extracting sha256:b5b0e172ab63b10d88fbdbb73cc3d8e7009291ecb7e8c069750245277c032f28   1.6s
 => => extracting sha256:45013ee4878f2d36efd91adeb4912c7758d53bd4a2ff7d832f3bc153d6f4d5fb   0.2s
 => => extracting sha256:42a4482331385c806f0929ed421e6fa381b24ebd0c0642992457db1ed33e1472   0.0s
 => [internal] load build context                                                           0.4s
 => => transferring context: 19.36MB                                                        0.3s
 => [2/4] RUN mkdir -p /usr/src/danger                                                      1.7s
 => [3/4] COPY . /usr/src/danger                                                            0.3s
 => ERROR [4/4] RUN cd /usr/src/danger &&   yarn &&   yarn run build:fast &&   chmod +x di  0.9s
------
 > [4/4] RUN cd /usr/src/danger &&   yarn &&   yarn run build:fast &&   chmod +x distribution/commands/danger.js &&   ln -s $(pwd)/distribution/commands/danger.js /usr/bin/danger:
#9 0.741 yarn install v1.22.18
#9 0.846 [1/5] Validating package.json...
#9 0.850 error danger@11.0.4: The engine "node" is incompatible with this module. Expected version ">=14.13.1". Got "12.22.12"
#9 0.860 error Found incompatible module.
#9 0.860 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
------
executor failed running [/bin/sh -c cd /usr/src/danger &&   yarn &&   yarn run build:fast &&   chmod +x distribution/commands/danger.js &&   ln -s $(pwd)/distribution/commands/danger.js /usr/bin/danger]: exit code: 1
```

Error message saying, this is because Node.js version is not appropriate.
FIY: Without docker, doing `$ yarn install` on Node.js v12 in root directory, it is also failed.

So I fixed it.
