### PR TITLE
Patch 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ## Main
 
 <!-- Your comment below this -->
+- Clear missing DSL timeout when DSL is found so danger runner can exit faster when done [@normano64]
 <!-- Your comment above this -->
 
 ## 11.3.0

--- a/source/commands/danger-runner.ts
+++ b/source/commands/danger-runner.ts
@@ -51,6 +51,7 @@ const run = (config: SharedCLI) => async (jsonString: string) => {
 
   d("Got STDIN for Danger Run")
   foundDSL = true
+  clearTimeout(missingDSLTimeout)
   const dangerFile = dangerfilePath(program)
 
   // Set up the runtime env
@@ -85,9 +86,9 @@ nodeCleanup((exitCode: number, signal: string) => {
 })
 
 // Add a timeout so that CI doesn't run forever if something has broken.
-setTimeout(() => {
+const missingDSLTimeout = setTimeout(() => {
   if (!foundDSL) {
-    console.error(chalk.red("Timeout: Failed to get the Danger DSL after 1 second"))
+    console.error(chalk.red("Timeout: Failed to get the Danger DSL after 10 second"))
     process.exitCode = 1
     process.exit(1)
   }


### PR DESCRIPTION
I noticed that the danger step in CI was always taking more than 10 seconds, the root cause was that nodeCleanup was waiting for the missing DSL timeout before continuing even when the DSL was found