### PR TITLE
Add and use status on GitHubFile

### DIFF
--- a/source/platforms/git/diffToGitJSONDSL.ts
+++ b/source/platforms/git/diffToGitJSONDSL.ts
@@ -9,11 +9,13 @@ import { GitJSONDSL } from "../../dsl/GitDSL"
  */
 
 export const diffToGitJSONDSL = (diff: string, commits: GitCommit[]): GitJSONDSL => {
-  const fileDiffs: any[] = parseDiff(diff)
+  const fileDiffs: parseDiff.File[] = parseDiff(diff)
 
-  const addedDiffs = fileDiffs.filter((diff: any) => diff["new"])
-  const removedDiffs = fileDiffs.filter((diff: any) => diff["deleted"])
-  const modifiedDiffs = fileDiffs.filter((diff: any) => !includes(addedDiffs, diff) && !includes(removedDiffs, diff))
+  const addedDiffs = fileDiffs.filter((diff: parseDiff.File) => diff.new == true) as any[]
+  const removedDiffs = fileDiffs.filter((diff: parseDiff.File) => diff.deleted == true) as any[]
+  const modifiedDiffs = fileDiffs.filter(
+    (diff: any) => !includes(addedDiffs, diff) && !includes(removedDiffs, diff)
+  ) as any[]
 
   return {
     //                                             Work around for danger/danger-js#807

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -21,6 +21,7 @@ const limit = pLimit(25)
 export interface GitHubFile {
   filename: string
   patch: string
+  status: string
 }
 
 // Note that there are parts of this class which don't seem to be
@@ -373,8 +374,17 @@ export class GitHubAPI {
     // This is a hack to get the file patch into a format that parse-diff accepts
     // as the GitHub API for listing pull request files is missing file names in the patch.
     function prefixedPatch(file: GitHubFile): string {
+      let fileMode = ""
+      if (file.status == "added") {
+        fileMode = "new file mode"
+      } else if (file.status == "removed") {
+        fileMode = "deleted file mode"
+      } else if (file.status == "modified") {
+        fileMode = "modified file mode"
+      }
       return `
 diff --git a/${file.filename} b/${file.filename}
+${fileMode} 0
 --- a/${file.filename}
 +++ b/${file.filename}
 ${file.patch}


### PR DESCRIPTION
Attempt to fix https://github.com/danger/danger-js/issues/1446

By adding the file mode to the file patch the output from parseDiff now includes `new` and `deleted` boolean values correctly and give us something to validate against in  `diffToGitJSONDSL`.

New Output:

```
Starting Danger PR on danger/danger-js#9
Created [ 'yarn.lock' ]

Deleted [ 'npm-shrinkwrap.json' ]
Modified [ 'README.md', 'package.json' ]
```