### PR TITLE
Use node18 for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-slim as build
+FROM node:18-slim as build
 
 LABEL maintainer="Orta Therox"
 LABEL "com.github.actions.name"="Danger JS Action"
@@ -16,7 +16,7 @@ RUN yarn install --production --frozen-lockfile
 RUN chmod +x distribution/commands/danger.js
 
 
-FROM node:14-slim
+FROM node:18-slim
 WORKDIR /usr/src/danger
 ENV PATH="/usr/src/danger/node_modules/.bin:$PATH"
 COPY package.json ./


### PR DESCRIPTION
Some of the plugins e.g https://github.com/sogame/danger-plugin-toolbox have dropped support for node12 and its latest version requires node18. 

Updating the Dockerfile to newer node version allows the dependencies to be upgraded as well.