### PR TITLE
chore(deps): yarn upgrade qs

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6167,9 +6167,9 @@ pupa@^3.1.0:
     escape-goat "^4.0.0"
 
 qs@^6.11.1:
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.0.tgz#c63fa40680d2c5c941412a0e899c89af60c0a930"
-  integrity sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==
+  version "6.14.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.1.tgz#a41d85b9d3902f31d27861790506294881871159"
+  integrity sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==
   dependencies:
     side-channel "^1.1.0"
 


### PR DESCRIPTION
npm audit
│ high                │ qs's arrayLimit bypass in its bracket notation allows  │
│                     │ DoS via memory exhaustion                              │
│ Package             │ qs                                                     │
│ Vulnerable versions │ <6.14.1                                                │
│ Patched versions    │ >=6.14.1                                               │
│ Paths               │ .>danger>@gitbeaker/rest>@gitbeaker/core>qs            │
│ More info           │ https://github.com/advisories/GHSA-6rw7-vpxm-498p      │
1 vulnerabilities found
Severity: 1 high