### PR TITLE
Improve Bamboo CI's configuration documentation

### DIFF
--- a/source/ci_source/providers/Bamboo.ts
+++ b/source/ci_source/providers/Bamboo.ts
@@ -4,31 +4,31 @@ import { ensureEnvKeysExist, ensureEnvKeysAreInt } from "../ci_source_helpers"
 /**
  * ### CI Setup
  *
- * Install dependencies and add a danger step to your `bitbucket-pipelines.yml`.
- * For improving the performance, you may need to cache `node_modules`.
+ * Bamboo v6.9+ provides the pull request key as an environment variable if
+ * the Bamboo branch is created from a pull request.
+ * However, Bamboo plan branches created as a result of a new Git branch
+ * (or manually) will not have this context added for Danger to utilise:
  *
- * ```yml
- * image: node:10.15.0
- * pipelines:
- *   pull-requests:
- *     "**":
- *       - step:
- *           caches:
- *             - node
- *           script:
- *             - export LANG="C.UTF-8"
- *             - yarn install
- *             - yarn danger ci
- * definitions:
- *   caches:
- *     node: node_modules
- * ```
+ * - Go to Plan Configuration -> Branches -> Select:
+ *   - Manually
+ *   - [x] **When pull request is created**
+ *   - When new branch in repository is created
+ *   - When new branch in repository is created and matches expression
+ *
+ * If you would like Bamboo to process all Git branches but still have Danger
+ * function on pull requests, a simple workaround is to create a separate Bamboo
+ * build plan for pull requests.
+ *
+ * A more complicated method could be to create a script to consult your source
+ * control's API for relevant pull requests based on a branch name, and then
+ * invoke Danger for each by setting the `DANGER_MANUAL_CI`,
+ * `DANGER_MANUAL_GH_REPO` and `DANGER_MANUAL_PR_NUM` environment variables.
  *
  * ### Token Setup
  *
- * You can either add `DANGER_BITBUCKETCLOUD_USERNAME`, `DANGER_BITBUCKETCLOUD_PASSWORD`
- * or add `DANGER_BITBUCKETCLOUD_OAUTH_KEY`, `DANGER_BITBUCKETCLOUD_OAUTH_SECRET`
- * -
+ * Set the relevant environment variables for your source control system, such
+ * as `DANGER_BITBUCKETSERVER_HOST`, `DANGER_BITBUCKETSERVER_USERNAME`, and
+ * `DANGER_BITBUCKETSERVER_TOKEN`.
  */
 
 export class Bamboo implements CISource {
@@ -56,7 +56,9 @@ export class Bamboo implements CISource {
     //ssh://git@bt01.cliplister.com:7999/clfr30/bc3_complete.git
     // bamboo_inject_slug="projects/CLFR30/repos/bc3_complete" \
 
-    const [, project, slug] = this.env.bamboo_planRepository_repositoryUrl.match(/\/(\w+)\/([a-zA-Z0-9_\.-]+(?:.git)?)$/)
+    const [, project, slug] = this.env.bamboo_planRepository_repositoryUrl.match(
+      /\/(\w+)\/([a-zA-Z0-9_\.-]+(?:.git)?)$/
+    )
 
     return `projects/${project}/repos/${slug.replace(/\.[^.]+$/, "")}`
   }


### PR DESCRIPTION
The Bamboo comments on the website were the same as Bitbucket Pipelines. From the Atlassian docs the oldest Bamboo I can find providing the `bamboo.repository.pr.key` property is 6.9: https://confluence.atlassian.com/bamboo0609/using-bamboo/bamboo-variables.