### PR TITLE
chore: replace lodash.find with native Array.find

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,6 @@
     "json5": "^2.2.3",
     "jsonpointer": "^5.0.0",
     "jsonwebtoken": "^9.0.0",
-    "lodash.find": "^4.6.0",
     "lodash.includes": "^4.3.0",
     "lodash.isobject": "^3.0.2",
     "lodash.keys": "^4.0.8",

--- a/source/ambient.d.ts
+++ b/source/ambient.d.ts
@@ -1,5 +1,4 @@
 declare module "lodash.includes"
-declare module "lodash.find"
 declare module "lodash.isobject"
 declare module "lodash.keys"
 declare module "jest-runtime"

--- a/source/ci_source/ci_source_helpers.ts
+++ b/source/ci_source/ci_source_helpers.ts
@@ -1,7 +1,6 @@
 import { Env } from "./ci_source"
 import { GitHubAPI } from "../platforms/github/GitHubAPI"
 import { GitHubPRDSL } from "../dsl/GitHubDSL"
-import find from "lodash.find"
 import {
   BitBucketServerAPI,
   bitbucketServerRepoCredentialsFromEnv,
@@ -64,7 +63,7 @@ export async function getPullRequestIDForBranch(metadata: RepoMetaData, env: Env
   }
   const api = new GitHubAPI(metadata, token)
   const prs = (await api.getPullRequests()) as any[]
-  const prForBranch: GitHubPRDSL = find(prs, (pr: GitHubPRDSL) => pr.head.ref === branch)
+  const prForBranch = prs.find((pr: GitHubPRDSL) => pr.head.ref === branch)
   if (prForBranch) {
     return prForBranch.number
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5149,11 +5149,6 @@ lodash.escaperegexp@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
   integrity sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==
 
-lodash.find@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
-  integrity sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg==
-
 lodash.flatten@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"


### PR DESCRIPTION
This PR replaces the usage of lodash.find with the native Array.find() method.
The behavior remains consistent with Lodash, but now relies on built-in JavaScript functionality for better simplicity and maintainability.

This change is part of a gradual effort to reduce Lodash dependencies across the codebase.

https://github.com/es-tooling/module-replacements/blob/main/docs/modules/lodash-underscore.md