### PR TITLE
GitLab: Add support to use threads instead of comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - GitLab: Added provider tests [#1319](https://github.com/danger/danger-js/pull/1319) [@ivankatliarchuk]
 
 - GitHub: Added `danger.github.pr.draft` field to DSL
-
+- GitLab: Add support for using threads instead of comments [#1331](https://github.com/danger/danger-js/pull/1331) [@uncaught]
 <!-- Your comment above this -->
 
 ## 11.1.2

--- a/docs/usage/gitlab.html.md
+++ b/docs/usage/gitlab.html.md
@@ -41,3 +41,8 @@ danger.gitlab.
   /** The commits associated with the merge request */
   commits: GitLabMRCommit[]
 ```
+
+---
+
+If you want danger to open threads (discussions) instead of just commenting in merge requests, set an environment
+variable `DANGER_GITLAB_USE_THREADS` with value `1` or `true`.

--- a/source/danger.d.ts
+++ b/source/danger.d.ts
@@ -1662,6 +1662,12 @@ interface GitLabNote {
   noteable_iid: number
 }
 
+interface GitLabDiscussion {
+  id: string //40 character hex
+  individual_note: boolean
+  notes: GitLabNote[]
+}
+
 interface GitLabDiscussionTextPosition {
   position_type: "text"
   base_sha: string
@@ -1671,6 +1677,10 @@ interface GitLabDiscussionTextPosition {
   new_line: number
   old_path: string
   old_line: number | null
+}
+
+interface GitLabDiscussionCreationOptions {
+  position?: GitLabDiscussionTextPosition
 }
 
 interface GitLabInlineNote extends GitLabNote {

--- a/source/dsl/GitLabDSL.ts
+++ b/source/dsl/GitLabDSL.ts
@@ -204,6 +204,12 @@ export interface GitLabNote {
   noteable_iid: number
 }
 
+export interface GitLabDiscussion {
+  id: string; //40 character hex
+  individual_note: boolean;
+  notes: GitLabNote[];
+}
+
 export interface GitLabDiscussionTextPosition {
   position_type: "text"
   base_sha: string
@@ -213,6 +219,10 @@ export interface GitLabDiscussionTextPosition {
   new_line: number
   old_path: string
   old_line: number | null
+}
+
+export interface GitLabDiscussionCreationOptions {
+  position?: GitLabDiscussionTextPosition
 }
 
 export interface GitLabInlineNote extends GitLabNote {

--- a/source/platforms/_tests/_gitlab.test.ts
+++ b/source/platforms/_tests/_gitlab.test.ts
@@ -1,0 +1,132 @@
+import GitLabAPI from "../gitlab/GitLabAPI"
+import GitLab from "../GitLab"
+import { GitLabDiscussion, GitLabNote, GitLabUser, GitLabUserProfile } from "../../dsl/GitLabDSL"
+
+const baseUri = "https://my-gitlab.org/my-project"
+
+const dangerUserId = 8797215
+
+const getUser = async (): Promise<GitLabUserProfile> => {
+  const user: Partial<GitLabUserProfile> = { id: dangerUserId }
+  return user as GitLabUserProfile
+}
+
+const dangerID = "dddanger1234"
+const dangerIdString = `DangerID: danger-id-${dangerID};`
+
+function mockNote(id: number, authorId: number, body = ""): GitLabNote {
+  const author: Partial<GitLabUser> = { id: authorId }
+  const note: Partial<GitLabNote> = { author: author as GitLabUser, body, id }
+  return note as GitLabNote
+}
+
+function mockDiscussion(id: string, notes: GitLabNote[]): GitLabDiscussion {
+  const discussion: Partial<GitLabDiscussion> = { id, notes }
+  return discussion as GitLabDiscussion
+}
+
+function mockApi(withExisting = false): GitLabAPI {
+  const note1 = mockNote(1001, dangerUserId, `some body ${dangerIdString} asdf`)
+  const note2 = mockNote(1002, 125235)
+  const note3 = mockNote(1003, dangerUserId, `another danger ${dangerIdString} body`)
+  const note4 = mockNote(1004, 745774)
+  const note5 = mockNote(1005, 745774)
+  const discussion1 = mockDiscussion("aaaaffff1111", [note1, note2])
+  const discussion2 = mockDiscussion("aaaaffff2222", [note3, note4])
+  const discussion3 = mockDiscussion("aaaaffff3333", [note5])
+
+  const newNote = mockNote(4711, dangerUserId)
+  const newDiscussion = mockDiscussion("aaaaffff0000", [newNote])
+
+  const api: Partial<GitLabAPI> = {
+    getUser,
+    createMergeRequestDiscussion: jest.fn(() => Promise.resolve(newDiscussion)),
+    createMergeRequestNote: jest.fn(() => Promise.resolve(newNote)),
+    deleteMergeRequestNote: jest.fn(() => Promise.resolve(true)),
+    getMergeRequestDiscussions: jest.fn(() => Promise.resolve(withExisting
+      ? [discussion1, discussion2, discussion3]
+      : [])),
+    mergeRequestURL: baseUri,
+    updateMergeRequestNote: jest.fn(() => Promise.resolve(newNote)),
+  }
+  return api as GitLabAPI
+}
+
+describe("updateOrCreateComment", () => {
+  const comment = "my new comment"
+
+  it("create a new single comment", async () => {
+    delete process.env.DANGER_GITLAB_USE_THREADS
+
+    const api = mockApi()
+    const url = await (new GitLab(api as GitLabAPI)).updateOrCreateComment(dangerID, comment)
+    expect(url).toEqual(`${baseUri}#note_4711`)
+
+    expect(api.getMergeRequestDiscussions).toHaveBeenCalledTimes(1)
+    expect(api.deleteMergeRequestNote).toHaveBeenCalledTimes(0)
+    expect(api.createMergeRequestDiscussion).toHaveBeenCalledTimes(0)
+    expect(api.createMergeRequestNote).toHaveBeenCalledTimes(1)
+    expect(api.createMergeRequestNote).toHaveBeenCalledWith(comment)
+    expect(api.updateMergeRequestNote).toHaveBeenCalledTimes(0)
+  })
+
+  it("create a new thread", async () => {
+    process.env.DANGER_GITLAB_USE_THREADS = "true"
+
+    const api = mockApi()
+    const url = await (new GitLab(api as GitLabAPI)).updateOrCreateComment(dangerID, comment)
+    expect(url).toEqual(`${baseUri}#note_4711`)
+
+    expect(api.getMergeRequestDiscussions).toHaveBeenCalledTimes(1)
+    expect(api.deleteMergeRequestNote).toHaveBeenCalledTimes(0)
+    expect(api.createMergeRequestDiscussion).toHaveBeenCalledTimes(1)
+    expect(api.createMergeRequestDiscussion).toHaveBeenCalledWith(comment)
+    expect(api.createMergeRequestNote).toHaveBeenCalledTimes(0)
+    expect(api.updateMergeRequestNote).toHaveBeenCalledTimes(0)
+  })
+
+  it("update an existing thread", async () => {
+    const api = mockApi(true)
+    const url = await (new GitLab(api as GitLabAPI)).updateOrCreateComment(dangerID, comment)
+    expect(url).toEqual(`${baseUri}#note_4711`)
+
+    expect(api.getMergeRequestDiscussions).toHaveBeenCalledTimes(1)
+    expect(api.deleteMergeRequestNote).toHaveBeenCalledTimes(2)
+    expect(api.deleteMergeRequestNote).toHaveBeenNthCalledWith(1, 1003)
+    expect(api.deleteMergeRequestNote).toHaveBeenNthCalledWith(2, 1004)
+    expect(api.createMergeRequestDiscussion).toHaveBeenCalledTimes(0)
+    expect(api.createMergeRequestNote).toHaveBeenCalledTimes(0)
+    expect(api.updateMergeRequestNote).toHaveBeenCalledTimes(1)
+    expect(api.updateMergeRequestNote).toHaveBeenCalledWith(1001, comment)
+  })
+})
+
+describe("deleteMainComment", () => {
+  it("delete nothing", async () => {
+    const api = mockApi()
+    const result = await (new GitLab(api as GitLabAPI)).deleteMainComment(dangerID)
+    expect(result).toEqual(false)
+
+    expect(api.getMergeRequestDiscussions).toHaveBeenCalledTimes(1)
+    expect(api.deleteMergeRequestNote).toHaveBeenCalledTimes(0)
+    expect(api.createMergeRequestDiscussion).toHaveBeenCalledTimes(0)
+    expect(api.createMergeRequestNote).toHaveBeenCalledTimes(0)
+    expect(api.updateMergeRequestNote).toHaveBeenCalledTimes(0)
+  })
+
+  it("delete all danger attached notes", async () => {
+    const api = mockApi(true)
+    const result = await (new GitLab(api as GitLabAPI)).deleteMainComment(dangerID)
+    expect(result).toEqual(true)
+
+    expect(api.getMergeRequestDiscussions).toHaveBeenCalledTimes(1)
+    expect(api.deleteMergeRequestNote).toHaveBeenCalledTimes(4)
+    expect(api.deleteMergeRequestNote).toHaveBeenNthCalledWith(1, 1001)
+    expect(api.deleteMergeRequestNote).toHaveBeenNthCalledWith(2, 1002)
+    expect(api.deleteMergeRequestNote).toHaveBeenNthCalledWith(3, 1003)
+    expect(api.deleteMergeRequestNote).toHaveBeenNthCalledWith(4, 1004)
+    expect(api.createMergeRequestDiscussion).toHaveBeenCalledTimes(0)
+    expect(api.createMergeRequestNote).toHaveBeenCalledTimes(0)
+    expect(api.updateMergeRequestNote).toHaveBeenCalledTimes(0)
+  })
+})

