### PR TITLE
Fix dead links

### DIFF
--- a/docs/guides/the_dangerfile.html.md
+++ b/docs/guides/the_dangerfile.html.md
@@ -122,10 +122,10 @@ JavaScript:
 
 Some TypeScript examples:
 
-- **Apps** - [Artsy/Emission][emiss]
+- **Apps** - [Artsy/Eigen][eigen]
 - **Libraries** [danger/danger-js][danger-js], [apollographql/apollo-client][apollo]
 
-[emiss]: https://github.com/artsy/emission/blob/master/dangerfile.ts
+[eigen]: https://github.com/artsy/eigen/blob/main/dangerfile.ts
 [danger-js]: https://github.com/danger/danger-js/blob/master/dangerfile.ts
 [meta]: https://github.com/artsy/metaphysics/blob/master/dangerfile.js
 [rn]: https://github.com/facebook/react-native/blob/master/bots/dangerfile.js
@@ -134,5 +134,5 @@ Some TypeScript examples:
 [jest]: https://github.com/facebook/jest
 [transpilation_guide]: /docs/tutorials/transpilation.html.md
 [changelog]: http://danger.systems/js/changelog.html
-[apollo]: https://github.com/apollographql/apollo-client/blob/master/config/dangerfile.ts
+[apollo]: https://github.com/apollographql/apollo-cache-persist/blob/master/dangerfile.ts
 [bamlab]: https://github.com/bamlab/dev-standards/blob/master/dangerfile.js

--- a/docs/tutorials/transpilation.html.md
+++ b/docs/tutorials/transpilation.html.md
@@ -24,7 +24,7 @@ A few notes:
 You might have a `src` folder where your actual source code is kept, and adding a `dangerfile.ts` at the root which will
 break compilation. The answer to this is to add the dangerfile to the `"exclude"` section. Then to get inline errors
 working correct, add it to the `"include"`. It's a neat little trick. You can see it working in
-[artsy/emission#tsconfig.json][tsconfig]
+[artsy/eigen#tsconfig.json][tsconfig]
 
 ```json
 {
@@ -69,7 +69,7 @@ it("does nothing when there's a PR body", () => {
 })
 ```
 
-[tsconfig]: https://github.com/artsy/emission/blob/main/tsconfig.json
+[tsconfig]: https://github.com/artsy/eigen/blob/main/tsconfig.json
 
 ### Disabling Transpilation
 

--- a/docs/usage/danger-process.html.md
+++ b/docs/usage/danger-process.html.md
@@ -199,7 +199,7 @@ Finally, let me ([@orta][]) know! I want to keep track of them all on the Danger
   Danger JS will re-send the JSON to your process.
 
 [danger-swift]: https://github.com/danger/danger-swift
-[swift-json]: https://github.com/danger/danger-swift/blob/main/fixtures/eidolon_609.json
+[swift-json]: https://github.com/danger/danger-swift/blob/master/fixtures/eidolon_609.json
 [swift-stdin]:
   https://github.com/danger/danger-swift/blob/1576e336e41698861456533463c8821675427258/Sources/Runner/main.swift#L9-L11
 [swift-eval]:


### PR DESCRIPTION
I noticed some of the links are no longer working due to the fact pointing to repositories that have been archived or they have stopped using danger completely.