### PR TITLE
Gitlab: Upgrade @gitbeaker/node from ^21.3.0 to ^35.8.1  [platform] GitLab

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
 
       # Validate related tooling
       - run: yarn declarations
-      - run: yarn tsc distribution/danger.d.ts
+      - run: yarn tsc --esModuleInterop distribution/danger.d.ts
       - run: rm -rf node_modules/@types/babel-*
       - run: rm -rf node_modules/@types/babylon
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ## Main
 
 <!-- Your comment below this -->
+- GitLab: Upgrade `@gitbeaker/node` from `^21.3.0` to `^35.8.1` [@buffcode]
 <!-- Your comment above this -->
 
 ## 11.2.8
@@ -61,9 +62,6 @@ Reverts a change for GitHub Actions which was likely causing duplicate comments 
 - Append random string to danger-results.json and danger-dsl.json files to better support concurrent processes #1311
 - Gitlab: add support for skipping remove of messages when empty [#1330](https://github.com/danger/danger-js/issues/1330) [@ivankatliarchuk]
 - Gitlab: package moved to a new home "@gitbreaker/*" [#1301](https://github.com/danger/danger-js/issues/1301) [@ivankatliarchuk]
-- Append random string to danger-results.json and danger-dsl.json files to better support concurrent processes #1311
-- GitLab: Upgrade `@gitbreaker/node` from `^21.3.0` to `^^35.7.0` [#1319](https://github.com/danger/danger-js/pull/1319) [@ivankatliarchuk]
-- Gitlab package moved to a new home "@gitbreaker/*" [#1301](https://github.com/danger/danger-js/issues/1301)  [@ivankatliarchuk]
 - GitLab: Improve support for MRs from forks [#1319](https://github.com/danger/danger-js/pull/1319) [@ivankatliarchuk]
 - GitLab: Added provider tests [#1319](https://github.com/danger/danger-js/pull/1319) [@ivankatliarchuk]
 - GitHub: Added `danger.github.pr.draft` field to DSL
@@ -1966,6 +1964,7 @@ Not usable for others, only stubs of classes etc. - [@orta]
 [@azz]: https://github.com/azz
 [@bdotdub]: https://github.com/bdotdub
 [@bigkraig]: https://github.com/bigkraig
+[@buffcode]: https://github.com/buffcode
 [@caffodian]: https://github.com/caffodian
 [@codestergit]: https://github.com/codestergit
 [@cwright017]: https://github.com/Cwright017

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ Reverts a change for GitHub Actions which was likely causing duplicate comments 
 - Append random string to danger-results.json and danger-dsl.json files to better support concurrent processes #1311
 - Gitlab: add support for skipping remove of messages when empty [#1330](https://github.com/danger/danger-js/issues/1330) [@ivankatliarchuk]
 - Gitlab: package moved to a new home "@gitbreaker/*" [#1301](https://github.com/danger/danger-js/issues/1301) [@ivankatliarchuk]
+- Append random string to danger-results.json and danger-dsl.json files to better support concurrent processes #1311
+- GitLab: Upgrade `@gitbreaker/node` from `^21.3.0` to `^^35.7.0` [#1319](https://github.com/danger/danger-js/pull/1319) [@ivankatliarchuk]
+- Gitlab package moved to a new home "@gitbreaker/*" [#1301](https://github.com/danger/danger-js/issues/1301)  [@ivankatliarchuk]
 - GitLab: Improve support for MRs from forks [#1319](https://github.com/danger/danger-js/pull/1319) [@ivankatliarchuk]
 - GitLab: Added provider tests [#1319](https://github.com/danger/danger-js/pull/1319) [@ivankatliarchuk]
 - GitHub: Added `danger.github.pr.draft` field to DSL

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "debug": "^4.1.1",
     "fast-json-patch": "^3.0.0-1",
     "get-stdin": "^6.0.0",
+    "@gitbeaker/core": "^35.8.1",
     "@gitbeaker/node": "^35.8.1",
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "debug": "^4.1.1",
     "fast-json-patch": "^3.0.0-1",
     "get-stdin": "^6.0.0",
-    "@gitbeaker/node": "^21.3.0",
+    "@gitbeaker/node": "^35.7.0",
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.1",
     "hyperlinker": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "debug": "^4.1.1",
     "fast-json-patch": "^3.0.0-1",
     "get-stdin": "^6.0.0",
-    "@gitbeaker/node": "^35.7.0",
+    "@gitbeaker/node": "^35.8.1",
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.1",
     "hyperlinker": "^1.0.0",

--- a/scripts/create-danger-dts.ts
+++ b/scripts/create-danger-dts.ts
@@ -15,7 +15,7 @@ fs.writeFileSync("types/index.d.ts", "// TypeScript Version: 2.2\n" + output)
 
 import * as ts from "typescript"
 
-const program = ts.createProgram(["source/danger.d.ts"], { noEmit: true })
+const program = ts.createProgram(["source/danger.d.ts"], { noEmit: true, esModuleInterop: true })
 const emitResult = program.emit()
 const allDiagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics)
 if (allDiagnostics.length) {

--- a/scripts/danger-dts.ts
+++ b/scripts/danger-dts.ts
@@ -10,6 +10,7 @@ const createDTS = () => {
 
 import { Octokit as GitHub } from "@octokit/rest"
 import { Gitlab, Types } from "@gitbeaker/node"
+import { Types as CoreTypes } from "@gitbeaker/core/dist"
 import { File } from "parse-diff"
 
 `

--- a/scripts/danger-dts.ts
+++ b/scripts/danger-dts.ts
@@ -9,7 +9,7 @@ const createDTS = () => {
 //
 
 import { Octokit as GitHub } from "@octokit/rest"
-import { Gitlab } from "@gitbeaker/node"
+import { Gitlab, Types } from "@gitbeaker/node"
 import { File } from "parse-diff"
 
 `

--- a/source/danger.d.ts
+++ b/source/danger.d.ts
@@ -3,7 +3,7 @@
 //
 
 import { Octokit as GitHub } from "@octokit/rest"
-import { Gitlab } from "@gitbeaker/node"
+import { Gitlab, Types } from "@gitbeaker/node"
 import { File } from "parse-diff"
 
 type MarkdownString = string
@@ -1476,10 +1476,10 @@ interface GitLabJSONDSL {
   metadata: RepoMetaData
   /** Info about the merge request */
   mr: GitLabMR
-  /** All of the individual commits in the merge request */
-  commits: GitLabMRCommit[]
+  /** All the individual commits in the merge request */
+  commits: Types.CommitSchema[]
   /** Merge Request-level MR approvals Configuration */
-  approvals: GitLabApproval
+  approvals: Types.MergeRequestLevelMergeRequestApprovalSchema
 }
 
 // danger.gitlab
@@ -1495,134 +1495,20 @@ interface GitLabDSL extends GitLabJSONDSL {
 
 // ---
 // JSON responses from API
+interface GitlabUpdateMr extends Types.UpdateMergeRequestOptions, Types.BaseRequestOptions {}
 
-interface GitLabUser {
-  id: number
-  name: string
-  username: string
-  state: "active" | "blocked"
-  avatar_url: string | null
-  web_url: string
+interface GitLabNote extends Types.MergeRequestNoteSchema {
+  type: "DiffNote" | "DiscussionNote" | null // XXX: other types? null means "normal comment"
 }
 
-interface GitLabUserProfile extends GitLabUser {
-  created_at: string
-  bio: string | null
-  location: string | null
-  public_email: string
-  skype: string
-  linkedin: string
-  twitter: string
-  website_url: string
-  organization: string
-  last_sign_in_at: string
-  confirmed_at: string
-  theme_id: number
-  last_activity_on: string
-  color_scheme_id: number
-  projects_limit: number
-  current_sign_in_at: string
-  identities: [{ provider: string; extern_uid: string }]
-  can_create_group: boolean
-  can_create_project: boolean
-  two_factor_enabled: boolean
-  external: boolean
-  private_profile: boolean
-}
-
-interface GitLabMRBase {
-  /** The MR's id */
-  id: number
-
-  /** The unique ID for this MR */
-  iid: number
-
-  /** The project ID for this MR */
-  project_id: number
-
-  /** The given name of the MR */
-  title: string
-
-  /** The body text describing the MR */
-  description: string
-
-  /** The MR's current availability */
-  state: "closed" | "open" | "locked" | "merged"
-
-  /** When was the MR made */
-  created_at: string
-
-  /** When was the MR updated */
-  updated_at: string
-
-  /** What branch is this MR being merged into */
-  target_branch: string
-  /** What branch is this MR come from */
-  source_branch: string
-
-  /** How many folks have given it an upvote */
-  upvotes: number
-  /** How many folks have given it an downvote */
-  downvotes: number
-
-  /** Who made it */
-  author: GitLabUser
-  /** Access rights for the user who created the MR */
-  user: {
-    /** Does the author have access to merge? */
-    can_merge: boolean
-  }
-  /** Who was assigned as the person to review */
-  assignee?: GitLabUser
-  assignees: GitLabUser[]
-  /** Users who were added as reviewers to the MR */
-  reviewers: GitLabUser[]
-  source_project_id: number
-  target_project_id: number
-  labels: string[]
-  work_in_progress: boolean
-  milestone: {
-    id: number
-    iid: number
-    project_id: number
-    title: string
-    description: string
-    state: "closed" | "active"
-    created_at: string
-    updated_at: string
-    due_date: string
-    start_date: string
-    web_url: string
-  }
-  merge_when_pipeline_succeeds: boolean
-  merge_status: "can_be_merged" // XXX: other statuses?
-  merge_error: null | null
-  sha: string
-  merge_commit_sha: string | null
-  user_notes_count: number
-  discussion_locked: null | null
-  should_remove_source_branch: boolean
-  force_remove_source_branch: boolean
-  allow_collaboration: boolean
-  allow_maintainer_to_push: boolean
-  web_url: string
-  time_stats: {
-    time_estimate: number
-    total_time_spent: number
-    human_time_estimate: number | null
-    human_total_time_spent: number | null
-  }
+interface GitLabInlineNote extends GitLabNote {
+  type: "DiffNote" | "DiscussionNote" | null // XXX: other types? null means "normal comment"
 }
 
 /** TODO: These need more comments from someone who uses GitLab, see GitLabDSL.ts in the danger-js repo */
-interface GitLabMR extends GitLabMRBase {
-  squash: boolean
+interface GitLabMR extends Types.MergeRequestSchema {
   subscribed: boolean
   changes_count: string
-  merged_by: GitLabUser
-  merged_at: string
-  closed_by: GitLabUser | null
-  closed_at: string | null
   latest_build_started_at: string
   latest_build_finished_at: string
   first_deployed_to_production_at: string | null
@@ -1640,37 +1526,16 @@ interface GitLabMR extends GitLabMRBase {
   }
   diverged_commits_count: number
   rebase_in_progress: boolean
-  approvals_before_merge: null | null
-}
-
-interface GitLabMRChange {
-  old_path: string
-  new_path: string
-  a_mode: string
-  b_mode: string
-  diff: string
-  new_file: boolean
-  renamed_file: boolean
-  deleted_file: boolean
-}
-
-interface GitLabMRChanges extends GitLabMRBase {
-  changes: GitLabMRChange[]
-}
-
-interface GitLabNote {
-  id: number
-  type: "DiffNote" | "DiscussionNote" | null // XXX: other types? null means "normal comment"
-  body: string
-  attachment: null // XXX: what can an attachment be?
-  author: GitLabUser
-  created_at: string
-  updated_at: string
-  system: boolean
-  noteable_id: number
-  noteable_type: "MergeRequest" // XXX: other types...?
-  resolvable: boolean
-  noteable_iid: number
+  approvals_before_merge: null
+  //
+  /** Access rights for the user who created the MR */
+  user: {
+    /** Does the author have access to merge? */
+    can_merge: boolean
+  }
+  merge_error: null
+  allow_collaboration: boolean
+  allow_maintainer_to_push: boolean
 }
 
 interface GitLabDiscussion {

--- a/source/danger.d.ts
+++ b/source/danger.d.ts
@@ -529,6 +529,29 @@ interface BitBucketServerChangesValueMove {
 // prettier-ignore
 type BitBucketServerChangesValue = BitBucketServerChangesValueAddCopyModifyDelete | BitBucketServerChangesValueMove
 
+/**
+ * Describes the possible arguments that
+ * could be used when calling the CLI
+ */
+interface CliArgs {
+  /** The base reference used by danger PR (e.g. not master) */
+  base: string
+  /** For debugging  */
+  verbose: string
+  /** Used by danger-js o allow having a custom CI */
+  externalCiProvider: string
+  /** Use SDTOUT instead of posting to the code review side */
+  textOnly: string
+  /** A custom path for the dangerfile (can also be a remote reference) */
+  dangerfile: string
+  /** So you can have many danger runs in one code review */
+  id: string
+  /** Use staged changes */
+  staging?: boolean
+}
+
+// NOTE: if add something new here, you need to change dslGenerator.ts
+
 /** A platform agnostic reference to a Git commit */
 interface GitCommit {
   /** The SHA for the commit */
@@ -1501,10 +1524,6 @@ interface GitLabNote extends Types.MergeRequestNoteSchema {
   type: "DiffNote" | "DiscussionNote" | null // XXX: other types? null means "normal comment"
 }
 
-interface GitLabInlineNote extends GitLabNote {
-  type: "DiffNote" | "DiscussionNote" | null // XXX: other types? null means "normal comment"
-}
-
 /** TODO: These need more comments from someone who uses GitLab, see GitLabDSL.ts in the danger-js repo */
 interface GitLabMR extends Types.MergeRequestSchema {
   subscribed: boolean
@@ -1538,43 +1557,6 @@ interface GitLabMR extends Types.MergeRequestSchema {
   allow_maintainer_to_push: boolean
 }
 
-interface GitLabDiscussion {
-  id: string //40 character hex
-  individual_note: boolean
-  notes: GitLabNote[]
-}
-
-interface GitLabDiscussionTextPosition {
-  position_type: "text"
-  base_sha: string
-  start_sha: string
-  head_sha: string
-  new_path: string
-  new_line: number
-  old_path: string
-  old_line: number | null
-}
-
-interface GitLabDiscussionCreationOptions {
-  position?: GitLabDiscussionTextPosition
-}
-
-interface GitLabInlineNote extends GitLabNote {
-  position: {
-    base_sha: string
-    start_sha: string
-    head_sha: string
-    old_path: string
-    new_path: string
-    position_type: "text" // XXX: other types?
-    old_line: number | null
-    new_line: number
-  }
-  resolvable: boolean
-  resolved: boolean
-  resolved_by: GitLabUser | null
-}
-
 interface GitLabMRCommit {
   id: string
   short_id: string
@@ -1588,23 +1570,6 @@ interface GitLabMRCommit {
   committer_name: string
   committer_email: string
   committed_date: string
-}
-
-interface GitLabCommit {
-  id: string
-  short_id: string
-  title: string
-  author_name: string
-  author_email: string
-  created_at: string
-}
-
-interface GitLabRepositoryCompare {
-  commit: GitLabCommit
-  commits: GitLabCommit[]
-  diffs: GitLabMRChange[]
-  compare_timeout: boolean
-  compare_same_ref: boolean
 }
 
 interface GitLabApproval {
@@ -1621,9 +1586,9 @@ interface GitLabApproval {
   approvals_left: number
   approved_by?:
     | {
-        user: GitLabUser
+        user: Types.UserSchema
       }[]
-    | GitLabUser[]
+    | Types.UserSchema[]
 }
 
 /** Key details about a repo */
@@ -1650,28 +1615,6 @@ interface Violation {
   /** Optional icon for table (Only valid for messages) */
   icon?: string
 }
-/**
- * Describes the possible arguments that
- * could be used when calling the CLI
- */
-interface CliArgs {
-  /** The base reference used by danger PR (e.g. not master) */
-  base: string
-  /** For debugging  */
-  verbose: string
-  /** Used by danger-js o allow having a custom CI */
-  externalCiProvider: string
-  /** Use SDTOUT instead of posting to the code review side */
-  textOnly: string
-  /** A custom path for the dangerfile (can also be a remote reference) */
-  dangerfile: string
-  /** So you can have many danger runs in one code review */
-  id: string
-  /** Use staged changes */
-  staging?: boolean
-}
-
-// NOTE: if add something new here, you need to change dslGenerator.ts
 /** A function with a callback function, which Danger wraps in a Promise */
 type CallbackableFn = (callback: (done: any) => void) => void
 

--- a/source/danger.d.ts
+++ b/source/danger.d.ts
@@ -4,6 +4,7 @@
 
 import { Octokit as GitHub } from "@octokit/rest"
 import { Gitlab, Types } from "@gitbeaker/node"
+import { Types as CoreTypes } from "@gitbeaker/core/dist"
 import { File } from "parse-diff"
 
 type MarkdownString = string
@@ -1498,7 +1499,7 @@ interface GitLabJSONDSL {
   /** Info about the repo */
   metadata: RepoMetaData
   /** Info about the merge request */
-  mr: GitLabMR
+  mr: CoreTypes.ExpandedMergeRequestSchema
   /** All the individual commits in the merge request */
   commits: Types.CommitSchema[]
   /** Merge Request-level MR approvals Configuration */
@@ -1514,81 +1515,6 @@ interface GitLabDSL extends GitLabJSONDSL {
     removeLabels(...labels: string[]): Promise<boolean>
   }
   api: InstanceType<typeof Gitlab>
-}
-
-// ---
-// JSON responses from API
-interface GitlabUpdateMr extends Types.UpdateMergeRequestOptions, Types.BaseRequestOptions {}
-
-interface GitLabNote extends Types.MergeRequestNoteSchema {
-  type: "DiffNote" | "DiscussionNote" | null // XXX: other types? null means "normal comment"
-}
-
-/** TODO: These need more comments from someone who uses GitLab, see GitLabDSL.ts in the danger-js repo */
-interface GitLabMR extends Types.MergeRequestSchema {
-  subscribed: boolean
-  changes_count: string
-  latest_build_started_at: string
-  latest_build_finished_at: string
-  first_deployed_to_production_at: string | null
-  pipeline: {
-    id: number
-    sha: string
-    ref: string
-    status: "canceled" | "failed" | "pending" | "running" | "skipped" | "success"
-    web_url: string
-  }
-  diff_refs: {
-    base_sha: string
-    head_sha: string
-    start_sha: string
-  }
-  diverged_commits_count: number
-  rebase_in_progress: boolean
-  approvals_before_merge: null
-  //
-  /** Access rights for the user who created the MR */
-  user: {
-    /** Does the author have access to merge? */
-    can_merge: boolean
-  }
-  merge_error: null
-  allow_collaboration: boolean
-  allow_maintainer_to_push: boolean
-}
-
-interface GitLabMRCommit {
-  id: string
-  short_id: string
-  created_at: string
-  parent_ids: string[]
-  title: string
-  message: string
-  author_name: string
-  author_email: string
-  authored_date: string
-  committer_name: string
-  committer_email: string
-  committed_date: string
-}
-
-interface GitLabApproval {
-  id: number
-  iid: number
-  project_id: number
-  title: string
-  description: string
-  state: "closed" | "open" | "locked" | "merged"
-  created_at: string
-  updated_at: string
-  merge_status: "can_be_merged"
-  approvals_required: number
-  approvals_left: number
-  approved_by?:
-    | {
-        user: Types.UserSchema
-      }[]
-    | Types.UserSchema[]
 }
 
 /** Key details about a repo */

--- a/source/dsl/GitLabDSL.ts
+++ b/source/dsl/GitLabDSL.ts
@@ -1,5 +1,5 @@
 // Please don't have includes in here that aren't inside the DSL folder, or the d.ts/flow defs break
-import { Gitlab } from "@gitbeaker/node"
+import { Gitlab, Types } from "@gitbeaker/node"
 import { RepoMetaData } from "./RepoMetaData"
 
 // getPlatformReviewDSLRepresentation
@@ -8,10 +8,10 @@ export interface GitLabJSONDSL {
   metadata: RepoMetaData
   /** Info about the merge request */
   mr: GitLabMR
-  /** All of the individual commits in the merge request */
-  commits: GitLabMRCommit[]
+  /** All the individual commits in the merge request */
+  commits: Types.CommitSchema[]
   /** Merge Request-level MR approvals Configuration */
-  approvals: GitLabApproval
+  approvals: Types.MergeRequestLevelMergeRequestApprovalSchema
 }
 
 // danger.gitlab
@@ -27,134 +27,20 @@ export interface GitLabDSL extends GitLabJSONDSL {
 
 // ---
 // JSON responses from API
+export interface GitlabUpdateMr extends Types.UpdateMergeRequestOptions, Types.BaseRequestOptions {}
 
-export interface GitLabUser {
-  id: number
-  name: string
-  username: string
-  state: "active" | "blocked"
-  avatar_url: string | null
-  web_url: string
+export interface GitLabNote extends Types.MergeRequestNoteSchema {
+  type: "DiffNote" | "DiscussionNote" | null // XXX: other types? null means "normal comment"
 }
 
-export interface GitLabUserProfile extends GitLabUser {
-  created_at: string
-  bio: string | null
-  location: string | null
-  public_email: string
-  skype: string
-  linkedin: string
-  twitter: string
-  website_url: string
-  organization: string
-  last_sign_in_at: string
-  confirmed_at: string
-  theme_id: number
-  last_activity_on: string
-  color_scheme_id: number
-  projects_limit: number
-  current_sign_in_at: string
-  identities: [{ provider: string; extern_uid: string }]
-  can_create_group: boolean
-  can_create_project: boolean
-  two_factor_enabled: boolean
-  external: boolean
-  private_profile: boolean
-}
-
-export interface GitLabMRBase {
-  /** The MR's id */
-  id: number
-
-  /** The unique ID for this MR */
-  iid: number
-
-  /** The project ID for this MR */
-  project_id: number
-
-  /** The given name of the MR */
-  title: string
-
-  /** The body text describing the MR */
-  description: string
-
-  /** The MR's current availability */
-  state: "closed" | "open" | "locked" | "merged"
-
-  /** When was the MR made */
-  created_at: string
-
-  /** When was the MR updated */
-  updated_at: string
-
-  /** What branch is this MR being merged into */
-  target_branch: string
-  /** What branch is this MR come from */
-  source_branch: string
-
-  /** How many folks have given it an upvote */
-  upvotes: number
-  /** How many folks have given it an downvote */
-  downvotes: number
-
-  /** Who made it */
-  author: GitLabUser
-  /** Access rights for the user who created the MR */
-  user: {
-    /** Does the author have access to merge? */
-    can_merge: boolean
-  }
-  /** Who was assigned as the person to review */
-  assignee?: GitLabUser
-  assignees: GitLabUser[]
-  /** Users who were added as reviewers to the MR */
-  reviewers: GitLabUser[]
-  source_project_id: number
-  target_project_id: number
-  labels: string[]
-  work_in_progress: boolean
-  milestone: {
-    id: number
-    iid: number
-    project_id: number
-    title: string
-    description: string
-    state: "closed" | "active"
-    created_at: string
-    updated_at: string
-    due_date: string
-    start_date: string
-    web_url: string
-  }
-  merge_when_pipeline_succeeds: boolean
-  merge_status: "can_be_merged" // XXX: other statuses?
-  merge_error: null | null
-  sha: string
-  merge_commit_sha: string | null
-  user_notes_count: number
-  discussion_locked: null | null
-  should_remove_source_branch: boolean
-  force_remove_source_branch: boolean
-  allow_collaboration: boolean
-  allow_maintainer_to_push: boolean
-  web_url: string
-  time_stats: {
-    time_estimate: number
-    total_time_spent: number
-    human_time_estimate: number | null
-    human_total_time_spent: number | null
-  }
+export interface GitLabInlineNote extends GitLabNote {
+  type: "DiffNote" | "DiscussionNote" | null // XXX: other types? null means "normal comment"
 }
 
 /** TODO: These need more comments from someone who uses GitLab, see GitLabDSL.ts in the danger-js repo */
-export interface GitLabMR extends GitLabMRBase {
-  squash: boolean
+export interface GitLabMR extends Types.MergeRequestSchema {
   subscribed: boolean
   changes_count: string
-  merged_by: GitLabUser
-  merged_at: string
-  closed_by: GitLabUser | null
-  closed_at: string | null
   latest_build_started_at: string
   latest_build_finished_at: string
   first_deployed_to_production_at: string | null
@@ -172,37 +58,16 @@ export interface GitLabMR extends GitLabMRBase {
   }
   diverged_commits_count: number
   rebase_in_progress: boolean
-  approvals_before_merge: null | null
-}
-
-export interface GitLabMRChange {
-  old_path: string
-  new_path: string
-  a_mode: string
-  b_mode: string
-  diff: string
-  new_file: boolean
-  renamed_file: boolean
-  deleted_file: boolean
-}
-
-export interface GitLabMRChanges extends GitLabMRBase {
-  changes: GitLabMRChange[]
-}
-
-export interface GitLabNote {
-  id: number
-  type: "DiffNote" | "DiscussionNote" | null // XXX: other types? null means "normal comment"
-  body: string
-  attachment: null // XXX: what can an attachment be?
-  author: GitLabUser
-  created_at: string
-  updated_at: string
-  system: boolean
-  noteable_id: number
-  noteable_type: "MergeRequest" // XXX: other types...?
-  resolvable: boolean
-  noteable_iid: number
+  approvals_before_merge: null
+  //
+  /** Access rights for the user who created the MR */
+  user: {
+    /** Does the author have access to merge? */
+    can_merge: boolean
+  }
+  merge_error: null
+  allow_collaboration: boolean
+  allow_maintainer_to_push: boolean
 }
 
 export interface GitLabDiscussion {

--- a/source/dsl/GitLabDSL.ts
+++ b/source/dsl/GitLabDSL.ts
@@ -33,10 +33,6 @@ export interface GitLabNote extends Types.MergeRequestNoteSchema {
   type: "DiffNote" | "DiscussionNote" | null // XXX: other types? null means "normal comment"
 }
 
-export interface GitLabInlineNote extends GitLabNote {
-  type: "DiffNote" | "DiscussionNote" | null // XXX: other types? null means "normal comment"
-}
-
 /** TODO: These need more comments from someone who uses GitLab, see GitLabDSL.ts in the danger-js repo */
 export interface GitLabMR extends Types.MergeRequestSchema {
   subscribed: boolean
@@ -70,43 +66,6 @@ export interface GitLabMR extends Types.MergeRequestSchema {
   allow_maintainer_to_push: boolean
 }
 
-export interface GitLabDiscussion {
-  id: string //40 character hex
-  individual_note: boolean
-  notes: GitLabNote[]
-}
-
-export interface GitLabDiscussionTextPosition {
-  position_type: "text"
-  base_sha: string
-  start_sha: string
-  head_sha: string
-  new_path: string
-  new_line: number
-  old_path: string
-  old_line: number | null
-}
-
-export interface GitLabDiscussionCreationOptions {
-  position?: GitLabDiscussionTextPosition
-}
-
-export interface GitLabInlineNote extends GitLabNote {
-  position: {
-    base_sha: string
-    start_sha: string
-    head_sha: string
-    old_path: string
-    new_path: string
-    position_type: "text" // XXX: other types?
-    old_line: number | null
-    new_line: number
-  }
-  resolvable: boolean
-  resolved: boolean
-  resolved_by: GitLabUser | null
-}
-
 export interface GitLabMRCommit {
   id: string
   short_id: string
@@ -120,23 +79,6 @@ export interface GitLabMRCommit {
   committer_name: string
   committer_email: string
   committed_date: string
-}
-
-export interface GitLabCommit {
-  id: string
-  short_id: string
-  title: string
-  author_name: string
-  author_email: string
-  created_at: string
-}
-
-export interface GitLabRepositoryCompare {
-  commit: GitLabCommit
-  commits: GitLabCommit[]
-  diffs: GitLabMRChange[]
-  compare_timeout: boolean
-  compare_same_ref: boolean
 }
 
 export interface GitLabApproval {
@@ -153,7 +95,7 @@ export interface GitLabApproval {
   approvals_left: number
   approved_by?:
     | {
-        user: GitLabUser
+        user: Types.UserSchema
       }[]
-    | GitLabUser[]
+    | Types.UserSchema[]
 }

--- a/source/dsl/GitLabDSL.ts
+++ b/source/dsl/GitLabDSL.ts
@@ -1,13 +1,14 @@
 // Please don't have includes in here that aren't inside the DSL folder, or the d.ts/flow defs break
 import { Gitlab, Types } from "@gitbeaker/node"
 import { RepoMetaData } from "./RepoMetaData"
+import { Types as CoreTypes } from "@gitbeaker/core/dist"
 
 // getPlatformReviewDSLRepresentation
 export interface GitLabJSONDSL {
   /** Info about the repo */
   metadata: RepoMetaData
   /** Info about the merge request */
-  mr: GitLabMR
+  mr: CoreTypes.ExpandedMergeRequestSchema
   /** All the individual commits in the merge request */
   commits: Types.CommitSchema[]
   /** Merge Request-level MR approvals Configuration */
@@ -23,79 +24,4 @@ export interface GitLabDSL extends GitLabJSONDSL {
     removeLabels(...labels: string[]): Promise<boolean>
   }
   api: InstanceType<typeof Gitlab>
-}
-
-// ---
-// JSON responses from API
-export interface GitlabUpdateMr extends Types.UpdateMergeRequestOptions, Types.BaseRequestOptions {}
-
-export interface GitLabNote extends Types.MergeRequestNoteSchema {
-  type: "DiffNote" | "DiscussionNote" | null // XXX: other types? null means "normal comment"
-}
-
-/** TODO: These need more comments from someone who uses GitLab, see GitLabDSL.ts in the danger-js repo */
-export interface GitLabMR extends Types.MergeRequestSchema {
-  subscribed: boolean
-  changes_count: string
-  latest_build_started_at: string
-  latest_build_finished_at: string
-  first_deployed_to_production_at: string | null
-  pipeline: {
-    id: number
-    sha: string
-    ref: string
-    status: "canceled" | "failed" | "pending" | "running" | "skipped" | "success"
-    web_url: string
-  }
-  diff_refs: {
-    base_sha: string
-    head_sha: string
-    start_sha: string
-  }
-  diverged_commits_count: number
-  rebase_in_progress: boolean
-  approvals_before_merge: null
-  //
-  /** Access rights for the user who created the MR */
-  user: {
-    /** Does the author have access to merge? */
-    can_merge: boolean
-  }
-  merge_error: null
-  allow_collaboration: boolean
-  allow_maintainer_to_push: boolean
-}
-
-export interface GitLabMRCommit {
-  id: string
-  short_id: string
-  created_at: string
-  parent_ids: string[]
-  title: string
-  message: string
-  author_name: string
-  author_email: string
-  authored_date: string
-  committer_name: string
-  committer_email: string
-  committed_date: string
-}
-
-export interface GitLabApproval {
-  id: number
-  iid: number
-  project_id: number
-  title: string
-  description: string
-  state: "closed" | "open" | "locked" | "merged"
-  created_at: string
-  updated_at: string
-  merge_status: "can_be_merged"
-  approvals_required: number
-  approvals_left: number
-  approved_by?:
-    | {
-        user: Types.UserSchema
-      }[]
-    | Types.UserSchema[]
 }

--- a/source/platforms/GitLab.ts
+++ b/source/platforms/GitLab.ts
@@ -37,7 +37,7 @@ class GitLab implements Platform {
       approvals,
     }
   }
-
+  // TODO: test
   getPlatformGitRepresentation = async (): Promise<GitJSONDSL> => {
     const changes = await this.api.getMergeRequestChanges()
     const commits = await this.api.getMergeRequestCommits()
@@ -47,16 +47,16 @@ class GitLab implements Platform {
         sha: commit.id,
         author: {
           name: commit.author_name,
-          email: commit.author_email,
-          date: commit.authored_date,
+          email: commit.author_email as string,
+          date: (commit.authored_date as Date).toString(),
         },
         committer: {
-          name: commit.committer_name,
-          email: commit.committer_email,
-          date: commit.committed_date,
+          name: commit.committer_name as string,
+          email: commit.committer_email as string,
+          date: (commit.committed_date as Date).toString(),
         },
         message: commit.message,
-        parents: commit.parent_ids,
+        parents: commit.parent_ids as string[],
         url: `${this.api.projectURL}/commit/${commit.id}`,
         tree: null,
       }

--- a/source/platforms/_tests/_gitlab.test.ts
+++ b/source/platforms/_tests/_gitlab.test.ts
@@ -1,14 +1,14 @@
 import GitLabAPI from "../gitlab/GitLabAPI"
 import GitLab from "../GitLab"
-import { GitLabDiscussion, GitLabNote, GitLabUser, GitLabUserProfile } from "../../dsl/GitLabDSL"
+import { Types } from "@gitbeaker/node"
 
 const baseUri = "https://my-gitlab.org/my-project"
 
 const dangerUserId = 8797215
 
-const getUser = async (): Promise<GitLabUserProfile> => {
-  const user: Partial<GitLabUserProfile> = { id: dangerUserId }
-  return user as GitLabUserProfile
+const getUser = async (): Promise<Types.UserExtendedSchema> => {
+  const user: Partial<Types.UserExtendedSchema> = { id: dangerUserId }
+  return user as Types.UserExtendedSchema
 }
 
 const dangerID = "dddanger1234"
@@ -19,21 +19,26 @@ function mockNote(
   authorId: number,
   body = "",
   type: "DiffNote" | "DiscussionNote" | null = "DiffNote"
-): GitLabNote {
-  const author: Partial<GitLabUser> = { id: authorId }
-  const note: Partial<GitLabNote> = { author: author as GitLabUser, body, id, type: type }
-  return note as GitLabNote
+): Types.MergeRequestNoteSchema {
+  const author: Partial<Types.UserSchema> = { id: authorId }
+  const note: Partial<Types.MergeRequestNoteSchema> = { author: author as Types.UserSchema, body, id, type: type }
+  return note as Types.MergeRequestNoteSchema
 }
 
-function mockDiscussion(id: string, notes: GitLabNote[]): GitLabDiscussion {
-  const discussion: Partial<GitLabDiscussion> = { id, notes }
-  return discussion as GitLabDiscussion
+function mockDiscussion(id: string, notes: Types.DiscussionNote[]): Types.DiscussionSchema {
+  const discussion: Partial<Types.DiscussionSchema> = { id, notes }
+  return discussion as Types.DiscussionSchema
 }
 
 function mockApi(withExisting = false): GitLabAPI {
   const note1 = mockNote(1001, dangerUserId, `some body ${dangerIdString} asdf`)
   const note2 = mockNote(1002, 125235)
-  const note3 = mockNote(1003, dangerUserId, `Main Danger comment ${dangerIdString} More text to ensure the Danger ID string can be found in the middle of a comment`, null)
+  const note3 = mockNote(
+    1003,
+    dangerUserId,
+    `Main Danger comment ${dangerIdString} More text to ensure the Danger ID string can be found in the middle of a comment`,
+    null
+  )
   const note4 = mockNote(1004, 745774)
   const note5 = mockNote(1005, 745774)
   const discussion1 = mockDiscussion("aaaaffff1111", [note1, note2])
@@ -51,9 +56,7 @@ function mockApi(withExisting = false): GitLabAPI {
     getMergeRequestDiscussions: jest.fn(() =>
       Promise.resolve(withExisting ? [discussion1, discussion2, discussion3] : [])
     ),
-    getMergeRequestNotes: jest.fn(() =>
-      Promise.resolve(withExisting ? [note1, note2, note3, note4, note5] : [])
-    ),
+    getMergeRequestNotes: jest.fn(() => Promise.resolve(withExisting ? [note1, note2, note3, note4, note5] : [])),
     mergeRequestURL: baseUri,
     updateMergeRequestNote: jest.fn(() => Promise.resolve(newNote)),
   }

--- a/source/platforms/gitlab/GitLabAPI.ts
+++ b/source/platforms/gitlab/GitLabAPI.ts
@@ -1,6 +1,6 @@
 import { RepoMetaData } from "../../dsl/RepoMetaData"
-import { GitLabMR, GitlabUpdateMr } from "../../dsl/GitLabDSL"
 import { Gitlab, Types } from "@gitbeaker/node"
+import { Types as CoreTypes } from "@gitbeaker/core/dist"
 import { Env } from "../../ci_source/ci_source"
 import { debug } from "../../debug"
 
@@ -76,14 +76,16 @@ class GitLabAPI {
     return user
   }
 
-  getMergeRequestInfo = async (): Promise<GitLabMR> => {
+  getMergeRequestInfo = async (): Promise<CoreTypes.ExpandedMergeRequestSchema> => {
     this.d(`getMergeRequestInfo for repo: ${this.repoSlug} pr: ${this.prId}`)
-    const mr = (await this.api.MergeRequests.show(this.repoSlug, this.prId)) as GitLabMR
+    const mr = await this.api.MergeRequests.show(this.repoSlug, this.prId)
     this.d("getMergeRequestInfo", mr)
-    return mr
+    return mr as CoreTypes.ExpandedMergeRequestSchema
   }
 
-  updateMergeRequestInfo = async (changes: GitlabUpdateMr): Promise<Types.MergeRequestSchema> => {
+  updateMergeRequestInfo = async (
+    changes: Types.UpdateMergeRequestOptions & Types.BaseRequestOptions
+  ): Promise<Types.MergeRequestSchema> => {
     const mr = this.api.MergeRequests.edit(this.repoSlug, this.prId, changes)
     this.d("updateMergeRequestInfo", mr)
     return mr
@@ -200,7 +202,7 @@ class GitLabAPI {
     const projectId = slug || this.repoSlug
     // Use the current state of PR if no ref is passed
     if (!ref) {
-      const mr: GitLabMR = await this.getMergeRequestInfo()
+      const mr = await this.getMergeRequestInfo()
       ref = mr.diff_refs.head_sha
     }
 

--- a/source/platforms/gitlab/GitLabGit.ts
+++ b/source/platforms/gitlab/GitLabGit.ts
@@ -1,6 +1,7 @@
 import { debug } from "../../debug"
-import { GitLabDSL, GitLabMRChange } from "../../dsl/GitLabDSL"
+import { GitLabDSL } from "../../dsl/GitLabDSL"
 import { GitDSL, GitJSONDSL } from "../../dsl/GitDSL"
+import { Types } from "@gitbeaker/node"
 import { gitJSONToGitDSL, GitJSONToGitDSLConfig } from "../git/gitJSONToGitDSL"
 import GitLabAPI from "./GitLabAPI"
 
@@ -22,7 +23,7 @@ export const gitLabGitDSL = (gitlab: GitLabDSL, json: GitJSONDSL, gitlabAPI: Git
   return gitJSONToGitDSL(json, config)
 }
 
-export const gitlabChangesToDiff = (changes: GitLabMRChange[]): string => {
+export const gitlabChangesToDiff = (changes: Types.CommitDiffSchema[]): string => {
   d("Converting GitLab Changes to Diff")
   // Gitlab doesn't return full raw git diff, relevant issue: https://gitlab.com/gitlab-org/gitlab/issues/24913
   return changes

--- a/source/platforms/gitlab/_tests/_gitlab_api.test.ts
+++ b/source/platforms/gitlab/_tests/_gitlab_api.test.ts
@@ -201,7 +201,7 @@ describe("GitLab API", () => {
     const titleToUpdate = "update merge request"
     const result = await api.updateMergeRequestInfo({ title: titleToUpdate })
     nockDone()
-    expect(JSON.stringify(result)).toContain(titleToUpdate)
+    expect(result.title).toContain(titleToUpdate)
   })
 
   describe("updateMergeRequestInfo (add|remove)labels", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,34 +1186,36 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@gitbeaker/core@^21.7.0":
-  version "21.7.0"
-  resolved "https://registry.yarnpkg.com/@gitbeaker/core/-/core-21.7.0.tgz#fcf7a12915d39f416e3f316d0a447a814179b8e5"
-  integrity sha512-cw72rE7tA27wc6JJe1WqeAj9v/6w0S7XJcEji+bRNjTlUfE1zgfW0Gf1mbGUi7F37SOABGCosQLfg9Qe63aIqA==
+"@gitbeaker/core@^35.7.0":
+  version "35.7.0"
+  resolved "https://registry.yarnpkg.com/@gitbeaker/core/-/core-35.7.0.tgz#426e426dff597c1d094bf1fe66fb1109980e816d"
+  integrity sha512-1N9QcHElYa1NuLhX9mJJ6tnL7wbCsK8Naj2kLXwNC4qyEcDhMiJDnI3YoqNIXSzPTufoNUAbgIsc/h/JmO17/A==
   dependencies:
-    "@gitbeaker/requester-utils" "^21.7.0"
-    form-data "^3.0.0"
+    "@gitbeaker/requester-utils" "^35.7.0"
+    form-data "^4.0.0"
     li "^1.3.0"
+    mime "^3.0.0"
+    query-string "^7.0.0"
     xcase "^2.0.1"
 
-"@gitbeaker/node@^21.3.0":
-  version "21.7.0"
-  resolved "https://registry.yarnpkg.com/@gitbeaker/node/-/node-21.7.0.tgz#2c19613f44ee497a8808c555abec614ebd2dfcad"
-  integrity sha512-OdM3VcTKYYqboOsnbiPcO0XimXXpYK4gTjARBZ6BWc+1LQXKmqo+OH6oUbyxOoaFu9hHECafIt3WZU3NM4sZTg==
+"@gitbeaker/node@^35.7.0":
+  version "35.7.0"
+  resolved "https://registry.yarnpkg.com/@gitbeaker/node/-/node-35.7.0.tgz#ba4ece7aff388132bdcab8d6fb08c8d063a70e7d"
+  integrity sha512-zh215EUloAxj2gwTHevBVypEiiwQR0WsFLGPWJwY+yUFJVQRcya+3mcsDbxgCLAk00wwhrTVYyNppvmoYbEZNg==
   dependencies:
-    "@gitbeaker/core" "^21.7.0"
-    "@gitbeaker/requester-utils" "^21.7.0"
-    form-data "^3.0.0"
-    got "^11.1.4"
+    "@gitbeaker/core" "^35.7.0"
+    "@gitbeaker/requester-utils" "^35.7.0"
+    delay "^5.0.0"
+    got "^11.8.3"
     xcase "^2.0.1"
 
-"@gitbeaker/requester-utils@^21.7.0":
-  version "21.7.0"
-  resolved "https://registry.yarnpkg.com/@gitbeaker/requester-utils/-/requester-utils-21.7.0.tgz#e9a9cfaf268d2a99eb7bbdc930943240a5f88878"
-  integrity sha512-eLTaVXlBnh8Qimj6QuMMA06mu/mLcJm3dy8nqhhn/Vm/D25sPrvpGwmbfFyvzj6QujPqtHvFfsCHtyZddL01qA==
+"@gitbeaker/requester-utils@^35.7.0":
+  version "35.7.0"
+  resolved "https://registry.yarnpkg.com/@gitbeaker/requester-utils/-/requester-utils-35.7.0.tgz#7c1ded70a10ac890322f22488ffea8a3a41ccc79"
+  integrity sha512-SDYKhL+XUrslpVwUumkCf4I4Ubf+lvzdghCYPwBt/og5kZIorFVbHCxRmtr5bO+iC9nrVNfg24sdoe51vDGn1w==
   dependencies:
-    form-data "^3.0.0"
-    query-string "^6.12.1"
+    form-data "^4.0.0"
+    qs "^6.10.1"
     xcase "^2.0.1"
 
 "@humanwhocodes/config-array@^0.9.2":
@@ -3434,6 +3436,11 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
+delay@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/delay/-/delay-5.0.0.tgz#137045ef1b96e5071060dd5be60bf9334436bd1d"
+  integrity sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -4381,6 +4388,15 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 form-data@~2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
@@ -4728,7 +4744,7 @@ got@10.7.0:
     to-readable-stream "^2.0.0"
     type-fest "^0.10.0"
 
-got@^11.1.4:
+got@^11.8.3:
   version "11.8.5"
   resolved "https://registry.yarnpkg.com/got/-/got-11.8.5.tgz#ce77d045136de56e8f024bebb82ea349bc730046"
   integrity sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==
@@ -6810,6 +6826,11 @@ mime@1.3.4:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
   integrity sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=
 
+mime@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-3.0.0.tgz#b374550dca3a0c18443b0c950a6a58f1931cf7a7"
+  integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
+
 mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
@@ -7159,6 +7180,11 @@ object-inspect@^1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0"
   integrity sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
+
+object-inspect@^1.9.0:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
+  integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
 
 object-keys@^1.0.8:
   version "1.0.11"
@@ -7917,15 +7943,22 @@ pupa@^2.0.1:
   dependencies:
     escape-goat "^2.0.0"
 
+qs@^6.10.1:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
+  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@~6.5.1:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
   integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
-query-string@^6.12.1:
-  version "6.14.1"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.14.1.tgz#7ac2dca46da7f309449ba0f86b1fd28255b0c86a"
-  integrity sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==
+query-string@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.1.tgz#754620669db978625a90f635f12617c271a088e1"
+  integrity sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==
   dependencies:
     decode-uri-component "^0.2.0"
     filter-obj "^1.1.0"
@@ -8755,6 +8788,15 @@ shx@^0.3.4:
   dependencies:
     minimist "^1.2.3"
     shelljs "^0.8.5"
+
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,33 +1186,33 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@gitbeaker/core@^35.7.0":
-  version "35.7.0"
-  resolved "https://registry.yarnpkg.com/@gitbeaker/core/-/core-35.7.0.tgz#426e426dff597c1d094bf1fe66fb1109980e816d"
-  integrity sha512-1N9QcHElYa1NuLhX9mJJ6tnL7wbCsK8Naj2kLXwNC4qyEcDhMiJDnI3YoqNIXSzPTufoNUAbgIsc/h/JmO17/A==
+"@gitbeaker/core@^35.8.1":
+  version "35.8.1"
+  resolved "https://registry.yarnpkg.com/@gitbeaker/core/-/core-35.8.1.tgz#b4ce2d08d344ff50e76c38ff81b800bec6dfe851"
+  integrity sha512-KBrDykVKSmU9Q9Gly8KeHOgdc0lZSa435srECxuO0FGqqBcUQ82hPqUc13YFkkdOI9T1JRA3qSFajg8ds0mZKA==
   dependencies:
-    "@gitbeaker/requester-utils" "^35.7.0"
+    "@gitbeaker/requester-utils" "^35.8.1"
     form-data "^4.0.0"
     li "^1.3.0"
     mime "^3.0.0"
     query-string "^7.0.0"
     xcase "^2.0.1"
 
-"@gitbeaker/node@^35.7.0":
-  version "35.7.0"
-  resolved "https://registry.yarnpkg.com/@gitbeaker/node/-/node-35.7.0.tgz#ba4ece7aff388132bdcab8d6fb08c8d063a70e7d"
-  integrity sha512-zh215EUloAxj2gwTHevBVypEiiwQR0WsFLGPWJwY+yUFJVQRcya+3mcsDbxgCLAk00wwhrTVYyNppvmoYbEZNg==
+"@gitbeaker/node@^35.8.1":
+  version "35.8.1"
+  resolved "https://registry.yarnpkg.com/@gitbeaker/node/-/node-35.8.1.tgz#d67885c827f2d7405afd7e39538a230721756e5c"
+  integrity sha512-g6rX853y61qNhzq9cWtxIEoe2KDeFBtXAeWMGWJnc3nz3WRump2pIICvJqw/yobLZqmTNt+ea6w3/n92Mnbn3g==
   dependencies:
-    "@gitbeaker/core" "^35.7.0"
-    "@gitbeaker/requester-utils" "^35.7.0"
+    "@gitbeaker/core" "^35.8.1"
+    "@gitbeaker/requester-utils" "^35.8.1"
     delay "^5.0.0"
     got "^11.8.3"
     xcase "^2.0.1"
 
-"@gitbeaker/requester-utils@^35.7.0":
-  version "35.7.0"
-  resolved "https://registry.yarnpkg.com/@gitbeaker/requester-utils/-/requester-utils-35.7.0.tgz#7c1ded70a10ac890322f22488ffea8a3a41ccc79"
-  integrity sha512-SDYKhL+XUrslpVwUumkCf4I4Ubf+lvzdghCYPwBt/og5kZIorFVbHCxRmtr5bO+iC9nrVNfg24sdoe51vDGn1w==
+"@gitbeaker/requester-utils@^35.8.1":
+  version "35.8.1"
+  resolved "https://registry.yarnpkg.com/@gitbeaker/requester-utils/-/requester-utils-35.8.1.tgz#f345cdd05abd4169cfcd239d202db6283eb17dc8"
+  integrity sha512-MFzdH+Z6eJaCZA5ruWsyvm6SXRyrQHjYVR6aY8POFraIy7ceIHOprWCs1R+0ydDZ8KtBnd8OTHjlJ0sLtSFJCg==
   dependencies:
     form-data "^4.0.0"
     qs "^6.10.1"


### PR DESCRIPTION
This is a follow up to https://github.com/danger/danger-js/pull/1327 by @ivankatliarchuk 

- All tests have been fixed
- This PR should allow for a smoother switch to `@gitbeaker/rest` (see https://github.com/danger/danger-js/issues/1386)
- `esModuleInterop` had to be enabled for DTS generation because of:
    ```
    /home/runner/work/danger-js/danger-js/node_modules/@gitbeaker/core/dist/types/infrastructure/Utils.d.ts:1:8 - Module '"/home/runner/work/danger-js/danger-js/node_modules/form-data/index"' can only be default-imported using the 'esModuleInterop' flag
    /home/runner/work/danger-js/danger-js/node_modules/@gitbeaker/requester-utils/dist/types/RequesterUtils.d.ts:2:8 - Module '"/home/runner/work/danger-js/danger-js/node_modules/form-data/index"' can only be default-imported using the 'esModuleInterop' flag
    ```