### PR TITLE
Fix `structuredDiffForFile` to return staged diffs when using `--staging`

### DIFF
--- a/source/platforms/LocalGit.ts
+++ b/source/platforms/LocalGit.ts
@@ -50,6 +50,7 @@ export class LocalGit implements Platform {
 
     const config: GitJSONToGitDSLConfig = {
       repo: process.cwd(),
+      staging: this.options.staging,
       baseSHA: this.options.base || "master",
       headSHA: "HEAD",
       getFileContents: localGetFileAtSHA,

--- a/source/platforms/LocalGit.ts
+++ b/source/platforms/LocalGit.ts
@@ -50,7 +50,7 @@ export class LocalGit implements Platform {
 
     const config: GitJSONToGitDSLConfig = {
       repo: process.cwd(),
-      staging: this.options.staging,
+      staging: this.options.staging || false,
       baseSHA: this.options.base || "master",
       headSHA: "HEAD",
       getFileContents: localGetFileAtSHA,
@@ -104,7 +104,7 @@ export class LocalGit implements Platform {
     return true
   }
 
-  getFileContents = (path: string) => new Promise<string>(res => res(readFileSync(path, "utf8")))
+  getFileContents = (path: string) => new Promise<string>((res) => res(readFileSync(path, "utf8")))
 
   async getReviewInfo(): Promise<any> {
     return {}

--- a/source/platforms/git/gitJSONToGitDSL.ts
+++ b/source/platforms/git/gitJSONToGitDSL.ts
@@ -25,7 +25,8 @@ export interface GitJSONToGitDSLConfig {
   /** This is used in getFileContents to figure out your repo  */
   repo?: string
 
-  // These two will be tricky when trying to do this for staged files
+  /** Whether to diff only files from the staging area */
+  staging: boolean = false
 
   /** The sha things are going into */
   baseSHA: string
@@ -48,7 +49,7 @@ export const gitJSONToGitDSL = (gitJSONRep: GitJSONDSL, config: GitJSONToGitDSLC
     ? null
     : memoize(
         (base: string, head: string) => {
-          return config.getFullDiff!(base, head)
+          return config.getFullDiff!(base, head, config.staging)
         },
         (base: string, head: string) => `${base}...${head}`
       )
@@ -194,7 +195,7 @@ export const gitJSONToGitDSL = (gitJSONRep: GitJSONDSL, config: GitJSONToGitDSLC
     if (config.getStructuredDiffForFile) {
       fileDiffs = await config.getStructuredDiffForFile(config.baseSHA, config.headSHA, filename)
     } else {
-      const diff = await getFullDiff!(config.baseSHA, config.headSHA)
+      const diff = await getFullDiff!(config.baseSHA, config.headSHA, config.staging)
       fileDiffs = parseDiff(diff)
     }
     const structuredDiff = fileDiffs.find(diff => diff.from === filename || diff.to === filename)

--- a/source/platforms/git/gitJSONToGitDSL.ts
+++ b/source/platforms/git/gitJSONToGitDSL.ts
@@ -36,7 +36,7 @@ export interface GitJSONToGitDSLConfig {
   /** A promise which will return the string content of a file at a sha */
   getFileContents: (path: string, repo: string | undefined, sha: string) => Promise<string>
   /** A promise which will return the diff string content for a file between shas */
-  getFullDiff?: (base: string, head: string, staging: boolean) => Promise<string>
+  getFullDiff?: (base: string, head: string, staging?: boolean) => Promise<string>
   getStructuredDiffForFile?: (base: string, head: string, filename: string) => Promise<GitStructuredDiff>
 }
 

--- a/source/platforms/git/gitJSONToGitDSL.ts
+++ b/source/platforms/git/gitJSONToGitDSL.ts
@@ -26,7 +26,7 @@ export interface GitJSONToGitDSLConfig {
   repo?: string
 
   /** Whether to diff only files from the staging area */
-  staging: boolean
+  staging?: boolean
 
   /** The sha things are going into */
   baseSHA: string


### PR DESCRIPTION
The `--staging` argument is used to select files with `fileMatch`, but when fetching diffs from `structuredDiffForFile()`, the `--staging` argument is ignored. This PR passes the `--staging` argument to that method as well and changes `null` diffs into actual diffs from the staging area.

This fixes the second issue from https://github.com/danger/danger-js/issues/1304. It needs https://github.com/danger/danger-js/pull/1305 to fix the correct file paths.

Note I'm not sure about the correctness of the code. I've made `yarn test` happy, but my ts knowledge is not that good to know for sure whether I'm doing the right thing. Also I see the `staging` argument is missing for the config of the other platforms, and I'm unsure what to fill it with there.