### PR TITLE
Expose Bitbucket Cloud API in DSL

### DIFF
--- a/source/danger.d.ts
+++ b/source/danger.d.ts
@@ -22,7 +22,29 @@ interface BitBucketCloudJSONDSL {
   activities: BitBucketCloudPRActivity[]
 }
 
-interface BitBucketCloudDSL extends BitBucketCloudJSONDSL {}
+interface BitBucketCloudAPIDSL {
+  /** Gets the contents of a file from a repo (defaults to yours) */
+  getFileContents(filePath: string, repoSlug?: string, refspec?: string): Promise<string>
+
+  /** Make a get call against the bitbucket server API */
+  get(path: string, headers: any, suppressErrors?: boolean): Promise<any>
+
+  /** Make a post call against the bitbucket server API */
+  post(path: string, headers: any, body: any, suppressErrors?: boolean): Promise<any>
+
+  /** Make a put call against the bitbucket server API */
+  put(path: string, headers: any, body: any): Promise<any>
+
+  /** Make a delete call against the bitbucket server API */
+  delete(path: string, headers: any, body: any): Promise<any>
+}
+
+interface BitBucketCloudDSL extends BitBucketCloudJSONDSL {
+  /**
+   * An authenticated API so you can extend danger's behavior.
+   */
+  api: BitBucketCloudAPIDSL
+}
 
 interface BitBucketCloudPagedResponse<T> {
   pagelen: number

--- a/source/dsl/BitBucketCloudDSL.ts
+++ b/source/dsl/BitBucketCloudDSL.ts
@@ -16,7 +16,29 @@ export interface BitBucketCloudJSONDSL {
   activities: BitBucketCloudPRActivity[]
 }
 
-export interface BitBucketCloudDSL extends BitBucketCloudJSONDSL {}
+export interface BitBucketCloudAPIDSL {
+  /** Gets the contents of a file from a repo (defaults to yours) */
+  getFileContents(filePath: string, repoSlug?: string, refspec?: string): Promise<string>
+
+  /** Make a get call against the bitbucket server API */
+  get(path: string, headers: any, suppressErrors?: boolean): Promise<any>
+
+  /** Make a post call against the bitbucket server API */
+  post(path: string, headers: any, body: any, suppressErrors?: boolean): Promise<any>
+
+  /** Make a put call against the bitbucket server API */
+  put(path: string, headers: any, body: any): Promise<any>
+
+  /** Make a delete call against the bitbucket server API */
+  delete(path: string, headers: any, body: any): Promise<any>
+}
+
+export interface BitBucketCloudDSL extends BitBucketCloudJSONDSL {
+  /**
+   * An authenticated API so you can extend danger's behavior.
+   */
+  api: BitBucketCloudAPIDSL
+}
 
 export interface BitBucketCloudPagedResponse<T> {
   pagelen: number

--- a/source/platforms/BitBucketCloud.ts
+++ b/source/platforms/BitBucketCloud.ts
@@ -1,5 +1,5 @@
 import { GitJSONDSL, GitDSL } from "../dsl/GitDSL"
-import { BitBucketCloudPRDSL, BitBucketCloudJSONDSL } from "../dsl/BitBucketCloudDSL"
+import { BitBucketCloudPRDSL, BitBucketCloudJSONDSL, BitBucketCloudDSL } from "../dsl/BitBucketCloudDSL"
 import { BitBucketCloudAPI } from "./bitbucket_cloud/BitBucketCloudAPI"
 import gitDSLForBitBucketCloud from "./bitbucket_cloud/BitBucketCloudGit"
 
@@ -181,3 +181,11 @@ export class BitBucketCloud implements Platform {
 
   getFileContents = this.api.getFileContents
 }
+
+export const bitbucketCloudJSONToBitBucketCloudDSL = (
+  bitbucket: BitBucketCloudJSONDSL,
+  api: BitBucketCloudAPI
+): BitBucketCloudDSL => ({
+  ...bitbucket,
+  api,
+})

--- a/source/platforms/bitbucket_cloud/BitBucketCloudAPI.ts
+++ b/source/platforms/bitbucket_cloud/BitBucketCloudAPI.ts
@@ -13,6 +13,7 @@ import {
   BitBucketCloudCommit,
   BitBucketCloudPRActivity,
   BitBucketCloudPRComment,
+  BitBucketCloudAPIDSL,
 } from "../../dsl/BitBucketCloudDSL"
 import { Comment } from "../platform"
 import { RepoMetaData } from "../../dsl/BitBucketServerDSL"
@@ -66,7 +67,7 @@ export function bitbucketCloudCredentialsFromEnv(env: Env): BitBucketCloudCreden
   throw new Error(`Either DANGER_BITBUCKETCLOUD_OAUTH_KEY or DANGER_BITBUCKETCLOUD_USERNAME is not set`)
 }
 
-export class BitBucketCloudAPI {
+export class BitBucketCloudAPI implements BitBucketCloudAPIDSL {
   fetch: typeof fetch
   accessToken: string | undefined
   uuid: string | undefined
@@ -219,20 +220,22 @@ export class BitBucketCloudAPI {
     const dangerIDMessage = dangerIDToString(dangerID)
 
     return comments
-      .filter(comment => comment.inline == null)
-      .filter(comment => comment.content.raw.includes(dangerIDMessage))
-      .filter(comment => comment.user.uuid === this.uuid)
+      .filter((comment) => comment.inline == null)
+      .filter((comment) => comment.content.raw.includes(dangerIDMessage))
+      .filter((comment) => comment.user.uuid === this.uuid)
   }
 
   getDangerInlineComments = async (dangerID: string): Promise<Comment[]> => {
     const comments = await this.getPullRequestComments()
     const dangerIDMessage = dangerIDToString(dangerID)
 
-    return comments.filter(comment => comment.inline).map(comment => ({
-      id: comment.id.toString(),
-      ownedByDanger: comment.content.raw.includes(dangerIDMessage) && comment.user.uuid === this.uuid,
-      body: comment.content.raw,
-    }))
+    return comments
+      .filter((comment) => comment.inline)
+      .map((comment) => ({
+        id: comment.id.toString(),
+        ownedByDanger: comment.content.raw.includes(dangerIDMessage) && comment.user.uuid === this.uuid,
+        body: comment.content.raw,
+      }))
   }
 
   postBuildStatus = async (

--- a/source/platforms/bitbucket_cloud/BitBucketCloudGit.ts
+++ b/source/platforms/bitbucket_cloud/BitBucketCloudGit.ts
@@ -1,7 +1,7 @@
 import { GitJSONDSL, GitDSL } from "../../dsl/GitDSL"
 import { BitBucketCloudAPI } from "./BitBucketCloudAPI"
 import { diffToGitJSONDSL } from "../git/diffToGitJSONDSL"
-import { BitBucketCloudCommit, BitBucketCloudDSL } from "../../dsl/BitBucketCloudDSL"
+import { BitBucketCloudCommit, BitBucketCloudJSONDSL } from "../../dsl/BitBucketCloudDSL"
 import { GitCommit, GitCommitAuthor } from "../../dsl/Commit"
 import { GitJSONToGitDSLConfig, gitJSONToGitDSL } from "../git/gitJSONToGitDSL"
 
@@ -36,7 +36,7 @@ function bitBucketCloudCommitToGitCommit(commit: BitBucketCloudCommit): GitCommi
     committer: user,
     message: commit.message,
     tree: null,
-    parents: commit.parents != null ? commit.parents.map(parent => parent.hash) : undefined,
+    parents: commit.parents != null ? commit.parents.map((parent) => parent.hash) : undefined,
     url: commit.links.html.href,
   }
 }
@@ -50,7 +50,7 @@ export default async function gitDSLForBitBucketCloud(api: BitBucketCloudAPI): P
 }
 
 export const bitBucketCloudGitDSL = (
-  bitBucketCloud: BitBucketCloudDSL,
+  bitBucketCloud: BitBucketCloudJSONDSL,
   json: GitJSONDSL,
   bitBucketCloudAPI: BitBucketCloudAPI
 ): GitDSL => {

--- a/source/platforms/bitbucket_cloud/_tests_/_bitbucket_cloud_git.test.ts
+++ b/source/platforms/bitbucket_cloud/_tests_/_bitbucket_cloud_git.test.ts
@@ -8,7 +8,7 @@ import { readFileSync, writeFileSync } from "fs"
 import { resolve, join as pathJoin } from "path"
 import { bitBucketCloudGitDSL as gitJSONToGitDSL } from "../BitBucketCloudGit"
 
-import { BitBucketCloudDSL } from "../../../dsl/BitBucketCloudDSL"
+import { BitBucketCloudJSONDSL } from "../../../dsl/BitBucketCloudDSL"
 import { GitJSONDSL, GitDSL } from "../../../dsl/GitDSL"
 import { GitCommit } from "../../../dsl/Commit"
 import { jsonDSLGenerator } from "../../../runner/dslGenerator"
@@ -16,18 +16,19 @@ import { jsonDSLGenerator } from "../../../runner/dslGenerator"
 const fixtures = resolve(__dirname, "..", "..", "_tests", "fixtures")
 
 /** Returns a fixture. */
-const loadFixture = (path: string): string =>
-  readFileSync(pathJoin(fixtures, path), {})
-    .toString()
-    .replace(/\r/g, "")
+const loadFixture = (path: string): string => readFileSync(pathJoin(fixtures, path), {}).toString().replace(/\r/g, "")
 
 /** Returns JSON from the fixtured dir */
-export const requestWithFixturedJSON = async (path: string): Promise<() => Promise<any>> => () =>
-  Promise.resolve(JSON.parse(loadFixture(path)))
+export const requestWithFixturedJSON =
+  async (path: string): Promise<() => Promise<any>> =>
+  () =>
+    Promise.resolve(JSON.parse(loadFixture(path)))
 
 /** Returns arbitrary text value from a request */
-export const requestWithFixturedContent = async (path: string): Promise<() => Promise<string>> => () =>
-  Promise.resolve(loadFixture(path))
+export const requestWithFixturedContent =
+  async (path: string): Promise<() => Promise<string>> =>
+  () =>
+    Promise.resolve(loadFixture(path))
 
 /**
  * HACKish: Jest on Windows seems to include some additional
@@ -44,7 +45,7 @@ describe("the dangerfile gitDSL - BitBucket Cloud", () => {
   let bbc: BitBucketCloud = {} as any
   let gitJSONDSL: GitJSONDSL = {} as any
 
-  let bbcDSL: BitBucketCloudDSL = {} as any
+  let bbcDSL: BitBucketCloudJSONDSL = {} as any
   let gitDSL: GitDSL = {} as any
 
   beforeEach(async () => {

--- a/source/runner/jsonToDSL.ts
+++ b/source/runner/jsonToDSL.ts
@@ -20,6 +20,7 @@ import GitLabAPI, { getGitLabAPICredentialsFromEnv } from "../platforms/gitlab/G
 import { gitLabGitDSL } from "../platforms/gitlab/GitLabGit"
 import { bitBucketCloudGitDSL } from "../platforms/bitbucket_cloud/BitBucketCloudGit"
 import { bitbucketServerJSONToBitBucketServerDSL } from "../platforms/BitBucketServer"
+import { bitbucketCloudJSONToBitBucketCloudDSL } from "../platforms/BitBucketCloud"
 const d = debug("jsonToDSL")
 
 /**
@@ -30,11 +31,12 @@ export const jsonToDSL = async (dsl: DangerDSLJSONType, source: CISource): Promi
   d(`Creating ${source && source.useEventDSL ? "event" : "pr"} DSL from JSON`)
 
   const api = apiForDSL(dsl)
-  const platformExists = [dsl.github, dsl.bitbucket_server, dsl.gitlab, dsl.bitbucket_cloud].some(p => !!p)
+  const platformExists = [dsl.github, dsl.bitbucket_server, dsl.gitlab, dsl.bitbucket_cloud].some((p) => !!p)
   const github = dsl.github && githubJSONToGitHubDSL(dsl.github, api as Octokit)
   const bitbucket_server =
     dsl.bitbucket_server && bitbucketServerJSONToBitBucketServerDSL(dsl.bitbucket_server, api as BitBucketServerAPI)
-  const bitbucket_cloud = dsl.bitbucket_cloud
+  const bitbucket_cloud =
+    dsl.bitbucket_cloud && bitbucketCloudJSONToBitBucketCloudDSL(dsl.bitbucket_cloud, api as BitBucketCloudAPI)
   const gitlab = dsl.gitlab && gitlabJSONToGitLabDSL(dsl.gitlab, api as GitLabAPI)
 
   let git: GitDSL

--- a/source/runner/templates/_tests/_bitbucketCloudTemplate.test.ts
+++ b/source/runner/templates/_tests/_bitbucketCloudTemplate.test.ts
@@ -21,7 +21,7 @@ const warningEmoji = ":warning:"
 const messageEmoji = ":sparkles:"
 
 describe("generating messages for BitBucket cloud", () => {
-  let complimentMock: jest.Mock<string, []>
+  let complimentMock: jest.SpyInstance<string, []>
   beforeEach(() => {
     complimentMock = jest.spyOn(utils, "compliment").mockReturnValue("Well done.")
   })


### PR DESCRIPTION
For the [danger-plugin-eslint](https://github.com/FabienLydoire/danger-plugin-eslint ) to work with BitBucket Cloud, we need to expose the BitBucketCloudAPI in the DSL.

This is the purpose of this PR.
I hope it helps :)