### PR TITLE
fix: remove `GITHUB_URL` environment variable as a fallback for the GitHub API URL

### DIFF
--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -52,7 +52,7 @@ export class GitHubAPI {
     // A token should have been set by this point
     const token = accessTokenForApp || this.token!
 
-    const host = process.env["DANGER_GITHUB_API_BASE_URL"] || process.env["GITHUB_URL"] || undefined
+    const host = process.env["DANGER_GITHUB_API_BASE_URL"] || "https://api.github.com"
     const options: ConstructorParameters<typeof GitHubNodeAPI>[0] & { debug: boolean } = {
       debug: !!process.env.LOG_FETCH_REQUESTS,
       baseUrl: host,
@@ -515,7 +515,7 @@ ${file.patch}
     }
 
     const containsBase = path.startsWith("http")
-    const baseUrl = process.env["DANGER_GITHUB_API_BASE_URL"] || process.env["GITHUB_URL"] || "https://api.github.com"
+    const baseUrl = process.env["DANGER_GITHUB_API_BASE_URL"] || "https://api.github.com"
     const url = containsBase ? path : `${baseUrl}/${path}`
 
     let customAccept = {}

--- a/source/platforms/github/customGitHubRequire.ts
+++ b/source/platforms/github/customGitHubRequire.ts
@@ -61,7 +61,7 @@ export async function getGitHubFileContents(
 ) {
   const refString = ref ? `?ref=${ref}` : ""
   const containsBase = path.startsWith("http")
-  const baseUrl = process.env["DANGER_GITHUB_API_BASE_URL"] || process.env["GITHUB_URL"] || "https://api.github.com"
+  const baseUrl = process.env["DANGER_GITHUB_API_BASE_URL"] || "https://api.github.com"
   const URLPath = `repos/${repoSlug}/contents/${path}${refString}`
   const url = containsBase ? URLPath : `${baseUrl}/${URLPath}`
 

--- a/source/runner/dslGenerator.ts
+++ b/source/runner/dslGenerator.ts
@@ -39,7 +39,7 @@ export const jsonDSLGenerator = async (
       github: {
         accessToken: process.env["DANGER_GITHUB_API_TOKEN"] || process.env["GITHUB_TOKEN"] || "NO_TOKEN",
         additionalHeaders: {},
-        baseURL: process.env["DANGER_GITHUB_API_BASE_URL"] || process.env["GITHUB_URL"] || undefined,
+        baseURL: process.env["DANGER_GITHUB_API_BASE_URL"] || "https://api.github.com",
       },
       cliArgs,
     },


### PR DESCRIPTION
close #1374