### PR TITLE
chore: Upgrade octokit/rest.js for CVE patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
   },
   "dependencies": {
     "@gitbeaker/rest": "^38.0.0",
-    "@octokit/rest": "^18.12.0",
+    "@octokit/rest": "^21.1.1",
     "async-retry": "1.2.3",
     "chalk": "^2.3.0",
     "commander": "^2.18.0",


### PR DESCRIPTION
Just some cleanup for a transitive CVE: https://github.com/advisories/GHSA-h5c3-5r3r-rr8q

- v19 dropped support for node 10/12 (https://github.com/octokit/rest.js/releases/tag/v19.0.0)
- v20 dropped support for node 14/16, removed preview support for the REST API, and removed the agent option (https://github.com/octokit/rest.js/releases/tag/v20.0.0)
- v21 updated the package to ESM (https://github.com/octokit/rest.js/releases/tag/v21.0.0)

None of these breaking changes should impact v12 of danger-js as it requires node >= 18.