### PR TITLE
fix messing the order of messages when posting to a git platform

### DIFF
--- a/source/dsl/DangerResults.ts
+++ b/source/dsl/DangerResults.ts
@@ -190,6 +190,9 @@ export function sortInlineResults(inlineResults: DangerInlineResults[]): DangerI
 
 export function sortResults(results: DangerResults): DangerResults {
   const sortByFile = (a: Violation, b: Violation): number => {
+    if (a.file === undefined && b.file === undefined) {
+      return 0;
+    }
     if (a.file === undefined) {
       return -1
     }
@@ -198,10 +201,13 @@ export function sortResults(results: DangerResults): DangerResults {
     }
 
     if (a.file == b.file) {
-      if (a.line == undefined) {
+      if (a.line === undefined && b.line === undefined) {
+        return 0;
+      }
+      if (a.line === undefined) {
         return -1
       }
-      if (b.line == undefined) {
+      if (b.line === undefined) {
         return 1
       }
 


### PR DESCRIPTION

The order of messages without file/line data were being reversed, but **only** when posting to a git platform e.g. github.

fixes https://github.com/danger/danger-js/issues/845
fixes https://github.com/danger/danger-js/issues/1014