### PR TITLE
Support files being ignored by babel configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 ## Main
 
 <!-- Your comment below this -->
+Ensure that [babel ignores](https://babeljs.io/docs/options#ignore) do not cause the transpiler to fall over, by supporting the 
+`null` return from `loadOptions` which occurs when a file is ignored.
 <!-- Your comment above this -->
 
 ## 12.3.3
@@ -2118,6 +2120,7 @@ Not usable for others, only stubs of classes etc. - [@orta]
 [@tibdex]: https://github.com/tibdex
 [@tim3trick]: https://github.com/tim3trick
 [@thawankeane]: https://github.com/thawankeane
+[@tomstrepsil: https://github.com/TomStrepsil]
 [@tychota]: https://github.com/tychota
 [@urkle]: https://github.com/urkle
 [@valscion]: https://github.com/valscion

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danger",
-  "version": "12.3.3",
+  "version": "12.3.4",
   "description": "Unit tests for Team Culture",
   "main": "distribution/danger.js",
   "typings": "distribution/danger.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "danger",
-  "version": "12.3.4",
+  "version": "12.3.3",
   "description": "Unit tests for Team Culture",
   "main": "distribution/danger.js",
   "typings": "distribution/danger.d.ts",

--- a/source/platforms/_tests/fixtures/bbc-dsl-input.json
+++ b/source/platforms/_tests/fixtures/bbc-dsl-input.json
@@ -2542,7 +2542,8 @@
   "settings": {
     "github": {
       "accessToken": "12345",
-      "additionalHeaders": {}
+      "additionalHeaders": {},
+      "baseURL": "https://api.github.com"
     },
     "cliArgs": {}
   }

--- a/source/platforms/_tests/fixtures/bbs-dsl-input.json
+++ b/source/platforms/_tests/fixtures/bbs-dsl-input.json
@@ -1087,7 +1087,8 @@
   "settings": {
     "github": {
       "accessToken": "12345",
-      "additionalHeaders": {}
+      "additionalHeaders": {},
+      "baseURL": "https://api.github.com"
     },
     "cliArgs": {}
   }

--- a/source/runner/runners/utils/_tests/_transpiler.test.ts
+++ b/source/runner/runners/utils/_tests/_transpiler.test.ts
@@ -92,7 +92,8 @@ describe("dirContains", () => {
 
 describe("babelify", () => {
   it("does not throw when a filepath is ignored due to babel options, and should return the content unchanged", () => {
-    const dangerfile = "import {a} from 'lodash'; a()"
+    const dangerfile = `import { a } from 'lodash';
+a();`
 
     const existsSyncMock = fs.existsSync as jest.Mock
     const actualFs = jest.requireActual("fs") as typeof fs

--- a/source/runner/runners/utils/transpiler.ts
+++ b/source/runner/runners/utils/transpiler.ts
@@ -172,7 +172,7 @@ export const babelify = (content: string, filename: string, extraPlugins: string
     return content
   }
 
-  const options = babel.loadOptions?.({ filename: filename }) ?? { plugins: [] }
+  const options = babel.loadOptions?.({ filename }) ?? { plugins: [] }
 
   const fileOpts = {
     filename,

--- a/source/runner/runners/utils/transpiler.ts
+++ b/source/runner/runners/utils/transpiler.ts
@@ -172,7 +172,7 @@ export const babelify = (content: string, filename: string, extraPlugins: string
     return content
   }
 
-  const options = babel.loadOptions ? babel.loadOptions({ filename }) : { plugins: [] }
+  const options = babel.loadOptions?.({ filename: filename }) ?? { plugins: [] }
 
   const fileOpts = {
     filename,
@@ -186,7 +186,7 @@ export const babelify = (content: string, filename: string, extraPlugins: string
   const result = transformSync(content, fileOpts)
   d("Result from Babel:")
   d(result)
-  return result.code
+  return result?.code ?? content
 }
 
 export default (code: string, filename: string, remoteFile: boolean = false) => {


### PR DESCRIPTION
Resolves #1469

Ensure that when `babel.loadOptions` returns `null` (which will be the case if a file is ignored by a babel configuration), this falls through to the guard to return the minimal options (`{ plugins: [] }`), thus preventing the error described in the issue.

For context, this was needed in a project that used [a local babel preset](https://github.com/ASOS/web-toggle-point/blob/main/peripheral/babel-preset-asos/), which had to be ignored to avoid a circular reference in babel.  When using a typescript dangerfile, the shared babel config baulked, due to attempt to spread `null`. 

This could be mitigated via `DANGER_DISABLE_TRANSPILATION`, but this then requires any local danger plugins etc to be in commonJs, which isn't ideal.

N.B. The `babelify` code was previously untested, and I have added bare-minimum test of the new functionality I have added, to simplify the review.  However, I am happy to attempt to "scout rule" the remainder of the function in tests, if that will be welcome.

N.B. The mocked dangerfile (copied from prior-art in the same test file) had to be changed to a _linted version_ - since despite tests passing locally otherwise, [the appveyor build](https://ci.appveyor.com/project/orta/danger-js/builds/51480736) had a failure thus:
```diff
    - Expected  - 1
    + Received  + 2
    - import {a} from 'lodash'; a()
    + import { a } from 'lodash';
    + a();
``` 

p.s. running:
```shell
yarn build; node --inspect distribution/commands/danger-pr.js https://github.com/danger/danger-js/pull/1476
```
...as per [the guide](https://github.com/danger/danger-js/blob/b07053c077cdcd200e22705f450970eb878a804f/README.md?plain=1#L86), has produced:
```shell
Processed 122 files (1.8s) (1 warning)

✔ No circular dependency found!

✨  Done in 5.72s.
Debugger listening on ws://127.0.0.1:9229/20b17684-51a1-4385-85ce-b6c9202e43ab
For help, see: https://nodejs.org/en/docs/inspector
Starting Danger PR on danger/danger-js#1476
You don't have a DANGER_GITHUB_API_TOKEN set up, this is optional, but TBH, you want to do this
Check out: http://danger.systems/js/guides/the_dangerfile.html#working-on-your-dangerfile
Jest tests passed :+1:

Unable to evaluate the Dangerfile
 Error: process.env.GITHUB_STEP_SUMMARY was not set, which is needed for setSummaryMarkdown
    at Object.setSummaryMarkdown (/danger-js/distribution/platforms/GitHub.js:133:23)
    at dangerfile.ts:89:31
    at step (dangerfile.ts:36:23)
    at Object.next (dangerfile.ts:17:53)
    at fulfilled (dangerfile.ts:8:58)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)


Danger: ⅹ Failing the build, there is 1 fail.
## Failures
Danger failed to run `dangerfile.ts`.
## Markdowns
## Error Error

process.env.GITHUB_STEP_SUMMARY was not set, which is needed for setSummaryMarkdown
Error: process.env.GITHUB_STEP_SUMMARY was not set, which is needed for setSummaryMarkdown
    at Object.setSummaryMarkdown (/git/danger-js/distribution/platforms/GitHub.js:133:23)
    at dangerfile.ts:89:31
    at step (dangerfile.ts:36:23)
    at Object.next (dangerfile.ts:17:53)
    at fulfilled (dangerfile.ts:8:58)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

### Dangerfile

--------------------------^
```

...which appears unrelated, and unclear how this can be resolved as a contributor?  

If I run danger locally on this branch, no issues are present:
```shell
node distribution/commands/danger-local.js --base main

Danger: ✓ passed review, received no feedback.
```