### PR TITLE
chore: remove lodash.keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,6 @@
     "jsonwebtoken": "^9.0.0",
     "lodash.includes": "^4.3.0",
     "lodash.isobject": "^3.0.2",
-    "lodash.keys": "^4.0.8",
     "lodash.mapvalues": "^4.6.0",
     "lodash.memoize": "^4.1.2",
     "memfs-or-file-map-to-github-branch": "^1.3.0",

--- a/source/platforms/git/gitJSONToGitDSL.ts
+++ b/source/platforms/git/gitJSONToGitDSL.ts
@@ -3,7 +3,6 @@ import parseDiff from "parse-diff"
 
 import includes from "lodash.includes"
 import isobject from "lodash.isobject"
-import keys from "lodash.keys"
 import memoize from "lodash.memoize"
 
 import * as jsonDiff from "fast-json-patch"
@@ -144,8 +143,8 @@ export const gitJSONToGitDSL = (gitJSONRep: GitJSONDSL, config: GitJSONToGitDSLC
         diff.removed = arrayBefore.filter((o) => !includes(arrayAfter, o))
         // Do the same, but for keys inside an object if they both are objects.
       } else if (isobject(afterValue) && isobject(beforeValue)) {
-        const beforeKeys = keys(beforeValue) as string[]
-        const afterKeys = keys(afterValue) as string[]
+        const beforeKeys = Object.keys(beforeValue) as string[]
+        const afterKeys = Object.keys(afterValue) as string[]
         diff.added = afterKeys.filter((o) => !includes(beforeKeys, o))
         diff.removed = beforeKeys.filter((o) => !includes(afterKeys, o))
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5189,11 +5189,6 @@ lodash.isstring@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
 
-lodash.keys@^4.0.8:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-4.2.0.tgz#a08602ac12e4fb83f91fc1fb7a360a4d9ba35205"
-  integrity sha512-J79MkJcp7Df5mizHiVNpjoHXLi4HLjh9VLS/M7lQSGoQ+0oQ+lWEigREkqKyizPB1IawvQLLKY8mzEcm1tkyxQ==
-
 lodash.mapvalues@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"


### PR DESCRIPTION
This PR replaces the usage of lodash.keys with the native Object.keys() method.
The behavior remains consistent with Lodash, but now relies on built-in JavaScript functionality for better simplicity and maintainability.