### PR TITLE
Add random chars to files to support concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ## Main
 
 <!-- Your comment below this -->
-
+- Append random string to danger-results.json and danger-dsl.json files to better support concurrent processes #1311
 
 <!-- Your comment above this -->
 

--- a/source/commands/danger-runner.ts
+++ b/source/commands/danger-runner.ts
@@ -18,6 +18,7 @@ import { getPlatformForEnv } from "../platforms/platform"
 import { tmpdir } from "os"
 import { writeFileSync } from "fs"
 import { join } from "path"
+import { randomBytes } from "crypto"
 
 const d = debug("runner")
 
@@ -72,12 +73,11 @@ nodeCleanup((exitCode: number, signal: string) => {
   const results: DangerResults = runtimeEnv.results
   d(`Process has finished with ${exitCode}, sending the results back to the host process ${signal || ""}`)
   d(
-    `Got md ${results.markdowns.length} w ${results.warnings.length} f ${results.fails.length} m ${
-      results.messages.length
-    }`
+    `Got md ${results.markdowns.length} w ${results.warnings.length} f ${results.fails.length} m ${results.messages.length}`
   )
   if (foundDSL) {
-    const resultsPath = join(tmpdir(), "danger-results.json")
+    const filename = `danger-results-${randomBytes(4).toString("hex")}.json`
+    const resultsPath = join(tmpdir(), filename)
     d(`Writing results into ${resultsPath}`)
     writeFileSync(resultsPath, JSON.stringify(results, null, 2), "utf8")
     process.stdout.write("danger-results:/" + resultsPath)


### PR DESCRIPTION
As discussed in #1311, we're currently experiencing an issue where we have two or more concurrent processes running Danger. Both processes attempt to read/write to the same file locations on disk, which means we have a race condition where only one process can complete successfully.

This PR attempts to remedy this by appending a random 4 byte token to the end of the filename to prevent clashes. For example:

```
danger://dsl//var/folders/0h/c4gthkj13sz3hb1z4fwpnd3c0000gp/T/danger-dsl-1e170c2b.json
```

I've not written JS before, so I'd love to hear if this could be improved. Additionally, a pre-commit hook seems to have done some lint/formatting. Let me know if this should not be included and I can send a raw diff.

**Note:** I've created a package of this PR and applied to one of our CI servers. We'll let it run concurrently for a few tests to ensure this works manually, as I'm not show how to unit test this enhancement.
