### PR TITLE
Customise GHE actions bot user ID

### DIFF
--- a/docs/usage/github_enterprise.html.md
+++ b/docs/usage/github_enterprise.html.md
@@ -1,0 +1,59 @@
+---
+title: GitHub Enteprise
+subtitle: Danger on GHE
+layout: guide_js
+order: 4
+blurb: An overview of using Danger with GitHub Enterprise, and some examples
+---
+
+If you are using DangerJS on GitHub Enteprise, you will need to set the Danger used ID to the GitHub Actions bot. This
+will enable Danger to correctly comment and update on PRs.
+
+If you include Danger as a dev-dependency, then you can call danger directly as another build-step after your tests:
+
+```yml
+name: Node CI
+on: [pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Use Node.js 10.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+    - name: install yarn
+      run: npm install -g yarn
+    - name: yarn install, build, and test
+      run: |
+        yarn install  --frozen-lockfile
+        yarn build
+        yarn test
+    - name: Danger
+      run: yarn danger ci
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DANGER_GHE_ACTIONS_BOT_USER_ID: *user_id*
+```
+
+If you are not running in a JavaScript ecosystem, or don't want to include the dependency then you can use Danger JS as
+an action.
+
+```yml
+name: "Danger JS"
+on: [pull_request]
+
+jobs:
+  build:
+    name: Danger JS
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Danger
+      uses: danger/danger-js@9.1.6
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DANGER_GHE_ACTIONS_BOT_USER_ID: *user_id*
+```

--- a/docs/usage/github_enterprise.html.md
+++ b/docs/usage/github_enterprise.html.md
@@ -6,7 +6,7 @@ order: 4
 blurb: An overview of using Danger with GitHub Enterprise, and some examples
 ---
 
-If you are using DangerJS on GitHub Enteprise, you will need to set the Danger used ID to the GitHub Actions bot. This
+If you are using DangerJS on GitHub Enteprise, you will need to set the Danger user ID to the GitHub Actions bot. This
 will enable Danger to correctly comment and update on PRs.
 
 If you include Danger as a dev-dependency, then you can call danger directly as another build-step after your tests:

--- a/source/ci_source/providers/GitHubActions.ts
+++ b/source/ci_source/providers/GitHubActions.ts
@@ -59,7 +59,7 @@ import { readFileSync, existsSync } from "fs"
  * Note it's likely the version number should change, but you get the point. This will run Danger
  * self-encapsulated inside a GitHub action.
  *
