### PR TITLE
Upped the DSL timeout to 10 seconds

### DIFF
--- a/source/commands/danger-runner.ts
+++ b/source/commands/danger-runner.ts
@@ -91,7 +91,7 @@ setTimeout(() => {
     process.exitCode = 1
     process.exit(1)
   }
-}, 1000)
+}, 10000)
 
 // Start waiting on STDIN for the DSL
 getSTDIN().then(run(program as any))


### PR DESCRIPTION
PR based on #1276

"Bitbucket is hitting the 1 secound timeout before it is able to get the DSL, the timeout is there so the CI doesn't hang if broken."