### PR TITLE
Fix commands run on paths with danger-pr in them

### DIFF
--- a/source/commands/utils/_tests/dangerRunToRunnerCLI.test.ts
+++ b/source/commands/utils/_tests/dangerRunToRunnerCLI.test.ts
@@ -116,3 +116,17 @@ describe("it can handle the command when running from pkg", () => {
     )
   })
 })
+
+it("should properly replace `danger-runner` in a path that contains an additional `danger-pr` in it", () => {
+  expect(
+    dangerRunToRunnerCLI([
+      "/Users/Mike.DiDomizio/.nvm/versions/node/v16.13.2/bin/node",
+      "/Users/Mike.DiDomizio/projects/test/danger-project-setup/node_modules/danger/distribution/commands/danger-pr.js",
+      "https://github.com/facebook/react/pull/11865"
+    ])
+  ).toEqual([
+    "/Users/Mike.DiDomizio/.nvm/versions/node/v16.13.2/bin/node",
+    "/Users/Mike.DiDomizio/projects/test/danger-project-setup/node_modules/danger/distribution/commands/danger-runner.js",
+    "https://github.com/facebook/react/pull/11865",
+  ])
+})

--- a/source/commands/utils/dangerRunToRunnerCLI.ts
+++ b/source/commands/utils/dangerRunToRunnerCLI.ts
@@ -15,7 +15,8 @@ const dangerRunToRunnerCLI = (argv: string[]) => {
     // convert
     let newJSFile = argv[1]
     usesProcessSeparationCommands.forEach((name) => {
-      newJSFile = newJSFile.replace("danger-" + name, "danger-runner")
+      const re = new RegExp(`danger-${name}\.js$`)
+      newJSFile = newJSFile.replace(re, "danger-runner.js")
     })
 
     // Support re-routing internally in npx for danger-ts


### PR DESCRIPTION
This fixes an issue I encountered when I was running danger commands from a project that has `danger-pr*` in the project name.

The issue is because the replace searches and finds the first instance of `danger-{command}` in the path and replaces it with `danger-runner`.  So when inside a project like `danger-project-setup` you end up with an error

```bash
node:internal/modules/cjs/loader:936
  throw err;
  ^

Error: Cannot find module '/Users/Mike.DiDomizio/projects/test/danger-runneroject-setup/node_modules/danger/distribution/commands/danger-pr.js'
```

The fix I've implemented is to create a regex with the command, searching for the `danger-${name}\.js$` at the end of the path and replace it.  So we're covered for the other commands as well.  Although I could possibly clean up the loop logic and just generate a regex that covers the array of commands, I've decided to keep this PR simple to make the change easy to approve.

The easiest way to reproduce this issue is to create a project like `danger-project-setup` and run the `danger pr` command inside the project.
