### PR TITLE
Fix commands run without the .js extension

### DIFF
--- a/source/commands/utils/_tests/dangerRunToRunnerCLI.test.ts
+++ b/source/commands/utils/_tests/dangerRunToRunnerCLI.test.ts
@@ -122,11 +122,25 @@ it("should properly replace `danger-runner` in a path that contains an additiona
     dangerRunToRunnerCLI([
       "/Users/Mike.DiDomizio/.nvm/versions/node/v16.13.2/bin/node",
       "/Users/Mike.DiDomizio/projects/test/danger-project-setup/node_modules/danger/distribution/commands/danger-pr.js",
-      "https://github.com/facebook/react/pull/11865"
+      "https://github.com/facebook/react/pull/11865",
     ])
   ).toEqual([
     "/Users/Mike.DiDomizio/.nvm/versions/node/v16.13.2/bin/node",
     "/Users/Mike.DiDomizio/projects/test/danger-project-setup/node_modules/danger/distribution/commands/danger-runner.js",
+    "https://github.com/facebook/react/pull/11865",
+  ])
+})
+
+it("should properly replace `danger-runner` in a path that contains an additional `danger-pr` in it even without the .js extension", () => {
+  expect(
+    dangerRunToRunnerCLI([
+      "/Users/Mike.DiDomizio/.nvm/versions/node/v16.13.2/bin/node",
+      "/Users/Mike.DiDomizio/projects/test/danger-project-setup/node_modules/danger/distribution/commands/danger-pr",
+      "https://github.com/facebook/react/pull/11865",
+    ])
+  ).toEqual([
+    "/Users/Mike.DiDomizio/.nvm/versions/node/v16.13.2/bin/node",
+    "/Users/Mike.DiDomizio/projects/test/danger-project-setup/node_modules/danger/distribution/commands/danger-runner",
     "https://github.com/facebook/react/pull/11865",
   ])
 })

--- a/source/commands/utils/dangerRunToRunnerCLI.ts
+++ b/source/commands/utils/dangerRunToRunnerCLI.ts
@@ -15,8 +15,8 @@ const dangerRunToRunnerCLI = (argv: string[]) => {
     // convert
     let newJSFile = argv[1]
     usesProcessSeparationCommands.forEach((name) => {
-      const re = new RegExp(`danger-${name}\.js$`)
-      newJSFile = newJSFile.replace(re, "danger-runner.js")
+      const re = new RegExp(`danger-${name}(\.js)?$`)
+      newJSFile = newJSFile.replace(re, "danger-runner$1")
     })
 
     // Support re-routing internally in npx for danger-ts


### PR DESCRIPTION
With Danger `11.2.5`, all our CI pipelines running Danger (with `yarn run danger-ci`) started to fail due to #1375 failing to replace `danger-{command}` to `danger-runner` (without the `.js` extension). This resulted in an endless loop of calls to `danger-ci`.

Making the replacement of the `.js` extension seems enough to cover our use case and @mikedidomizio 's (as the test he added in the mentioned PR still passes).