### PR TITLE
Allowing slashes in branch names

### DIFF
--- a/source/ci_source/providers/CodeBuild.ts
+++ b/source/ci_source/providers/CodeBuild.ts
@@ -66,13 +66,13 @@ export class CodeBuild implements CISource {
 
   private async _getPrId(): Promise<string> {
     const sourceParts = (this.env.CODEBUILD_SOURCE_VERSION || "").split("/")
-    const triggerParts = (this.env.CODEBUILD_WEBHOOK_TRIGGER || "").split("/")
+    const triggerParts = this.env.CODEBUILD_WEBHOOK_TRIGGER || ""
 
-    const branchName = triggerParts[0] === "branch" ? triggerParts[1] : null
+    const branchName = triggerParts.startsWith("branch/") ? triggerParts.replace("branch/", "") : null
     let prId = sourceParts[0] === "pr" ? sourceParts[1] : null
 
     if (!prId) {
-      prId = triggerParts[0] === "pr" ? triggerParts[1] : null
+      prId = triggerParts.startsWith("pr/") ? triggerParts.replace("pr/", "") : null
     }
 
     if (!prId && branchName) {

--- a/source/ci_source/providers/_tests/_codebuild.test.ts
+++ b/source/ci_source/providers/_tests/_codebuild.test.ts
@@ -51,7 +51,7 @@ describe(".isPR", () => {
     expect(codebuild.isPR).toBeFalsy()
   })
 
-  it.each(["CODEBUILD_BUILD_ID", "CODEBUILD_SOURCE_REPO_URL"])(`does not validate when %s is missing`, async key => {
+  it.each(["CODEBUILD_BUILD_ID", "CODEBUILD_SOURCE_REPO_URL"])(`does not validate when %s is missing`, async (key) => {
     const copiedEnv = { ...correctEnv }
     delete copiedEnv[key]
     const codebuild = await setupCodeBuildSource(copiedEnv)
@@ -71,7 +71,7 @@ describe(".pullRequestID", () => {
     jest.resetAllMocks()
   })
 
-  it.each(["CODEBUILD_SOURCE_VERSION", "CODEBUILD_WEBHOOK_TRIGGER"])("splits it from %s", async key => {
+  it.each(["CODEBUILD_SOURCE_VERSION", "CODEBUILD_WEBHOOK_TRIGGER"])("splits it from %s", async (key) => {
     const codebuild = await setupCodeBuildSource({ [key]: "pr/2" })
     await codebuild.setup()
     expect(codebuild.pullRequestID).toEqual("2")
@@ -88,6 +88,18 @@ describe(".pullRequestID", () => {
     expect(codebuild.pullRequestID).toBe("1")
     expect(getPullRequestIDForBranch).toHaveBeenCalledTimes(1)
     expect(getPullRequestIDForBranch).toHaveBeenCalledWith(codebuild, env, "my-branch")
+  })
+
+  it('allows for branch names with "/" in them', async () => {
+    const env = {
+      CODEBUILD_SOURCE_REPO_URL: "https://github.com/sharkysharks/some-repo",
+      CODEBUILD_WEBHOOK_TRIGGER: "branch/my-branch/with/slashes",
+      DANGER_GITHUB_API_TOKEN: "xxx",
+    }
+    const codebuild = await setupCodeBuildSource(env)
+    expect(codebuild.pullRequestID).toBe("0")
+    expect(getPullRequestIDForBranch).toHaveBeenCalledTimes(1)
+    expect(getPullRequestIDForBranch).toHaveBeenCalledWith(codebuild, env, "my-branch/with/slashes")
   })
 
   it("does not call the API if no PR number or branch name available in the env vars", async () => {


### PR DESCRIPTION
I'm currently running into a few issues with branch names that include a slash like `feature/branch-name`. So this means that `CODEBUILD_WEBHOOK_TRIGGER` will look like `branch/feature/branch-name` and danger then splits the string into an array and looks for the second index('feature'). This misses the rest of the name meaning that the PR cannot be found and Danger errors out.

To combat this I've swapped out the split to arrays and seen as we know what the ENVs will be formatted we can just check the start of the strings and then replace the part we don't want.