### PR TITLE
Gitlab: Upgrade @gitbreaker/node from ^21.3.0 to ^35.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 <!-- Your comment below this -->
 - Append random string to danger-results.json and danger-dsl.json files to better support concurrent processes #1311
-
+- GitLab: Upgrade `@gitbreaker/node` from `^21.3.0` to `^^35.7.0` [#1319](https://github.com/danger/danger-js/pull/1319) [@ivankatliarchuk]
 - Gitlab package moved to a new home "@gitbreaker/*" [#1301](https://github.com/danger/danger-js/issues/1301)  [@ivankatliarchuk]
 - GitLab: Improve support for MRs from forks [#1319](https://github.com/danger/danger-js/pull/1319) [@ivankatliarchuk]
 - GitLab: Added provider tests [#1319](https://github.com/danger/danger-js/pull/1319) [@ivankatliarchuk]

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "debug": "^4.1.1",
     "fast-json-patch": "^3.0.0-1",
     "get-stdin": "^6.0.0",
-    "@gitbeaker/node": "^21.3.0",
+    "@gitbeaker/node": "^35.7.0",
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.1",
     "hyperlinker": "^1.0.0",

--- a/scripts/danger-dts.ts
+++ b/scripts/danger-dts.ts
@@ -9,7 +9,7 @@ const createDTS = () => {
 //
 
 import { Octokit as GitHub } from "@octokit/rest"
-import { Gitlab } from "@gitbeaker/node"
+import { Gitlab, Types } from "@gitbeaker/node"
 import { File } from "parse-diff"
 
 `

--- a/source/danger.d.ts
+++ b/source/danger.d.ts
@@ -3,7 +3,7 @@
 //
 
 import { Octokit as GitHub } from "@octokit/rest"
-import { Gitlab } from "@gitbeaker/node"
+import { Gitlab, Types } from "@gitbeaker/node"
 import { File } from "parse-diff"
 
 type MarkdownString = string
@@ -1467,10 +1467,10 @@ interface GitLabJSONDSL {
   metadata: RepoMetaData
   /** Info about the merge request */
   mr: GitLabMR
-  /** All of the individual commits in the merge request */
-  commits: GitLabMRCommit[]
+  /** All the individual commits in the merge request */
+  commits: Types.CommitSchema[]
   /** Merge Request-level MR approvals Configuration */
-  approvals: GitLabApproval
+  approvals: Types.MergeRequestLevelMergeRequestApprovalSchema
 }
 
 // danger.gitlab
@@ -1484,134 +1484,20 @@ interface GitLabDSL extends GitLabJSONDSL {
 
 // ---
 // JSON responses from API
+interface GitlabUpdateMr extends Types.UpdateMergeRequestOptions, Types.BaseRequestOptions {}
 
-interface GitLabUser {
-  id: number
-  name: string
-  username: string
-  state: "active" | "blocked"
-  avatar_url: string | null
-  web_url: string
+interface GitLabNote extends Types.MergeRequestNoteSchema {
+  type: "DiffNote" | "DiscussionNote" | null // XXX: other types? null means "normal comment"
 }
 
-interface GitLabUserProfile extends GitLabUser {
-  created_at: string
-  bio: string | null
-  location: string | null
-  public_email: string
-  skype: string
-  linkedin: string
-  twitter: string
-  website_url: string
-  organization: string
-  last_sign_in_at: string
-  confirmed_at: string
-  theme_id: number
-  last_activity_on: string
-  color_scheme_id: number
-  projects_limit: number
-  current_sign_in_at: string
-  identities: [{ provider: string; extern_uid: string }]
-  can_create_group: boolean
-  can_create_project: boolean
-  two_factor_enabled: boolean
-  external: boolean
-  private_profile: boolean
-}
-
-interface GitLabMRBase {
-  /** The MR's id */
-  id: number
-
-  /** The unique ID for this MR */
-  iid: number
-
-  /** The project ID for this MR */
-  project_id: number
-
-  /** The given name of the MR */
-  title: string
-
-  /** The body text describing the MR */
-  description: string
-
-  /** The MR's current availability */
-  state: "closed" | "open" | "locked" | "merged"
-
-  /** When was the MR made */
-  created_at: string
-
-  /** When was the MR updated */
-  updated_at: string
-
-  /** What branch is this MR being merged into */
-  target_branch: string
-  /** What branch is this MR come from */
-  source_branch: string
-
-  /** How many folks have given it an upvote */
-  upvotes: number
-  /** How many folks have given it an downvote */
-  downvotes: number
-
-  /** Who made it */
-  author: GitLabUser
-  /** Access rights for the user who created the MR */
-  user: {
-    /** Does the author have access to merge? */
-    can_merge: boolean
-  }
-  /** Who was assigned as the person to review */
-  assignee?: GitLabUser
-  assignees: GitLabUser[]
-  /** Users who were added as reviewers to the MR */
-  reviewers: GitLabUser[]
-  source_project_id: number
-  target_project_id: number
-  labels: string[]
-  work_in_progress: boolean
-  milestone: {
-    id: number
-    iid: number
-    project_id: number
-    title: string
-    description: string
-    state: "closed" | "active"
-    created_at: string
-    updated_at: string
-    due_date: string
-    start_date: string
-    web_url: string
-  }
-  merge_when_pipeline_succeeds: boolean
-  merge_status: "can_be_merged" // XXX: other statuses?
-  merge_error: null | null
-  sha: string
-  merge_commit_sha: string | null
-  user_notes_count: number
-  discussion_locked: null | null
-  should_remove_source_branch: boolean
-  force_remove_source_branch: boolean
-  allow_collaboration: boolean
-  allow_maintainer_to_push: boolean
-  web_url: string
-  time_stats: {
-    time_estimate: number
-    total_time_spent: number
-    human_time_estimate: number | null
-    human_total_time_spent: number | null
-  }
+interface GitLabInlineNote extends GitLabNote {
+  type: "DiffNote" | "DiscussionNote" | null // XXX: other types? null means "normal comment"
 }
 
 /** TODO: These need more comments from someone who uses GitLab, see GitLabDSL.ts in the danger-js repo */
-interface GitLabMR extends GitLabMRBase {
-  squash: boolean
+interface GitLabMR extends Types.MergeRequestSchema {
   subscribed: boolean
   changes_count: string
-  merged_by: GitLabUser
-  merged_at: string
-  closed_by: GitLabUser | null
-  closed_at: string | null
   latest_build_started_at: string
   latest_build_finished_at: string
   first_deployed_to_production_at: string | null
@@ -1629,37 +1515,16 @@ interface GitLabMR extends GitLabMRBase {
   }
   diverged_commits_count: number
   rebase_in_progress: boolean
-  approvals_before_merge: null | null
-}
-
-interface GitLabMRChange {
-  old_path: string
-  new_path: string
-  a_mode: string
-  b_mode: string
-  diff: string
-  new_file: boolean
-  renamed_file: boolean
-  deleted_file: boolean
-}
-
-interface GitLabMRChanges extends GitLabMRBase {
-  changes: GitLabMRChange[]
-}
-
-interface GitLabNote {
-  id: number
-  type: "DiffNote" | "DiscussionNote" | null // XXX: other types? null means "normal comment"
-  body: string
-  attachment: null // XXX: what can an attachment be?
-  author: GitLabUser
-  created_at: string
-  updated_at: string
-  system: boolean
-  noteable_id: number
-  noteable_type: "MergeRequest" // XXX: other types...?
-  resolvable: boolean
-  noteable_iid: number
+  approvals_before_merge: null
+  //
+  /** Access rights for the user who created the MR */
+  user: {
+    /** Does the author have access to merge? */
+    can_merge: boolean
+  }
+  merge_error: null
+  allow_collaboration: boolean
+  allow_maintainer_to_push: boolean
 }
 
 interface GitLabDiscussionTextPosition {
@@ -1671,73 +1536,6 @@ interface GitLabDiscussionTextPosition {
   new_line: number
   old_path: string
   old_line: number | null
-}
-
-interface GitLabInlineNote extends GitLabNote {
-  position: {
-    base_sha: string
-    start_sha: string
-    head_sha: string
-    old_path: string
-    new_path: string
-    position_type: "text" // XXX: other types?
-    old_line: number | null
-    new_line: number
-  }
-  resolvable: boolean
-  resolved: boolean
-  resolved_by: GitLabUser | null
-}
-
-interface GitLabMRCommit {
-  id: string
-  short_id: string
-  created_at: string
-  parent_ids: string[]
-  title: string
-  message: string
-  author_name: string
-  author_email: string
-  authored_date: string
-  committer_name: string
-  committer_email: string
-  committed_date: string
-}
-
-interface GitLabCommit {
-  id: string
-  short_id: string
-  title: string
-  author_name: string
-  author_email: string
-  created_at: string
-}
-
-interface GitLabRepositoryCompare {
-  commit: GitLabCommit
-  commits: GitLabCommit[]
-  diffs: GitLabMRChange[]
-  compare_timeout: boolean
-  compare_same_ref: boolean
-}
-
-interface GitLabApproval {
-  id: number
-  iid: number
-  project_id: number
-  title: string
-  description: string
-  state: "closed" | "open" | "locked" | "merged"
-  created_at: string
-  updated_at: string
-  merge_status: "can_be_merged"
-  approvals_required: number
-  approvals_left: number
-  approved_by?:
-    | {
-        user: GitLabUser
-      }[]
-    | GitLabUser[]
 }
 /**
  * The result of user doing warn, message or fail, built this way for

--- a/source/dsl/GitLabDSL.ts
+++ b/source/dsl/GitLabDSL.ts
@@ -1,6 +1,6 @@
 // Please don't have includes in here that aren't inside the DSL folder, or the d.ts/flow defs break
 // TODO: extract out from BitBucket specifically, or create our own type
-import { Gitlab } from "@gitbeaker/node"
+import { Gitlab, Types } from "@gitbeaker/node"
 import { RepoMetaData } from "./BitBucketServerDSL"
 
 // getPlatformReviewDSLRepresentation
@@ -9,10 +9,10 @@ export interface GitLabJSONDSL {
   metadata: RepoMetaData
   /** Info about the merge request */
   mr: GitLabMR
-  /** All of the individual commits in the merge request */
-  commits: GitLabMRCommit[]
+  /** All the individual commits in the merge request */
+  commits: Types.CommitSchema[]
   /** Merge Request-level MR approvals Configuration */
-  approvals: GitLabApproval
+  approvals: Types.MergeRequestLevelMergeRequestApprovalSchema
 }
 
 // danger.gitlab
@@ -26,134 +26,20 @@ export interface GitLabDSL extends GitLabJSONDSL {
 
 // ---
 // JSON responses from API
+export interface GitlabUpdateMr extends Types.UpdateMergeRequestOptions, Types.BaseRequestOptions {}
 
-export interface GitLabUser {
-  id: number
-  name: string
-  username: string
-  state: "active" | "blocked"
-  avatar_url: string | null
-  web_url: string
+export interface GitLabNote extends Types.MergeRequestNoteSchema {
+  type: "DiffNote" | "DiscussionNote" | null // XXX: other types? null means "normal comment"
 }
 
-export interface GitLabUserProfile extends GitLabUser {
-  created_at: string
-  bio: string | null
-  location: string | null
-  public_email: string
-  skype: string
-  linkedin: string
-  twitter: string
-  website_url: string
-  organization: string
-  last_sign_in_at: string
-  confirmed_at: string
-  theme_id: number
-  last_activity_on: string
-  color_scheme_id: number
-  projects_limit: number
-  current_sign_in_at: string
-  identities: [{ provider: string; extern_uid: string }]
-  can_create_group: boolean
-  can_create_project: boolean
-  two_factor_enabled: boolean
-  external: boolean
-  private_profile: boolean
-}
-
-export interface GitLabMRBase {
-  /** The MR's id */
-  id: number
-
-  /** The unique ID for this MR */
-  iid: number
-
-  /** The project ID for this MR */
-  project_id: number
-
-  /** The given name of the MR */
-  title: string
-
-  /** The body text describing the MR */
-  description: string
-
-  /** The MR's current availability */
-  state: "closed" | "open" | "locked" | "merged"
-
-  /** When was the MR made */
-  created_at: string
-
-  /** When was the MR updated */
-  updated_at: string
-
-  /** What branch is this MR being merged into */
-  target_branch: string
-  /** What branch is this MR come from */
-  source_branch: string
-
-  /** How many folks have given it an upvote */
-  upvotes: number
-  /** How many folks have given it an downvote */
-  downvotes: number
-
-  /** Who made it */
-  author: GitLabUser
-  /** Access rights for the user who created the MR */
-  user: {
-    /** Does the author have access to merge? */
-    can_merge: boolean
-  }
-  /** Who was assigned as the person to review */
-  assignee?: GitLabUser
-  assignees: GitLabUser[]
-  /** Users who were added as reviewers to the MR */
-  reviewers: GitLabUser[]
-  source_project_id: number
-  target_project_id: number
-  labels: string[]
-  work_in_progress: boolean
-  milestone: {
-    id: number
-    iid: number
-    project_id: number
-    title: string
-    description: string
-    state: "closed" | "active"
-    created_at: string
-    updated_at: string
-    due_date: string
-    start_date: string
-    web_url: string
-  }
-  merge_when_pipeline_succeeds: boolean
-  merge_status: "can_be_merged" // XXX: other statuses?
-  merge_error: null | null
-  sha: string
-  merge_commit_sha: string | null
-  user_notes_count: number
-  discussion_locked: null | null
-  should_remove_source_branch: boolean
-  force_remove_source_branch: boolean
-  allow_collaboration: boolean
-  allow_maintainer_to_push: boolean
-  web_url: string
-  time_stats: {
-    time_estimate: number
-    total_time_spent: number
-    human_time_estimate: number | null
-    human_total_time_spent: number | null
-  }
+export interface GitLabInlineNote extends GitLabNote {
+  type: "DiffNote" | "DiscussionNote" | null // XXX: other types? null means "normal comment"
 }
 
 /** TODO: These need more comments from someone who uses GitLab, see GitLabDSL.ts in the danger-js repo */
-export interface GitLabMR extends GitLabMRBase {
-  squash: boolean
+export interface GitLabMR extends Types.MergeRequestSchema {
   subscribed: boolean
   changes_count: string
-  merged_by: GitLabUser
-  merged_at: string
-  closed_by: GitLabUser | null
-  closed_at: string | null
   latest_build_started_at: string
   latest_build_finished_at: string
   first_deployed_to_production_at: string | null
@@ -171,37 +57,16 @@ export interface GitLabMR extends GitLabMRBase {
   }
   diverged_commits_count: number
   rebase_in_progress: boolean
-  approvals_before_merge: null | null
-}
-
-export interface GitLabMRChange {
-  old_path: string
-  new_path: string
-  a_mode: string
-  b_mode: string
-  diff: string
-  new_file: boolean
-  renamed_file: boolean
-  deleted_file: boolean
-}
-
-export interface GitLabMRChanges extends GitLabMRBase {
-  changes: GitLabMRChange[]
-}
-
-export interface GitLabNote {
-  id: number
-  type: "DiffNote" | "DiscussionNote" | null // XXX: other types? null means "normal comment"
-  body: string
-  attachment: null // XXX: what can an attachment be?
-  author: GitLabUser
-  created_at: string
-  updated_at: string
-  system: boolean
-  noteable_id: number
-  noteable_type: "MergeRequest" // XXX: other types...?
-  resolvable: boolean
-  noteable_iid: number
+  approvals_before_merge: null
+  //
+  /** Access rights for the user who created the MR */
+  user: {
+    /** Does the author have access to merge? */
+    can_merge: boolean
+  }
+  merge_error: null
+  allow_collaboration: boolean
+  allow_maintainer_to_push: boolean
 }
 
 export interface GitLabDiscussionTextPosition {
@@ -213,71 +78,4 @@ export interface GitLabDiscussionTextPosition {
   new_line: number
   old_path: string
   old_line: number | null
-}
-
-export interface GitLabInlineNote extends GitLabNote {
-  position: {
-    base_sha: string
-    start_sha: string
-    head_sha: string
-    old_path: string
-    new_path: string
-    position_type: "text" // XXX: other types?
-    old_line: number | null
-    new_line: number
-  }
-  resolvable: boolean
-  resolved: boolean
-  resolved_by: GitLabUser | null
-}
-
-export interface GitLabMRCommit {
-  id: string
-  short_id: string
-  created_at: string
-  parent_ids: string[]
-  title: string
-  message: string
-  author_name: string
-  author_email: string
-  authored_date: string
-  committer_name: string
-  committer_email: string
-  committed_date: string
-}
-
-export interface GitLabCommit {
-  id: string
-  short_id: string
-  title: string
-  author_name: string
-  author_email: string
-  created_at: string
-}
-
-export interface GitLabRepositoryCompare {
-  commit: GitLabCommit
-  commits: GitLabCommit[]
-  diffs: GitLabMRChange[]
-  compare_timeout: boolean
-  compare_same_ref: boolean
-}
-
-export interface GitLabApproval {
-  id: number
-  iid: number
-  project_id: number
-  title: string
-  description: string
-  state: "closed" | "open" | "locked" | "merged"
-  created_at: string
-  updated_at: string
-  merge_status: "can_be_merged"
-  approvals_required: number
-  approvals_left: number
-  approved_by?:
-    | {
-        user: GitLabUser
-      }[]
-    | GitLabUser[]
 }

--- a/source/platforms/GitLab.ts
+++ b/source/platforms/GitLab.ts
@@ -31,26 +31,26 @@ class GitLab implements Platform {
       approvals,
     }
   }
-
+  // TODO: test
   getPlatformGitRepresentation = async (): Promise<GitJSONDSL> => {
     const changes = await this.api.getMergeRequestChanges()
     const commits = await this.api.getMergeRequestCommits()
 
-    const mappedCommits: GitCommit[] = commits.map(commit => {
+    const mappedCommits: GitCommit[] = commits.map((commit) => {
       return {
         sha: commit.id,
         author: {
           name: commit.author_name,
-          email: commit.author_email,
-          date: commit.authored_date,
+          email: commit.author_email as string,
+          date: (commit.authored_date as Date).toString(),
         },
         committer: {
-          name: commit.committer_name,
-          email: commit.committer_email,
-          date: commit.committed_date,
+          name: commit.committer_name as string,
+          email: commit.committer_email as string,
+          date: (commit.committed_date as Date).toString(),
         },
         message: commit.message,
-        parents: commit.parent_ids,
+        parents: commit.parent_ids as string[],
         url: `${this.api.projectURL}/commit/${commit.id}`,
         tree: null,
       }
@@ -58,10 +58,10 @@ class GitLab implements Platform {
 
     // XXX: does "renamed_file"/move count is "delete/create", or "modified"?
     const modified_files: string[] = changes
-      .filter(change => !change.new_file && !change.deleted_file)
-      .map(change => change.new_path)
-    const created_files: string[] = changes.filter(change => change.new_file).map(change => change.new_path)
-    const deleted_files: string[] = changes.filter(change => change.deleted_file).map(change => change.new_path)
+      .filter((change) => !change.new_file && !change.deleted_file)
+      .map((change) => change.new_path)
+    const created_files: string[] = changes.filter((change) => change.new_file).map((change) => change.new_path)
+    const deleted_files: string[] = changes.filter((change) => change.deleted_file).map((change) => change.new_path)
 
     return {
       modified_files,
@@ -74,7 +74,7 @@ class GitLab implements Platform {
   getInlineComments = async (dangerID: string): Promise<Comment[]> => {
     const dangerUserID = (await this.api.getUser()).id
 
-    return (await this.api.getMergeRequestInlineNotes()).map(note => {
+    return (await this.api.getMergeRequestInlineNotes()).map((note) => {
       return {
         id: `${note.id}`,
         body: note.body,

--- a/source/platforms/gitlab/GitLabAPI.ts
+++ b/source/platforms/gitlab/GitLabAPI.ts
@@ -3,17 +3,11 @@ import {
   GitLabDiscussionTextPosition,
   GitLabInlineNote,
   GitLabMR,
-  GitLabMRChange,
-  GitLabMRChanges,
-  GitLabMRCommit,
   GitLabNote,
-  GitLabUserProfile,
-  GitLabRepositoryCompare,
-  GitLabApproval,
+  GitlabUpdateMr,
 } from "../../dsl/GitLabDSL"
 
-import { Gitlab } from "@gitbeaker/node"
-import { RepositoryFileSchema } from "@gitbeaker/core/dist/types/services/RepositoryFiles"
+import { Gitlab, Types } from "@gitbeaker/node"
 import { Env } from "../../ci_source/ci_source"
 import { debug } from "../../debug"
 
@@ -36,7 +30,7 @@ export function getGitLabAPICredentialsFromEnv(env: Env): GitLabAPICredentials {
     const protocolRegex = /^https?:\/\//i
     host = protocolRegex.test(envHost) ? envHost : `https://${envHost}`
   } else if (envCIAPI) {
-    // GitLab >= v11.7 supplies the API Endpoint in an environment variable and we can work out our host value from that.
+    // GitLab >= v11.7 supplies the API Endpoint in an environment variable, and we can work out our host value from that.
     // See https://docs.gitlab.com/ce/ci/variables/predefined_variables.html
     const hostRegex = /^(https?):\/\/([^\/]+)\//i
     if (hostRegex.test(envCIAPI)) {
@@ -80,9 +74,10 @@ class GitLabAPI {
     return this.api
   }
 
-  getUser = async (): Promise<GitLabUserProfile> => {
+  getUser = async (): Promise<Types.UserExtendedSchema> => {
     this.d("getUser")
-    const user = (await this.api.Users.current()) as GitLabUserProfile
+    // https://github.com/jdalrymple/gitbeaker/issues/2084
+    const user = (await this.api.Users.current()) as Types.UserExtendedSchema
     this.d("getUser", user)
     return user
   }
@@ -94,31 +89,31 @@ class GitLabAPI {
     return mr
   }
 
-  updateMergeRequestInfo = async (changes: object): Promise<object> => {
+  updateMergeRequestInfo = async (changes: GitlabUpdateMr): Promise<Types.MergeRequestSchema> => {
     const mr = this.api.MergeRequests.edit(this.repoSlug, this.prId, changes)
     this.d("updateMergeRequestInfo", mr)
     return mr
   }
 
-  getMergeRequestApprovals = async (): Promise<GitLabApproval> => {
+  getMergeRequestApprovals = async (): Promise<Types.MergeRequestLevelMergeRequestApprovalSchema> => {
     this.d(`getMergeRequestApprovals for repo: ${this.repoSlug} pr: ${this.prId}`)
-    const approvals = (await this.api.MergeRequests.approvals(this.repoSlug, {
+    const approvals = await this.api.MergeRequestApprovals.configuration(this.repoSlug, {
       mergerequestIid: this.prId,
-    })) as GitLabApproval
+    })
     this.d("getMergeRequestApprovals", approvals)
     return approvals
   }
 
-  getMergeRequestChanges = async (): Promise<GitLabMRChange[]> => {
+  getMergeRequestChanges = async (): Promise<Types.CommitDiffSchema[]> => {
     this.d(`getMergeRequestChanges for repo: ${this.repoSlug} pr: ${this.prId}`)
-    const mr = (await this.api.MergeRequests.changes(this.repoSlug, this.prId)) as GitLabMRChanges
+    const mr = await this.api.MergeRequests.changes(this.repoSlug, this.prId)
     this.d("getMergeRequestChanges", mr.changes)
-    return mr.changes
+    return mr.changes as Types.CommitDiffSchema[]
   }
 
-  getMergeRequestCommits = async (): Promise<GitLabMRCommit[]> => {
+  getMergeRequestCommits = async (): Promise<Types.CommitSchema[]> => {
     this.d("getMergeRequestCommits", this.repoSlug, this.prId)
-    const commits = (await this.api.MergeRequests.commits(this.repoSlug, this.prId)) as GitLabMRCommit[]
+    const commits = await this.api.MergeRequests.commits(this.repoSlug, this.prId)
     this.d("getMergeRequestCommits", commits)
     return commits
   }
@@ -206,7 +201,7 @@ class GitLabAPI {
 
     try {
       this.d("getFileContents", projectId, path, ref)
-      const response = (await api.show(projectId, path, ref)) as RepositoryFileSchema
+      const response = await api.show(projectId, path, ref)
       const result: string = Buffer.from(response.content, response.encoding).toString()
       this.d("getFileContents", result)
       return result
@@ -220,14 +215,14 @@ class GitLabAPI {
     }
   }
 
-  getCompareChanges = async (base?: string, head?: string): Promise<GitLabMRChange[]> => {
+  getCompareChanges = async (base?: string, head?: string): Promise<Types.CommitDiffSchema[]> => {
     if (!base || !head) {
       return this.getMergeRequestChanges()
     }
     const api = this.api.Repositories
     const projectId = this.repoSlug
-    const compare = (await api.compare(projectId, base, head)) as GitLabRepositoryCompare
-    return compare.diffs
+    const compare = await api.compare(projectId, base, head)
+    return compare.diffs ? compare.diffs : []
   }
 
   addLabels = async (...labels: string[]): Promise<boolean> => {
@@ -239,16 +234,13 @@ class GitLabAPI {
 
   removeLabels = async (...labels: string[]): Promise<boolean> => {
     const mr = await this.getMergeRequestInfo()
-
     for (const label of labels) {
-      const index = mr.labels.indexOf(label)
-      if (index > -1) {
-        mr.labels.splice(index, 1)
+      const index = mr.labels?.indexOf(label)
+      if ((index as number) > -1) {
+        mr.labels?.splice(index as number, 1)
       }
     }
-
-    await this.updateMergeRequestInfo({ labels: mr.labels.join(",") })
-
+    await this.updateMergeRequestInfo({ labels: mr.labels?.join(",") })
     return true
   }
 }

--- a/source/platforms/gitlab/GitLabGit.ts
+++ b/source/platforms/gitlab/GitLabGit.ts
@@ -1,6 +1,7 @@
 import { debug } from "../../debug"
-import { GitLabDSL, GitLabMRChange } from "../../dsl/GitLabDSL"
+import { GitLabDSL } from "../../dsl/GitLabDSL"
 import { GitDSL, GitJSONDSL } from "../../dsl/GitDSL"
+import { Types } from "@gitbeaker/node"
 import { gitJSONToGitDSL, GitJSONToGitDSLConfig } from "../git/gitJSONToGitDSL"
 import GitLabAPI from "./GitLabAPI"
 
@@ -22,11 +23,11 @@ export const gitLabGitDSL = (gitlab: GitLabDSL, json: GitJSONDSL, gitlabAPI: Git
   return gitJSONToGitDSL(json, config)
 }
 
-export const gitlabChangesToDiff = (changes: GitLabMRChange[]): string => {
+export const gitlabChangesToDiff = (changes: Types.CommitDiffSchema[]): string => {
   d("Converting GitLab Changes to Diff")
   // Gitlab doesn't return full raw git diff, relevant issue: https://gitlab.com/gitlab-org/gitlab/issues/24913
   return changes
-    .map(change => {
+    .map((change) => {
       const { diff } = change
       if (diff.startsWith("diff --git a/") || diff.startsWith("--- a/") || diff.startsWith("--- /dev/null")) {
         return diff

--- a/source/platforms/gitlab/_tests/_gitlab_api.test.ts
+++ b/source/platforms/gitlab/_tests/_gitlab_api.test.ts
@@ -193,7 +193,7 @@ describe("GitLab API", () => {
     const titleToUpdate = "update merge request"
     const result = await api.updateMergeRequestInfo({ title: titleToUpdate })
     nockDone()
-    expect(JSON.stringify(result)).toContain(titleToUpdate)
+    expect(result.title).toContain(titleToUpdate)
   })
 
   describe("updateMergeRequestInfo (add|remove)labels", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,34 +1186,36 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@gitbeaker/core@^21.7.0":
-  version "21.7.0"
-  resolved "https://registry.yarnpkg.com/@gitbeaker/core/-/core-21.7.0.tgz#fcf7a12915d39f416e3f316d0a447a814179b8e5"
-  integrity sha512-cw72rE7tA27wc6JJe1WqeAj9v/6w0S7XJcEji+bRNjTlUfE1zgfW0Gf1mbGUi7F37SOABGCosQLfg9Qe63aIqA==
+"@gitbeaker/core@^35.7.0":
+  version "35.7.0"
+  resolved "https://registry.yarnpkg.com/@gitbeaker/core/-/core-35.7.0.tgz#426e426dff597c1d094bf1fe66fb1109980e816d"
+  integrity sha512-1N9QcHElYa1NuLhX9mJJ6tnL7wbCsK8Naj2kLXwNC4qyEcDhMiJDnI3YoqNIXSzPTufoNUAbgIsc/h/JmO17/A==
   dependencies:
-    "@gitbeaker/requester-utils" "^21.7.0"
-    form-data "^3.0.0"
+    "@gitbeaker/requester-utils" "^35.7.0"
+    form-data "^4.0.0"
     li "^1.3.0"
+    mime "^3.0.0"
+    query-string "^7.0.0"
     xcase "^2.0.1"
 
-"@gitbeaker/node@^21.3.0":
-  version "21.7.0"
-  resolved "https://registry.yarnpkg.com/@gitbeaker/node/-/node-21.7.0.tgz#2c19613f44ee497a8808c555abec614ebd2dfcad"
-  integrity sha512-OdM3VcTKYYqboOsnbiPcO0XimXXpYK4gTjARBZ6BWc+1LQXKmqo+OH6oUbyxOoaFu9hHECafIt3WZU3NM4sZTg==
+"@gitbeaker/node@^35.7.0":
+  version "35.7.0"
+  resolved "https://registry.yarnpkg.com/@gitbeaker/node/-/node-35.7.0.tgz#ba4ece7aff388132bdcab8d6fb08c8d063a70e7d"
+  integrity sha512-zh215EUloAxj2gwTHevBVypEiiwQR0WsFLGPWJwY+yUFJVQRcya+3mcsDbxgCLAk00wwhrTVYyNppvmoYbEZNg==
   dependencies:
-    "@gitbeaker/core" "^21.7.0"
-    "@gitbeaker/requester-utils" "^21.7.0"
-    form-data "^3.0.0"
-    got "^11.1.4"
+    "@gitbeaker/core" "^35.7.0"
+    "@gitbeaker/requester-utils" "^35.7.0"
+    delay "^5.0.0"
+    got "^11.8.3"
     xcase "^2.0.1"
 
-"@gitbeaker/requester-utils@^21.7.0":
-  version "21.7.0"
-  resolved "https://registry.yarnpkg.com/@gitbeaker/requester-utils/-/requester-utils-21.7.0.tgz#e9a9cfaf268d2a99eb7bbdc930943240a5f88878"
-  integrity sha512-eLTaVXlBnh8Qimj6QuMMA06mu/mLcJm3dy8nqhhn/Vm/D25sPrvpGwmbfFyvzj6QujPqtHvFfsCHtyZddL01qA==
+"@gitbeaker/requester-utils@^35.7.0":
+  version "35.7.0"
+  resolved "https://registry.yarnpkg.com/@gitbeaker/requester-utils/-/requester-utils-35.7.0.tgz#7c1ded70a10ac890322f22488ffea8a3a41ccc79"
+  integrity sha512-SDYKhL+XUrslpVwUumkCf4I4Ubf+lvzdghCYPwBt/og5kZIorFVbHCxRmtr5bO+iC9nrVNfg24sdoe51vDGn1w==
   dependencies:
-    form-data "^3.0.0"
-    query-string "^6.12.1"
+    form-data "^4.0.0"
+    qs "^6.10.1"
     xcase "^2.0.1"
 
 "@humanwhocodes/config-array@^0.9.2":
@@ -3434,6 +3436,11 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
+delay@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/delay/-/delay-5.0.0.tgz#137045ef1b96e5071060dd5be60bf9334436bd1d"
+  integrity sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -4381,6 +4388,15 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 form-data@~2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
@@ -4728,7 +4744,7 @@ got@10.7.0:
     to-readable-stream "^2.0.0"
     type-fest "^0.10.0"
 
-got@^11.1.4:
+got@^11.8.3:
   version "11.8.5"
   resolved "https://registry.yarnpkg.com/got/-/got-11.8.5.tgz#ce77d045136de56e8f024bebb82ea349bc730046"
   integrity sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==
@@ -6859,6 +6875,11 @@ mime@1.3.4:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
   integrity sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=
 
+mime@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-3.0.0.tgz#b374550dca3a0c18443b0c950a6a58f1931cf7a7"
+  integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
+
 mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
@@ -7208,6 +7229,11 @@ object-inspect@^1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0"
   integrity sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
+
+object-inspect@^1.9.0:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
+  integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
 
 object-keys@^1.0.8:
   version "1.0.11"
@@ -7966,15 +7992,22 @@ pupa@^2.0.1:
   dependencies:
     escape-goat "^2.0.0"
 
+qs@^6.10.1:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
+  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
   integrity sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==
 
-query-string@^6.12.1:
-  version "6.14.1"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.14.1.tgz#7ac2dca46da7f309449ba0f86b1fd28255b0c86a"
-  integrity sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==
+query-string@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.1.tgz#754620669db978625a90f635f12617c271a088e1"
+  integrity sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==
   dependencies:
     decode-uri-component "^0.2.0"
     filter-obj "^1.1.0"
@@ -8797,6 +8830,15 @@ shx@^0.3.4:
   dependencies:
     minimist "^1.2.3"
     shelljs "^0.8.5"
+
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
issue https://github.com/danger/danger-js/issues/1301

I'm trying to update a gitbreaker version, as the switch happen, but the version used is outdated. As latest gitbreaker version has well-defined types. 
Initialy failed, seems like my approach was wrong.