### PR TITLE
Fix: Restore GitLabDSL.api to be GitLabAPI instance

### DIFF
--- a/source/dsl/GitLabDSL.ts
+++ b/source/dsl/GitLabDSL.ts
@@ -1,5 +1,5 @@
 // Please don't have includes in here that aren't inside the DSL folder, or the d.ts/flow defs break
-import { Gitlab } from "@gitbeaker/node"
+import GitLabAPI from "../platforms/gitlab/GitLabAPI"
 import { RepoMetaData } from "./RepoMetaData"
 
 // getPlatformReviewDSLRepresentation
@@ -20,7 +20,7 @@ export interface GitLabDSL extends GitLabJSONDSL {
   utils: {
     fileContents(path: string, repoSlug?: string, ref?: string): Promise<string>
   }
-  api: InstanceType<typeof Gitlab>
+  api: GitLabAPI
 }
 
 // ---

--- a/source/platforms/GitLab.ts
+++ b/source/platforms/GitLab.ts
@@ -228,5 +228,5 @@ export const gitlabJSONToGitLabDSL = (gl: GitLabDSL, api: GitLabAPI): GitLabDSL 
   utils: {
     fileContents: api.getFileContents,
   },
-  api: api.apiInstance,
+  api,
 })

--- a/source/platforms/gitlab/GitLabAPI.ts
+++ b/source/platforms/gitlab/GitLabAPI.ts
@@ -77,10 +77,6 @@ class GitLabAPI {
     return `${this.projectURL}/merge_requests/${this.prId}`
   }
 
-  get apiInstance() {
-    return this.api
-  }
-
   getUser = async (): Promise<GitLabUserProfile> => {
     this.d("getUser")
     const user = (await this.api.Users.current()) as GitLabUserProfile


### PR DESCRIPTION
Revert "Ensures that the Gitlab API is exposed properly through the dts"

This reverts commit e8d20521270e283df8572c103eb330d622ab04bd.

The breakage introduced between 10.6.5 and 10.6.6 **patch** version update

Refs:
- https://github.com/danger/danger-js/issues/1314#issuecomment-1421655392