### PR TITLE
fix: reject with real errors for GitLab API calls for better debugging

### DIFF
--- a/source/platforms/gitlab/GitLabAPI.ts
+++ b/source/platforms/gitlab/GitLabAPI.ts
@@ -184,9 +184,8 @@ class GitLabAPI {
       return note as Types.MergeRequestNoteSchema
     } catch (e) {
       this.d("createMergeRequestNote", e)
+      throw e
     }
-
-    return Promise.reject()
   }
 
   updateMergeRequestDiscussionNote = async (
@@ -207,9 +206,8 @@ class GitLabAPI {
       return discussionNote as Types.MergeRequestDiscussionNoteSchema
     } catch (e) {
       this.d("updateMergeRequestDiscussionNote", e)
+      throw e
     }
-
-    return Promise.reject()
   }
 
   updateMergeRequestNote = async (id: number, body: string): Promise<Types.MergeRequestNoteSchema> => {
@@ -220,9 +218,8 @@ class GitLabAPI {
       return note as Types.MergeRequestNoteSchema
     } catch (e) {
       this.d("updateMergeRequestNote", e)
+      throw e
     }
-
-    return Promise.reject()
   }
 
   // note: deleting the _only_ discussion note in a discussion also deletes the discussion \o/


### PR DESCRIPTION
In previous implementation, some GitLab API calls would make a Promise rejection with `undefined` as the reason.
And in the [global `unhandledRejection` handler](https://github.com/frantic1048/danger-js/blob/b67d710af4d177d57e7091a742da54a2e9fa37fc/source/commands/utils/sharedDangerfileArgs.ts#L5), it will print a generic "Error: undefined" message.
This makes debugging very hard.

This commit fixes the issue by filling in the rejection reason with the actual error.