### PR TITLE
Feature: Expose updateMergeRequestInfo for gitlab api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ## Main
 
 <!-- Your comment below this -->
+- Feature: Expose updateMergeRequestInfo for gitlab api #1391 - [@glensc]
 <!-- Your comment above this -->
 
 ## 11.2.7

--- a/source/dsl/GitLabDSL.ts
+++ b/source/dsl/GitLabDSL.ts
@@ -21,6 +21,7 @@ export interface GitLabDSL extends GitLabJSONDSL {
     fileContents(path: string, repoSlug?: string, ref?: string): Promise<string>
     addLabels(...labels: string[]): Promise<boolean>
     removeLabels(...labels: string[]): Promise<boolean>
+    updateMergeRequestInfo(changes: object): Promise<object>
   }
   api: InstanceType<typeof Gitlab>
 }

--- a/source/platforms/GitLab.ts
+++ b/source/platforms/GitLab.ts
@@ -290,6 +290,7 @@ export const gitlabJSONToGitLabDSL = (gl: GitLabDSL, api: GitLabAPI): GitLabDSL 
     fileContents: api.getFileContents,
     addLabels: api.addLabels,
     removeLabels: api.removeLabels,
+    updateMergeRequestInfo: api.updateMergeRequestInfo,
   },
   api: api.apiInstance,
 })


### PR DESCRIPTION
Similarly to https://github.com/danger/danger-js/pull/1353, expose `updateMergeRequestInfo` method to be able to edit merge requests from danger code.