### PR TITLE
Fix `danger local` to play nice with git config diff.noprefix

### DIFF
--- a/source/platforms/git/localGetDiff.ts
+++ b/source/platforms/git/localGetDiff.ts
@@ -2,8 +2,8 @@ import { debug } from "../../debug"
 import { spawn } from "child_process"
 
 const d = debug("localGetDiff")
-const useCommittedDiffArgs = (base: string, head: string) => ["diff", `${base}...${head}`]
-const useStagingChanges = (base: string) => ["diff", base]
+const useCommittedDiffArgs = (base: string, head: string) => ["diff", "--src-prefix='a/' --dst-prefix='b/'", `${base}...${head}`]
+const useStagingChanges = (base: string) => ["diff", "--src-prefix='a/' --dst-prefix='b/'", base]
 export const localGetDiff = (base: string, head: string, staging: boolean = false) =>
   new Promise<string>(done => {
     const args = staging ? useStagingChanges(base) : useCommittedDiffArgs(base, head)


### PR DESCRIPTION
This fixes https://github.com/danger/danger-js/issues/1302.

As far as I understood a similar fix isn't needed for GitHub/GitLab, as they get their diff from the API.

I didn't wrote any tests as I can imagine it will be hard/impossible to test with git config.
