### PR TITLE
fix: Fix compatibility issue with ts-node/register

### DIFF
--- a/source/runner/runners/inline.ts
+++ b/source/runner/runners/inline.ts
@@ -14,6 +14,8 @@ import resultsForCaughtError from "./utils/resultsForCaughtError"
 
 const d = debug("inline_runner")
 
+const disableTranspilation = process.env.DANGER_DISABLE_TRANSPILATION === "true"
+
 /**
  * Executes a Dangerfile at a specific path, with a context.
  * The values inside a Danger context are applied as globals to the Dangerfiles runtime.
@@ -73,13 +75,15 @@ export const runDangerfileEnvironment = async (
     module._compile(compiled, filename)
   }
 
-  const customRequire = moduleHandler || customModuleHandler
+  if (!disableTranspilation) {
+    const customRequire = moduleHandler || customModuleHandler
 
-  // Tell all these filetypes to get the custom compilation
-  require.extensions[".ts"] = customRequire
-  require.extensions[".tsx"] = customRequire
-  require.extensions[".js"] = customRequire
-  require.extensions[".jsx"] = customRequire
+    // Tell all these filetypes to get the custom compilation
+    require.extensions[".ts"] = customRequire
+    require.extensions[".tsx"] = customRequire
+    require.extensions[".js"] = customRequire
+    require.extensions[".jsx"] = customRequire
+  }
 
   // Loop through all files and their potential contents, they edit
   // results inside the env, so no need to keep track ourselves


### PR DESCRIPTION
Possible solution to #1107 . 
I could not make it run locally with yalc, to test properly, but I would appreciate a suggestion!

## Changes

As the issue suggest, it currently has some issues when trying to run dangerfiles with imports in typescript

I tried to implement @orta suggestion, but as mentioned couldn't properly test locally