### PR TITLE
Bump CI node to 16 to fix danger_babel_test test

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "16"
 
       # Get local dependencies & test
       - run: yarn install


### PR DESCRIPTION
> error workbox-webpack-plugin@6.6.1: The engine "node" is incompatible with this module. Expected version ">=16.0.0". Got "14.21.3"
> error Found incompatible module.

- https://github.com/danger/danger-js/actions/runs/5706662040/job/15462583894?pr=1392#step:17:152

NOTE: There's alternative solution: https://github.com/danger/danger-js/pull/1394