### PR TITLE
GitHub: use files API with pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 <!-- Your comment below this -->
 
 - Adds a log when you run on GitHub Actions without being a pull_request - [@orta]
+- GitHub: Move to 'List pull request files' API with pagination support [@fabianehlert]
 
 <!-- Your comment above this -->
 


### PR DESCRIPTION
Switched from using the GitHub API [Get a pull request](https://docs.github.com/en/rest/pulls#get-a-pull-request) to the [List pull requests files](https://docs.github.com/en/rest/pulls#list-pull-requests-files) API, incorporating pagination to retrieve pull request diffs. This change enables the analysis of pull requests containing more than 300 files.

Although the 300 file limit on the "Get a pull request" API isn't new, GitHub recently began enforcing it with a HTTP 406 status code. Currently, Danger is failing when analyzing pull requests exceeding this limit.

The "List pull requests files" API returns a slightly different git diff format, omitting the initial `diff --git …` part which `parse-diff` expects. As a _hack_, I'm adding it manually now.

Happy to hear your feedback on this approach :)

Fixes https://github.com/danger/danger-js/issues/1432 and https://github.com/danger/swift/issues/606