### PR TITLE
GitLab: Improve GitLab CI support for MRs from forks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 
 <!-- Your comment below this -->
 - Append random string to danger-results.json and danger-dsl.json files to better support concurrent processes #1311
-
+- GitLab: Improve support for MRs from forks [#1319](https://github.com/danger/danger-js/pull/1319) [@ivankatliarchuk]
+- GitLab: Added provider tests [#1319](https://github.com/danger/danger-js/pull/1319) [@ivankatliarchuk]
 <!-- Your comment above this -->
 
 ## 11.1.2
@@ -28,7 +29,7 @@
 
 - Bug fix for over-deleting inline comments #1287
 
-## 11.1.0 
+## 11.1.0
 
 - Adds support for the new [GitHub Job summaries](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/) API via:
  - `danger.github.setSummaryMarkdown("[markdown]")` for the JavaScript DSL
@@ -57,7 +58,7 @@
 # 11.0.0 -> 11.0.2
 
 - *Breaking:* Upgrade @octokit/rest from ^16.43.1 to ^18.12.0 - [#1204](https://github.com/danger/danger-js/pull/1204) [@fbartho]
-  
+
   This is only likely to hit you if you use `danger.github.api` pretty extensively in your Dangerfiles, but better to keep an eye out.
 
 # 10.8.1
@@ -1947,6 +1948,7 @@ Not usable for others, only stubs of classes etc. - [@orta]
 [@hmschreiner]: https://github.com/hmschreiner
 [@hongrich]: https://github.com/hongrich
 [@igorbek]: https://github.com/igorbek
+[@ivankatliarchuk]: https://github.com/ivankatliarchuk
 [@iljadaderko]: https://github.com/IljaDaderko
 [@imorente]: https://github.com/imorente
 [@jamiebuilds]: https://github.com/jamiebuilds

--- a/source/ci_source/providers/GitLabCI.ts
+++ b/source/ci_source/providers/GitLabCI.ts
@@ -23,6 +23,7 @@ export class GitLabCI implements CISource {
   }
 
   get repoSlug(): string {
+    // return this.env.CI_MERGE_REQUEST_PROJECT_PATH || this.env.CI_PROJECT_PATH
     return this.env.CI_PROJECT_PATH
   }
 

--- a/source/ci_source/providers/GitLabCI.ts
+++ b/source/ci_source/providers/GitLabCI.ts
@@ -23,8 +23,7 @@ export class GitLabCI implements CISource {
   }
 
   get repoSlug(): string {
-    // return this.env.CI_MERGE_REQUEST_PROJECT_PATH || this.env.CI_PROJECT_PATH
-    return this.env.CI_PROJECT_PATH
+    return this.env.CI_MERGE_REQUEST_PROJECT_PATH || this.env.CI_PROJECT_PATH
   }
 
   get commitHash(): string {

--- a/source/ci_source/providers/_tests/_gitlab.test.ts
+++ b/source/ci_source/providers/_tests/_gitlab.test.ts
@@ -34,12 +34,12 @@ describe(".pullRequestID", () => {
 })
 
 describe(".repoSlug", () => {
-  it("derives it from the PR Url", () => {
+  it("derives it 'CI_PROJECT_PATH' env var", () => {
     const result = new GitLabCI(correctEnv)
     expect(result.repoSlug).toEqual("gitlab-org/gitlab-foss")
   })
 
-  it("derives it form forked PR Url", () => {
+  it("derives it form 'CI_MERGE_REQUEST_PROJECT_PATH' env var if set", () => {
     correctEnv["CI_MERGE_REQUEST_PROJECT_PATH"] = "gitlab-org/release-tools"
     const result = new GitLabCI(correctEnv)
     expect(result.repoSlug).toEqual("gitlab-org/release-tools")

--- a/source/ci_source/providers/_tests/_gitlab.test.ts
+++ b/source/ci_source/providers/_tests/_gitlab.test.ts
@@ -34,7 +34,7 @@ describe(".pullRequestID", () => {
 })
 
 describe(".repoSlug", () => {
-  it("derives it 'CI_PROJECT_PATH' env var", () => {
+  it("derives it from 'CI_PROJECT_PATH' env var", () => {
     const result = new GitLabCI(correctEnv)
     expect(result.repoSlug).toEqual("gitlab-org/gitlab-foss")
   })

--- a/source/ci_source/providers/_tests/_gitlab.test.ts
+++ b/source/ci_source/providers/_tests/_gitlab.test.ts
@@ -5,7 +5,6 @@ const correctEnv = {
   GITLAB_CI: "true",
   CI_MERGE_REQUEST_IID: "27117",
   CI_PROJECT_PATH: "gitlab-org/gitlab-foss",
-  // DANGER_GITLAB_API_TOKEN: "gitlab_dummy_a829-07bd7559eecb"
 }
 
 describe("being found when looking for CI", () => {
@@ -27,8 +26,6 @@ describe(".isCI", () => {
   })
 })
 
-// missed
-
 describe(".pullRequestID", () => {
   it("pulls it out of the env", () => {
     const result = new GitLabCI(correctEnv)
@@ -40,5 +37,11 @@ describe(".repoSlug", () => {
   it("derives it from the PR Url", () => {
     const result = new GitLabCI(correctEnv)
     expect(result.repoSlug).toEqual("gitlab-org/gitlab-foss")
+  })
+
+  it("derives it form forked PR Url", () => {
+    correctEnv["CI_MERGE_REQUEST_PROJECT_PATH"] = "gitlab-org/release-tools"
+    const result = new GitLabCI(correctEnv)
+    expect(result.repoSlug).toEqual("gitlab-org/release-tools")
   })
 })

--- a/source/ci_source/providers/_tests/_gitlab.test.ts
+++ b/source/ci_source/providers/_tests/_gitlab.test.ts
@@ -1,0 +1,44 @@
+import { GitLabCI } from "../GitLabCI"
+import { getCISourceForEnv } from "../../get_ci_source"
+
+const correctEnv = {
+  GITLAB_CI: "true",
+  CI_MERGE_REQUEST_IID: "27117",
+  CI_PROJECT_PATH: "gitlab-org/gitlab-foss",
+  // DANGER_GITLAB_API_TOKEN: "gitlab_dummy_a829-07bd7559eecb"
+}
+
+describe("being found when looking for CI", () => {
+  it("finds GitLab with the right ENV", () => {
+    const ci = getCISourceForEnv(correctEnv)
+    expect(ci).toBeInstanceOf(GitLabCI)
+  })
+})
+
+describe(".isCI", () => {
+  it("validates when all GitLab environment vars are set", async () => {
+    const result = new GitLabCI(correctEnv)
+    expect(result.isCI).toBeTruthy()
+  })
+
+  it("does not validate without env", async () => {
+    const result = new GitLabCI({})
+    expect(result.isCI).toBeFalsy()
+  })
+})
+
+// missed
+
+describe(".pullRequestID", () => {
+  it("pulls it out of the env", () => {
+    const result = new GitLabCI(correctEnv)
+    expect(result.pullRequestID).toEqual("27117")
+  })
+})
+
+describe(".repoSlug", () => {
+  it("derives it from the PR Url", () => {
+    const result = new GitLabCI(correctEnv)
+    expect(result.repoSlug).toEqual("gitlab-org/gitlab-foss")
+  })
+})


### PR DESCRIPTION
- Added Gitlab provider tests
- [updated pr](https://github.com/danger/danger-js/pull/978) as its looks like is abandoned