### PR TITLE
Fix `fileMatch` to not return committed or working-dir files when using `--staging`

### DIFF
--- a/source/platforms/git/localGetDiff.ts
+++ b/source/platforms/git/localGetDiff.ts
@@ -3,7 +3,7 @@ import { spawn } from "child_process"
 
 const d = debug("localGetDiff")
 const useCommittedDiffArgs = (base: string, head: string) => ["diff", `${base}...${head}`]
-const useStagingChanges = (base: string) => ["diff", base]
+const useStagingChanges = (base: string) => ["diff", '--staged]
 export const localGetDiff = (base: string, head: string, staging: boolean = false) =>
   new Promise<string>(done => {
     const args = staging ? useStagingChanges(base) : useCommittedDiffArgs(base, head)

--- a/source/platforms/git/localGetDiff.ts
+++ b/source/platforms/git/localGetDiff.ts
@@ -3,7 +3,7 @@ import { spawn } from "child_process"
 
 const d = debug("localGetDiff")
 const useCommittedDiffArgs = (base: string, head: string) => ["diff", "--src-prefix='a/' --dst-prefix='b/'", `${base}...${head}`]
-const useStagingChanges = (base: string) => ["diff", "--src-prefix='a/' --dst-prefix='b/'", "--staged"]
+const useStagingChanges = () => ["diff", "--src-prefix='a/' --dst-prefix='b/'", "--staged"]
 
 export const localGetDiff = (base: string, head: string, staging: boolean = false) =>
   new Promise<string>((done) => {

--- a/source/platforms/git/localGetDiff.ts
+++ b/source/platforms/git/localGetDiff.ts
@@ -3,7 +3,7 @@ import { spawn } from "child_process"
 
 const d = debug("localGetDiff")
 const useCommittedDiffArgs = (base: string, head: string) => ["diff", `${base}...${head}`]
-const useStagingChanges = (base: string) => ["diff", '--staged]
+const useStagingChanges = (base: string) => ["diff", '--staged']
 export const localGetDiff = (base: string, head: string, staging: boolean = false) =>
   new Promise<string>(done => {
     const args = staging ? useStagingChanges(base) : useCommittedDiffArgs(base, head)

--- a/source/platforms/git/localGetDiff.ts
+++ b/source/platforms/git/localGetDiff.ts
@@ -3,25 +3,25 @@ import { spawn } from "child_process"
 
 const d = debug("localGetDiff")
 const useCommittedDiffArgs = (base: string, head: string) => ["diff", `${base}...${head}`]
-const useStagingChanges = (base: string) => ["diff", '--staged']
+const useStagingChanges = () => ["diff", "--staged"]
 export const localGetDiff = (base: string, head: string, staging: boolean = false) =>
-  new Promise<string>(done => {
-    const args = staging ? useStagingChanges(base) : useCommittedDiffArgs(base, head)
+  new Promise<string>((done) => {
+    const args = staging ? useStagingChanges() : useCommittedDiffArgs(base, head)
     let stdout = ""
 
     const child = spawn("git", args, { env: process.env })
     d("> git", args.join(" "))
 
-    child.stdout.on("data", chunk => {
+    child.stdout.on("data", (chunk) => {
       stdout += chunk
     })
 
-    child.stderr.on("data", data => {
+    child.stderr.on("data", (data) => {
       console.error(`Could not get diff from git between ${base} and ${head}`)
       throw new Error(data.toString())
     })
 
-    child.on("close", function(code) {
+    child.on("close", function (code) {
       if (code === 0) {
         done(stdout)
       }


### PR DESCRIPTION
Changes `git diff <base>` to `git diff --staged`. The first one also returns changes from base to working-dir, and thus includes working-dir and committed files. The second only returns changes in the staging area.

Currently, this actually only fixes the file paths, which is one of the issues in https://github.com/danger/danger-js/issues/1304.
It doesn't fix the diffs yet. See https://github.com/danger/danger-js/issues/1304 for more details.