### PR TITLE
Revert "Moving the GITHUB_WORKFLOW check before actually getting the userInfo"

### DIFF
--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -130,17 +130,17 @@ export class GitHubAPI {
       return parseInt(perilID)
     }
 
+    const info = await this.getUserInfo()
+    if (info.id) {
+      return info.id
+    }
+
     const useGitHubActionsID = process.env["GITHUB_WORKFLOW"]
     if (useGitHubActionsID) {
       // This is the user.id of the github-actions app (https://github.com/apps/github-actions)
       // that is used to comment when using danger in a GitHub Action
       // with GITHUB_TOKEN (https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token)
       return 41898282
-    }
-
-    const info = await this.getUserInfo()
-    if (info.id) {
-      return info.id
     }
 
     return undefined


### PR DESCRIPTION
Reverts danger/danger-js#1337 - likely the cause of #1347 