### PR TITLE
Refactor: Put long node error inside html details

### DIFF
--- a/source/commands/utils/reporting.ts
+++ b/source/commands/utils/reporting.ts
@@ -1,7 +1,7 @@
 import { DangerResults } from "../../dsl/DangerResults"
 
 export const markdownCode = (string: string): string => `
-\`\`\`sh
+\`\`\`
 ${string}
 \`\`\`
 `

--- a/source/commands/utils/runDangerSubprocess.ts
+++ b/source/commands/utils/runDangerSubprocess.ts
@@ -127,7 +127,8 @@ export const runDangerSubprocess = (
       d(`Handling fail from subprocess`)
       process.exitCode = code
 
-      const failResults = resultsWithFailure(`\`${processDisplayName}\` failed.`, "### Log\n\n" + markdownCode(allLogs))
+      const moreMarkdown = "### Log\n\n<details>\n\n" + markdownCode(allLogs) + "\n\n</details>\n"
+      const failResults = resultsWithFailure(`\`${processDisplayName}\` failed.`, moreMarkdown)
       if (results) {
         results = mergeResults(results, failResults)
       } else {


### PR DESCRIPTION
when node process errors, that huge dump of details is placed as a note. put it into HTML `<details>` so the code block is collapsed by default.

<img width="946" alt="image" src="https://github.com/danger/danger-js/assets/199095/f0309733-b24c-4eaf-891a-e4a539af1c08">
