### PR TITLE
fix: allow absolute paths to Dangerfile

### DIFF
--- a/source/runner/runners/inline.ts
+++ b/source/runner/runners/inline.ts
@@ -107,13 +107,13 @@ export const runDangerfileEnvironment = async (
       d("Started parsing Dangerfile: ", filename)
       let optionalExport
       if (filename.endsWith(".mts")) {
-        const tmpFileName = path.join(process.cwd(), `._dangerfile.mjs`)
+        const tmpFileName = path.resolve(process.cwd(), `._dangerfile.mjs`)
         fs.writeFileSync(tmpFileName, compiled)
         // tried but data urls have trouble with imports and I don't know how to fix
         // optionalExport = (await import(`data:text/javascript;base64,${btoa(compiled)}`));
         optionalExport = await import(tmpFileName)
       } else if (filename.endsWith(".mjs")) {
-        optionalExport = await import(path.join(process.cwd(), filename))
+        optionalExport = await import(path.resolve(process.cwd(), filename))
       } else {
         optionalExport = _require(compiled, filename, {})
       }


### PR DESCRIPTION
# Problem
We are using Danger within a Docker-container in our CI pipeline. As most of our pipelines use a central Danger configuration as well as standardized CI pipelines, Danger is not required to be setup in every single repository, but fully baked into our container.

The Dangerfile is placed alongside the required dependencies in a different path (`/app`) than the actual project (`/workdir`).

When running DangerJS with `--dangerfile /app/dangerfile.mjs` the path is joined with `path.cwd()`, resulting in an invalid path like `/workdir/app/dangerfile.mjs`.

# Solution
Switching to `path.resolve` instead of `path.join` resolves (pun intended) this, without impacting other use cases.