### PR TITLE
fix(node): #1180 - Adjust tsconfig compiler options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ## Main
 
 <!-- Your comment below this -->
-
+- [#1180] Set module properly when tsconfig does not contain compilerOptions.module [@matthewh]
 <!-- Your comment above this -->
 
 ## 12.3.2

--- a/source/runner/runners/utils/transpiler.ts
+++ b/source/runner/runners/utils/transpiler.ts
@@ -149,10 +149,14 @@ const sanitizeTSConfig = (config: any, esm: boolean = false) => {
   //
   // @see https://github.com/apollographql/react-apollo/pull/1402#issuecomment-351810274
   //
-  if (!esm && safeConfig.compilerOptions.module) {
-    safeConfig.compilerOptions.module = "commonjs"
-  } else {
-    safeConfig.compilerOptions.module = "es6"
+  if (safeConfig.compilerOptions.module) {
+    if (!esm) {
+      // .ts files should fall back to commonjs
+      safeConfig.compilerOptions.module = "commonjs"
+    } else {
+      // .mts files must use `import`/`export` syntax
+      safeConfig.compilerOptions.module = "es6"
+    }
   }
 
   return safeConfig


### PR DESCRIPTION
Accidentally applied `es6` when compilerOptions.module was not defined.

I recognize posting an error message to indicate a successful fix isn't great practice but I'm testing locally and this at least proves the code transpiled correctly and executed and failed once danger realized it's not inside a github PR.

# "Success"

```
❯ pwd
/Volumes/Projects/multipart/eslint-plugin-jest
❯ danger local --base main --staging
...

Unable to evaluate the Dangerfile
 TypeError: Cannot read properties of  (reading 'pr')
    at Object.<anonymous> (dangerfile.ts:51:19)
    at Module._compile (node:internal/modules/cjs/loader:1376:14)
    at requireFromString (/Volumes/Projects/multipart/danger-js/node_modules/require-from-string/index.js:28:4)
    at /Volumes/Projects/multipart/danger-js/distribution/runner/runners/inline.js:183:68
    at step (/Volumes/Projects/multipart/danger-js/distribution/runner/runners/inline.js:56:23)
    at Object.next (/Volumes/Projects/multipart/danger-js/distribution/runner/runners/inline.js:37:53)
    at /Volumes/Projects/multipart/danger-js/distribution/runner/runners/inline.js:31:71
    at new Promise (<anonymous>)
    at __awaiter (/Volumes/Projects/multipart/danger-js/distribution/runner/runners/inline.js:27:12)
    at Object.runDangerfileEnvironment (/Volumes/Projects/multipart/danger-js/distribution/runner/runners/inline.js:123:132)
```

# Addresses original error

```
Cannot use import statement outside a module
dangerfile.ts:46
import { parse } from 'path';
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at internalCompileFunction (node:internal/vm:76:18)
    at wrapSafe (node:internal/modules/cjs/loader:1283:20)
    at Module._compile (node:internal/modules/cjs/loader:1328:27)
    at requireFromString (/usr/src/danger/node_modules/require-from-string/index.js:28:4)
    at /usr/src/danger/dist/runner/runners/inline.js:183:68
    at step (/usr/src/danger/dist/runner/runners/inline.js:56:23)
    at Object.next (/usr/src/danger/dist/runner/runners/inline.js:37:53)
    at /usr/src/danger/dist/runner/runners/inline.js:31:71
    at new Promise (<anonymous>)
    at __awaiter (/usr/src/danger/dist/runner/runners/inline.js:27:12)
```