### PR TITLE
fix: GitLab Inline comments deleted with main comment updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ## Main
 
 <!-- Your comment below this -->
-
+- Fix issue where GitLab inline comments would not show on merge requests #1351 - [@davidbrunow]
 <!-- Your comment above this -->
 
 ## 11.2.6


### PR DESCRIPTION
Fixes #1351 and possibly #1380.

I verified this fix with an inline comment and a main Danger note with `DANGER_GITLAB_USE_THREADS` both set and unset. With it unset all behavior looked good to me. 

With that flag set, I am seeing an issue where the main Danger note was replacing the inline comment. Since that is not the intended behavior I tested the latest release with that flag set and also saw the same bad behavior there. Since that behavior is consistent I'd like to move forward with this pull request without trying to fix that behavior.