### PR TITLE
FIx: use proper branch name in publish_package workflow

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -3,7 +3,7 @@ name: Release Danger-JS package
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
     tags:
       - '*'
 


### PR DESCRIPTION
See this comment:
- https://github.com/danger/danger-js/pull/1388/files#r1278599734