### PR TITLE
Add dangerID to gitlab createComment api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ## Main
 
 <!-- Your comment below this -->
+- Add dangerID to gitlab createComment api #1395 [@glensc]
 <!-- Your comment above this -->
 
 ## 11.2.7

--- a/source/platforms/GitLab.ts
+++ b/source/platforms/GitLab.ts
@@ -114,7 +114,7 @@ class GitLab implements Platform {
         newOrUpdatedNote = await this.api.updateMergeRequestNote(existingNote.id, newComment)
       } else {
         // create a new comment
-        newOrUpdatedNote = await this.createComment(newComment)
+        newOrUpdatedNote = await this.createComment(dangerID, newComment)
       }
 
       // create URL from note
@@ -145,7 +145,7 @@ class GitLab implements Platform {
     }
   }
 
-  createComment = async (comment: string): Promise<GitLabNote> => {
+  createComment = async (_dangerID: string, comment: string): Promise<GitLabNote> => {
     d("createComment", { comment })
     if (useThreads()) {
       return (await this.api.createMergeRequestDiscussion(comment)).notes[0]


### PR DESCRIPTION
Alternative fix https://github.com/danger/danger-js/pull/1381 based on review notes:
- https://github.com/danger/danger-js/pull/1381#pullrequestreview-1434996715

Fixes https://github.com/danger/danger-js/issues/1380#issuecomment-1519375625
Replaces https://github.com/danger/danger-js/issues/1380