### PR TITLE
fix: gitlab api `diffForFile`

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,6 @@
     "fast-json-patch": "^3.0.0-1",
     "get-stdin": "^6.0.0",
     "@gitbeaker/node": "^21.3.0",
-    "gitlab": "^10.0.1",
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.1",
     "hyperlinker": "^1.0.0",

--- a/source/dsl/GitLabDSL.ts
+++ b/source/dsl/GitLabDSL.ts
@@ -1,5 +1,4 @@
 // Please don't have includes in here that aren't inside the DSL folder, or the d.ts/flow defs break
-
 // TODO: extract out from BitBucket specifically, or create our own type
 import { Gitlab } from "@gitbeaker/node"
 import { RepoMetaData } from "./BitBucketServerDSL"
@@ -245,19 +244,6 @@ export interface GitLabMRCommit {
   committer_name: string
   committer_email: string
   committed_date: string
-}
-
-export interface GitLabRepositoryFile {
-  file_name: string
-  file_path: string
-  size: number
-  encoding: "base64"
-  content: string
-  content_sha256: string
-  ref: string
-  blob_id: string
-  commit_id: string
-  last_commit_id: string
 }
 
 export interface GitLabCommit {

--- a/source/platforms/gitlab/GitLabAPI.ts
+++ b/source/platforms/gitlab/GitLabAPI.ts
@@ -9,12 +9,12 @@ import {
   GitLabMRCommit,
   GitLabNote,
   GitLabUserProfile,
-  GitLabRepositoryFile,
   GitLabRepositoryCompare,
   GitLabApproval,
 } from "../../dsl/GitLabDSL"
 
 import { Gitlab } from "@gitbeaker/node"
+import { RepositoryFileSchema } from "@gitbeaker/core/dist/types/services/RepositoryFiles"
 import { Env } from "../../ci_source/ci_source"
 import { debug } from "../../debug"
 
@@ -229,14 +229,14 @@ class GitLabAPI {
 
     try {
       this.d("getFileContents", projectId, path, ref)
-      const response = (await api.show(projectId, path, ref)) as GitLabRepositoryFile
-      const result: string = Buffer.from(response.content, "base64").toString()
+      const response = (await api.show(projectId, path, ref)) as RepositoryFileSchema
+      const result: string = Buffer.from(response.content, response.encoding).toString()
       this.d("getFileContents", result)
       return result
     } catch (e) {
       this.d("getFileContents", e)
       // GitHubAPI.fileContents returns "" when the file does not exist, keep it consistent across providers
-      if ((e as any).response.status === 404) {
+      if ((e as any).response.statusCode === 404) {
         return ""
       }
       throw e

--- a/source/platforms/gitlab/_tests/_gitlab_api.test.ts
+++ b/source/platforms/gitlab/_tests/_gitlab_api.test.ts
@@ -175,6 +175,11 @@ describe("GitLab API", () => {
         ref: "master",
         expected: "source 'https://rubygems.org'",
       },
+      {
+        filePath: "FileNotExist",
+        ref: "master",
+        expected: "",
+      },
     ]
     for (let el in parameters) {
       let result = await api.getFileContents(parameters[el].filePath, api.repoMetadata.repoSlug, parameters[el].ref)

--- a/source/platforms/gitlab/_tests/_gitlab_api.test.ts
+++ b/source/platforms/gitlab/_tests/_gitlab_api.test.ts
@@ -166,4 +166,20 @@ describe("GitLab API", () => {
     const { response } = loadFixture("getCompareChanges")
     expect(result).toEqual(response.diffs)
   })
+
+  it("getFileContents", async () => {
+    const { nockDone } = await nockBack("getFileContents.json")
+    const parameters: { filePath: string; ref: string; expected: string }[] = [
+      {
+        filePath: "Gemfile",
+        ref: "master",
+        expected: "source 'https://rubygems.org'",
+      },
+    ]
+    for (let el in parameters) {
+      let result = await api.getFileContents(parameters[el].filePath, api.repoMetadata.repoSlug, parameters[el].ref)
+      expect(result).toContain(parameters[el].expected)
+    }
+    nockDone()
+  })
 })

--- a/source/platforms/gitlab/_tests/fixtures/getFileContents.json
+++ b/source/platforms/gitlab/_tests/fixtures/getFileContents.json
@@ -1,0 +1,22 @@
+[
+  {
+    "scope": "https://gitlab.com",
+    "method": "GET",
+    "path": "/api/v4/projects/gitlab-org%2Fgitlab-foss/repository/files/Gemfile?ref=master",
+    "body": "",
+    "status": 200,
+    "response": {
+      "file_name": "Gemfile",
+      "file_path": "Gemfile",
+      "size": 4989,
+      "encoding": "base64",
+      "content_sha256": "d1db2dff734c9a5f59b9e994b2f610317a0bdbdf938d4dc2797bb0bd384233f6",
+      "ref": "master",
+      "blob_id": "78b0a38bcaae68ca1bd5fc967c9901c854f3d9ab",
+      "commit_id": "86461e8c72db13d6d334fd107d38aa1b021d030e",
+      "last_commit_id": "a16398e10f87edd229a12be2f1fc87cd4a76f902",
+      "execute_filemode": false,
+      "content": "c291cmNlICdodHRwczovL3J1YnlnZW1zLm9yZycK"
+    }
+  }
+]

--- a/source/platforms/gitlab/_tests/fixtures/getFileContents.json
+++ b/source/platforms/gitlab/_tests/fixtures/getFileContents.json
@@ -18,5 +18,13 @@
       "execute_filemode": false,
       "content": "c291cmNlICdodHRwczovL3J1YnlnZW1zLm9yZycK"
     }
+  },
+  {
+    "scope": "https://gitlab.com",
+    "method": "GET",
+    "path": "/api/v4/projects/gitlab-org%2Fgitlab-foss/repository/files/FileNotExist?ref=master",
+    "body": "",
+    "status": 404,
+    "response": {}
   }
 ]


### PR DESCRIPTION
# BUG

## Impact

Gitlab functionality is broken. Construct `await danger.git.diffForFile(file)` throw an unhadled exception when file not found

--- 

found a regression.
 with `gitlab` library
```json
if ((e as any).response.status === 404) {
        return ""
      }
```

`@gitbreaker` library
```json
if ((e as any).response.statusCode === 404) {
        return ""
      }
```

gitbreaker does handle errors in [un-documented way](https://github.com/jdalrymple/gitbeaker/issues/396)

tested locally with local installation
```sh
yarn build && yarn pack
```