### PR TITLE
Refactor Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,14 @@ COPY package.json yarn.lock ./
 RUN yarn install
 COPY . .
 RUN yarn run build:fast
+RUN yarn remove 'typescript' --dev && yarn add 'typescript@^4.5.5'
 RUN yarn install --production --frozen-lockfile
 RUN chmod +x distribution/commands/danger.js
 
 
 FROM node:14-slim
 WORKDIR /usr/src/danger
+ENV PATH="/usr/src/danger/node_modules/.bin:$PATH"
 COPY package.json ./
 COPY --from=build /usr/src/danger/distribution ./dist
 COPY --from=build /usr/src/danger/node_modules ./node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-slim
+FROM node:14-slim as build
 
 LABEL maintainer="Orta Therox"
 LABEL "com.github.actions.name"="Danger JS Action"
@@ -6,12 +6,22 @@ LABEL "com.github.actions.description"="Runs JavaScript/TypeScript Dangerfiles"
 LABEL "com.github.actions.icon"="zap"
 LABEL "com.github.actions.color"="blue"
 
-RUN mkdir -p /usr/src/danger
-COPY . /usr/src/danger
-RUN cd /usr/src/danger && \
-  yarn && \
-  yarn run build:fast && \
-  chmod +x distribution/commands/danger.js && \
-  ln -s $(pwd)/distribution/commands/danger.js /usr/bin/danger
+WORKDIR /usr/src/danger
+RUN yarn global add yarn-audit-fix
+COPY package.json yarn.lock ./
+RUN yarn install && \
+    yarn-audit-fix
+COPY . .
+RUN yarn run build:fast
+RUN rm -rf node_modules
+RUN yarn install --production --frozen-lockfile
+
+FROM node:14-slim
+WORKDIR /usr/src/danger
+COPY package.json ./
+COPY --from=build /usr/src/danger/distribution ./dist
+COPY --from=build /usr/src/danger/node_modules ./node_modules
+RUN chmod +x /usr/src/danger/dist/commands/danger.js && \
+    ln -s /usr/src/danger/dist/commands/danger.js /usr/bin/danger
 
 ENTRYPOINT ["danger", "ci"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY package.json yarn.lock ./
 RUN yarn install
 COPY . .
 RUN yarn run build:fast
-RUN yarn remove 'typescript' --dev && yarn add 'typescript@^4.5.5'
+RUN yarn remove 'typescript' --dev && yarn add 'typescript'
 RUN yarn install --production --frozen-lockfile
 RUN chmod +x distribution/commands/danger.js
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,21 +7,19 @@ LABEL "com.github.actions.icon"="zap"
 LABEL "com.github.actions.color"="blue"
 
 WORKDIR /usr/src/danger
-RUN yarn global add yarn-audit-fix
 COPY package.json yarn.lock ./
-RUN yarn install && \
-    yarn-audit-fix
+RUN yarn install
 COPY . .
 RUN yarn run build:fast
-RUN rm -rf node_modules
 RUN yarn install --production --frozen-lockfile
+RUN chmod +x distribution/commands/danger.js
+
 
 FROM node:14-slim
 WORKDIR /usr/src/danger
 COPY package.json ./
 COPY --from=build /usr/src/danger/distribution ./dist
 COPY --from=build /usr/src/danger/node_modules ./node_modules
-RUN chmod +x /usr/src/danger/dist/commands/danger.js && \
-    ln -s /usr/src/danger/dist/commands/danger.js /usr/bin/danger
+RUN ln -s /usr/src/danger/dist/commands/danger.js /usr/bin/danger
 
 ENTRYPOINT ["danger", "ci"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4198,9 +4198,9 @@ fast-glob@^3.2.9:
     micromatch "^4.0.4"
 
 fast-json-patch@^3.0.0-1:
-  version "3.0.0-1"
-  resolved "https://registry.yarnpkg.com/fast-json-patch/-/fast-json-patch-3.0.0-1.tgz#4c68f2e7acfbab6d29d1719c44be51899c93dabb"
-  integrity sha512-6pdFb07cknxvPzCeLsFHStEy+MysPJPgZQ9LbQ/2O67unQF93SNqfdSqnPPl71YMHX+AD8gbl7iuoGFzHEdDuw==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fast-json-patch/-/fast-json-patch-3.1.1.tgz#85064ea1b1ebf97a3f7ad01e23f9337e72c66947"
+  integrity sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==
 
 fast-json-stable-stringify@2.x:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3325,9 +3325,9 @@ decamelize@^1.0.0, decamelize@^1.2.0:
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
 decode-uri-component@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
-  integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
+  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
 decompress-response@^3.3.0:
   version "3.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4991,9 +4991,9 @@ html-encoding-sniffer@^1.0.1:
     whatwg-encoding "^1.0.1"
 
 http-cache-semantics@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
-  integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
+  integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
 
 http-errors@~1.6.1:
   version "1.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3052,7 +3052,7 @@ compression@^1.6.2:
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 configstore@^3.0.0:
   version "3.1.1"
@@ -6850,9 +6850,9 @@ mimic-response@^3.1.0:
   integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
 
 minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
-  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7932,9 +7932,9 @@ pupa@^2.0.1:
     escape-goat "^2.0.0"
 
 qs@~6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
-  integrity sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
+  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
 query-string@^6.12.1:
   version "6.14.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6159,24 +6159,10 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@2.x:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.0.1.tgz#3d6d0d1066039eb50984e66a7840e4f4b7a2c660"
-  integrity sha512-t6N/86QDIRYvOL259jR5c5TbtMnekl2Ib314mGeMh37zAwjgbWHieqijPH7pWaogmJq1F2I4Sphg19U1s+ZnXQ==
-  dependencies:
-    minimist "^1.2.0"
-
-json5@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
-  integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
-  dependencies:
-    minimist "^1.2.0"
-
-json5@^2.1.2:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
-  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
+json5@2.x, json5@^2.1.0, json5@^2.1.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.2.tgz#64471c5bdcc564c18f7c1d4df2e2297f2457c5ab"
+  integrity sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==
 
 jsonfile@^3.0.0:
   version "3.0.1"
@@ -6861,12 +6847,12 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@1.2.0, minimist@^1.1.1:
+minimist@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
-minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
+minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==


### PR DESCRIPTION
* resolves #1274
* refactors `Dockerfile` to optimize for size
  - converts to use a two stage build with only the minimum in
    the final stage
  - ~~applies `yarn-audit-fix` during build stage setup to automatically
    upgrade to latest patch version of dependencies~~
  - converts final build step to use the `--production` flag to
    prevent development dependencies from being present in final
    image
  - ensures that typescript is installed in resulting container

~~In addition to reducing the overall size of the container (reduced from over 1gb to under 200MB) this change results in container with far fewer known vulnerable node module.~~

```
before   latest                 2ab391c36636   23 minutes ago       1.17GB
after      latest                 91697973ff7b   About a minute ago   245MB
```