--- a/source/platforms/gitlab/_tests/_gitlab_api.test.ts
+++ b/source/platforms/gitlab/_tests/_gitlab_api.test.ts
@@ -132,6 +132,14 @@ describe("GitLab API", () => {
     expect(result).toEqual(response)
   })
 
+  it("getMergeRequestDiscussions", async () => {
+    const { nockDone } = await nockBack("getMergeRequestDiscussions.json")
+    const result = await api.getMergeRequestDiscussions()
+    nockDone()
+    const { response } = loadFixture("getMergeRequestDiscussions")
+    expect(result).toEqual(response)
+  })
+
   it("getMergeRequestNotes", async () => {
     const { nockDone } = await nockBack("getMergeRequestNotes.json")
     const result = await api.getMergeRequestNotes()

--- a/source/platforms/gitlab/_tests/fixtures/getMergeRequestDiscussions.json
+++ b/source/platforms/gitlab/_tests/fixtures/getMergeRequestDiscussions.json
@@ -1,0 +1,92 @@
+[
+  {
+    "scope": "https://gitlab.com:443",
+    "method": "GET",
+    "path": "/api/v4/projects/gitlab-org%2Fgitlab-foss/merge_requests/27117/discussions",
+    "body": "",
+    "status": 200,
+    "response": [
+      {
+        "id": "6fe51a9c5758556dfef42725a66dee2729a6fb82",
+        "individual_note": false,
+        "notes": [
+          {
+            "id": 166211215,
+            "type": null,
+            "body": "mentioned in issue gitlab-org/release/tasks#778",
+            "attachment": null,
+            "author": {
+              "id": 1786152,
+              "name": "🤖 GitLab Bot 🤖",
+              "username": "gitlab-bot",
+              "state": "active",
+              "avatar_url": "https://gl-canary.freetls.fastly.net/uploads/-/system/user/avatar/1786152/avatar.png",
+              "web_url": "https://gitlab.com/gitlab-bot"
+            },
+            "created_at": "2019-05-02T14:34:54.054Z",
+            "updated_at": "2019-05-02T14:34:54.054Z",
+            "system": true,
+            "noteable_id": 27253868,
+            "noteable_type": "MergeRequest",
+            "resolvable": false,
+            "noteable_iid": 27117
+          }
+        ]
+      }
+    ],
+    "rawHeaders": [
+      "Server",
+      "nginx",
+      "Date",
+      "Mon, 20 May 2019 11:19:03 GMT",
+      "Content-Type",
+      "application/json",
+      "Content-Length",
+      "9682",
+      "Connection",
+      "close",
+      "Cache-Control",
+      "max-age=0, private, must-revalidate",
+      "Etag",
+      "W/\"edab8aad8eea37dd376785c34c7c250f\"",
+      "Link",
+      "<https://gitlab.com/api/v4/projects/gitlab-org%2Fgitlab-foss/merge_requests/27117/notes?id=gitlab-org%2Fgitlab-foss&noteable_id=27117&order_by=created_at&page=1&per_page=20&sort=desc>; rel=\"first\", <https://gitlab.com/api/v4/projects/gitlab-org%2Fgitlab-foss/merge_requests/27117/notes?id=gitlab-org%2Fgitlab-foss&noteable_id=27117&order_by=created_at&page=1&per_page=20&sort=desc>; rel=\"last\"",
+      "Vary",
+      "Origin",
+      "X-Content-Type-Options",
+      "nosniff",
+      "X-Frame-Options",
+      "SAMEORIGIN",
+      "X-Next-Page",
+      "",
+      "X-Page",
+      "1",
+      "X-Per-Page",
+      "20",
+      "X-Prev-Page",
+      "",
+      "X-Request-Id",
+      "yd9SuXYdPCa",
+      "X-Runtime",
+      "1.305536",
+      "X-Total",
+      "15",
+      "X-Total-Pages",
+      "1",
+      "Strict-Transport-Security",
+      "max-age=31536000",
+      "Referrer-Policy",
+      "strict-origin-when-cross-origin",
+      "RateLimit-Limit",
+      "600",
+      "RateLimit-Observed",
+      "1",
+      "RateLimit-Remaining",
+      "599",
+      "RateLimit-Reset",
+      "1558351203",
+      "RateLimit-ResetTime",
+      "Mon, 20 May 2019 11:20:03 GMT"
+    ]
+  }
+]


### PR DESCRIPTION
- Add support to use threads instead of comments
- Implements #1138 

# Implementation

- Threads are used if an environment variable `DANGER_GITLAB_USE_THREADS` is set to a value of `1` or `true`.
- Threads are completely removed with all answers (even of other users) if danger removes its main comment.

## GitLab API change

- A new method `getMergeRequestDiscussions` fetches all the threads (discussions) of a merge request
- **BREAKING** The method `createMergeRequestDiscussion` has had its second argument changed from being the position object to be the actual options object for that gitbreaker API call, which contains the position.

# Migration considerations

- You can switch to using threads and back any time.
- Only newly created comments are affected by the current setting.
- Because existing comments can be turned into a thread by simply replying to them, danger will always delete its entire threads, no matter the setting.