- * If you are using DangerJS on GitHub Enteprise, you will need to set the Danger used ID to
+ * If you are using DangerJS on GitHub Enteprise, you will need to set the Danger user ID to
  * the GitHub Actions bot. This will enable Danger to correctly comment and update on PRs.
  *
  * * ```yml

--- a/source/ci_source/providers/GitHubActions.ts
+++ b/source/ci_source/providers/GitHubActions.ts
@@ -59,6 +59,26 @@ import { readFileSync, existsSync } from "fs"
  * Note it's likely the version number should change, but you get the point. This will run Danger
  * self-encapsulated inside a GitHub action.
  *
+ * If you are using DangerJS on GitHub Enteprise, you will need to set the Danger used ID to
+ * the GitHub Actions bot. This will enable Danger to correctly comment and update on PRs.
+ *
+ * * ```yml
+ * name: "Danger JS"
+ * on: [pull_request]
+ *
+ * jobs:
+ *   build:
+ *     name: Danger JS
+ *     runs-on: ubuntu-latest
+ *     steps:
+ *     - uses: actions/checkout@v1
+ *     - name: Danger
+ *       uses: danger/danger-js@9.1.6
+ *       env:
+ *         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+ *         DANGER_GHE_ACTIONS_BOT_USER_ID: *user_id*
+ * ```
+ *
  * <!-- !JS --!>
  * <!-- Swift --!>
  *

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -150,7 +150,7 @@ export class GitHubAPI {
       return 41898282
     }
 
-    this.d("Danger used ID is undefined.")
+    this.d("Danger user ID is undefined.")
     return undefined
   }
 

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -140,7 +140,7 @@ export class GitHubAPI {
     const useGitHubActionsID = process.env["GITHUB_WORKFLOW"]
     if (useGitHubActionsID) {
       // Allow to customise the GitHub actions app ID for Github Enterprise
-      const gheActionsID = process.env["GHE_ACTIONS_BOT_USER_ID"]
+      const gheActionsID = process.env["DANGER_GHE_ACTIONS_BOT_USER_ID"]
       if (gheActionsID) {
         return parseInt(gheActionsID)
       }

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -130,17 +130,22 @@ export class GitHubAPI {
       return parseInt(perilID)
     }
 
-    const info = await this.getUserInfo()
-    if (info.id) {
-      return info.id
-    }
-
     const useGitHubActionsID = process.env["GITHUB_WORKFLOW"]
     if (useGitHubActionsID) {
+      // Allow to customise the GitHub actions app ID for Github Enterprise
+      const gheActionsID = process.env["GHE_ACTIONS_BOT_USER_ID"]
+      if (gheActionsID) {
+        return parseInt(gheActionsID)
+      }
       // This is the user.id of the github-actions app (https://github.com/apps/github-actions)
       // that is used to comment when using danger in a GitHub Action
       // with GITHUB_TOKEN (https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token)
       return 41898282
+    }
+
+    const info = await this.getUserInfo()
+    if (info.id) {
+      return info.id
     }
 
     return undefined

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -130,11 +130,9 @@ export class GitHubAPI {
       return parseInt(perilID)
     }
 
-    if (process.env["DANGER_GITHUB_API_TOKEN"]) {
-      const info = await this.getUserInfo()
-      if (info.id) {
-        return info.id
-      }
+    const info = await this.getUserInfo()
+    if (info.id) {
+      return info.id
     }
 
     const useGitHubActionsID = process.env["GITHUB_WORKFLOW"]

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -130,6 +130,13 @@ export class GitHubAPI {
       return parseInt(perilID)
     }
 
+    if (process.env["DANGER_GITHUB_API_TOKEN"]) {
+      const info = await this.getUserInfo()
+      if (info.id) {
+        return info.id
+      }
+    }
+
     const useGitHubActionsID = process.env["GITHUB_WORKFLOW"]
     if (useGitHubActionsID) {
       // Allow to customise the GitHub actions app ID for Github Enterprise
@@ -143,11 +150,7 @@ export class GitHubAPI {
       return 41898282
     }
 
-    const info = await this.getUserInfo()
-    if (info.id) {
-      return info.id
-    }
-
+    this.d("Danger used ID is undefined.")
     return undefined
   }
 

--- a/source/platforms/github/_tests/_github_api.test.ts
+++ b/source/platforms/github/_tests/_github_api.test.ts
@@ -363,9 +363,26 @@ describe("Peril", () => {
       delete process.env.PERIL_BOT_USER_ID
     })
 
-    it("Makes getUserId return undefined", async () => {
+    it("Makes getUserId return PERIL_BOT_USER_ID", async () => {
       const userID = await api.getUserID()
       expect(userID).toBe(1)
+    })
+  })
+
+  describe("Allows setting GHE_ACTIONS_BOT_USER_ID env variable", () => {
+    beforeEach(() => {
+      process.env.GITHUB_WORKFLOW = "foobar"
+      process.env.GHE_ACTIONS_BOT_USER_ID = "1234"
+    })
+
+    afterEach(() => {
+      delete process.env.GITHUB_WORKFLOW
+      delete process.env.GHE_ACTIONS_BOT_USER_ID
+    })
+
+    it("Makes getUserId return GHE_ACTIONS_BOT_USER_ID", async () => {
+      const userID = await api.getUserID()
+      expect(userID).toBe(1234)
     })
   })
 })

--- a/source/platforms/github/_tests/_github_api.test.ts
+++ b/source/platforms/github/_tests/_github_api.test.ts
@@ -317,7 +317,7 @@ describe("Bots", () => {
     delete process.env.PERIL_BOT_USER_ID
     delete process.env.DANGER_GITHUB_API_TOKEN
     delete process.env.GITHUB_WORKFLOW
-    delete process.env.GHE_ACTIONS_BOT_USER_ID
+    delete process.env.DANGER_GHE_ACTIONS_BOT_USER_ID
   })
 
   it("Allows setting additional headers", async () => {
@@ -379,9 +379,9 @@ describe("Bots", () => {
     expect(userID).toBe(2)
   })
 
-  it("Makes getUserId return GHE_ACTIONS_BOT_USER_ID when set", async () => {
+  it("Makes getUserId return DANGER_GHE_ACTIONS_BOT_USER_ID when set", async () => {
     process.env.GITHUB_WORKFLOW = "foobar"
-    process.env.GHE_ACTIONS_BOT_USER_ID = "3"
+    process.env.DANGER_GHE_ACTIONS_BOT_USER_ID = "3"
 
     const userID = await api.getUserID()
     expect(userID).toBe(3)


### PR DESCRIPTION
# Context
- In GitHub actions, the user ID of the bot is [hardcoded for github.com](https://github.com/danger/danger-js/blob/029fb4f0ad4c1ba9a56cc596057abdeb1df671b2/source/platforms/github/GitHubAPI.ts#L127-L144) without an option to overwrite it for GitHub Enterprise. As a result when called [here](https://github.com/danger/danger-js/blob/029fb4f0ad4c1ba9a56cc596057abdeb1df671b2/source/platforms/github/GitHubAPI.ts#L86) and [here](https://github.com/danger/danger-js/blob/029fb4f0ad4c1ba9a56cc596057abdeb1df671b2/source/platforms/github/GitHubAPI.ts#L315) to update the PR comments, it fails to find the comments.

# Changes
- Adds logic to customise `DANGER_GHE_ACTIONS_BOT_USER_ID `.