### PR TITLE
feat: add pre-commit hook configuration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,13 @@
+- id: danger
+  name: danger
+  description: formalize your team etiquette
+  language: node
+  stages:
+    - pre-commit
+  entry: danger local
+  args:
+    - --base=main
+    - --dangerfile=dangerfile.local.js
+    - --staging
+  pass_filenames: false
+  always_run: true


### PR DESCRIPTION
This adds support for using danger directly with `.pre-commit-hooks.yaml` configuration file widely used with the python (and other) ecosystems.

More info https://pre-commit.com
