### PR TITLE
Fix the shouldUseGitHubOverride logic for ESM imports

### DIFF
--- a/source/platforms/github/_tests/_customGitHubRequire.test.ts
+++ b/source/platforms/github/_tests/_customGitHubRequire.test.ts
@@ -31,6 +31,12 @@ describe("shouldUseGitHubOverride", () => {
     const parent: any = { filename: dangerPrefix + "./my-import" }
     expect(shouldUseGitHubOverride(module, parent)).toBeTruthy()
   })
+
+  it("ignores modules without a parent", () => {
+    const module = "./peril"
+    const parent: any = undefined
+    expect(shouldUseGitHubOverride(module, parent)).toBeFalsy()
+  })
 })
 
 describe("customGitHubResolveRequest", () => {

--- a/source/platforms/github/customGitHubRequire.ts
+++ b/source/platforms/github/customGitHubRequire.ts
@@ -86,9 +86,9 @@ export async function getGitHubFileContents(
 
 // Setup a callback used to determine whether a specific `require` invocation
 // needs to be overridden.
-export const shouldUseGitHubOverride = (request: string, parent: NodeModule): boolean => {
+export const shouldUseGitHubOverride = (request: string, parent?: NodeModule): boolean => {
   // Is it a from a file we're handling, and is it relative?
-  if (parent.filename.startsWith(dangerPrefix) && request.startsWith(".")) {
+  if (parent?.filename.startsWith(dangerPrefix) && request.startsWith(".")) {
     return true
   }
   // Basically any import that's not a relative import from a Dangerfile


### PR DESCRIPTION
The `shouldUseGitHubOverride` util is called with `Module._load` parameters. So far, it assumed it will get a string `request` and a `NodeModule` `parent` parameters. However, for ESM imports `parent` is actually `undefined`.

Account for this in code by making `parent` an optional argument; add a test.

Fixes gh-1421

cc @fbartho