### PR TITLE
fix(javadoc): fail and warn functions fix misleading documentation

### DIFF
--- a/source/runner/Dangerfile.ts
+++ b/source/runner/Dangerfile.ts
@@ -27,7 +27,7 @@ export interface DangerContext {
   schedule(asyncFunction: Scheduleable): void
 
   /**
-   * Fails a build, outputting a specific reason for failing into a HTML table.
+   * Highlights critical issues. Message is shown inside a HTML table.
    *
    * @param {MarkdownString} message the String to output
    * @param {string | undefined} file a file which this message should be attached to
@@ -36,8 +36,7 @@ export interface DangerContext {
   fail(message: MarkdownString, file?: string, line?: number): void
 
   /**
-   * Highlights low-priority issues, but does not fail the build. Message
-   * is shown inside a HTML table.
+   * Highlights low-priority issues. Message is shown inside a HTML table.
    *
    * @param {MarkdownString} message the String to output
    * @param {string | undefined} file a file which this message should be attached to


### PR DESCRIPTION
References:
https://github.com/danger/danger-js/blob/fdc1c49aff5e569580a23d0547ea0442a753826c/source/commands/utils/sharedDangerfileArgs.ts#L52
https://github.com/danger/danger-js/blob/fdc1c49aff5e569580a23d0547ea0442a753826c/source/runner/Executor.ts#L156

Behaviour:
By default `failOnErrors` is `false` and will not fail run in case of any fails will be found. In this case current documentation is a bit misleading because users can expect different behaviour.