### PR TITLE
Chore: Upgrade GitBeaker dependency to 43.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 <!-- Your comment below this -->
 
+- GitLab: Upgrade `@gitbeaker/rest` from `^38.0.0` to `^43.8.0` [#1510](https://github.com/danger/danger-js/pull/1510) [@glensc]
 
 <!-- Your comment above this -->
 

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "typescript-json-schema": "^0.53.0"
   },
   "dependencies": {
-    "@gitbeaker/rest": "^38.0.0",
+    "@gitbeaker/rest": "^43.8.0",
     "@octokit/rest": "^20.1.2",
     "async-retry": "1.2.3",
     "chalk": "^4.1.2",

--- a/source/platforms/GitLab.ts
+++ b/source/platforms/GitLab.ts
@@ -122,7 +122,10 @@ class GitLab implements Platform {
 
       if (existingNote) {
         // update the existing comment
-        newOrUpdatedNote = await this.api.updateMergeRequestNote(existingNote.id, newComment)
+        newOrUpdatedNote = {
+          ...(await this.api.updateMergeRequestNote(existingNote.id, newComment)),
+          type: existingNote.type,
+        }
       } else {
         // create a new comment
         newOrUpdatedNote = (await this.api.createMergeRequestDiscussion(newComment))?.notes?.[0]

--- a/source/platforms/_tests/_gitlab.test.ts
+++ b/source/platforms/_tests/_gitlab.test.ts
@@ -46,6 +46,13 @@ function mockDangerNote(id: number, resolved = false): Types.MergeRequestNoteSch
   return mockNote(id, dangerUserId, `some body ${dangerIdString} asdf`, resolved)
 }
 
+function asDiscussionNote(note: Types.MergeRequestNoteSchema): Types.DiscussionNoteSchema {
+  return {
+    ...note,
+    type: (note.type ?? "DiffNote") as Types.DiscussionNoteSchema["type"],
+  }
+}
+
 function mockDiscussion(id: string, notes: Types.DiscussionNoteSchema[]): Types.DiscussionSchema {
   const discussion: Partial<Types.DiscussionSchema> = { id, notes }
   return discussion as Types.DiscussionSchema
@@ -63,12 +70,12 @@ function mockApi(withExisting = false): GitLabAPI {
   )
   const note4 = mockNote(1004, 745774)
   const note5 = mockNote(1005, 745774)
-  const discussion1 = mockDiscussion("aaaaffff1111", [note1, note2])
-  const discussion2 = mockDiscussion("aaaaffff2222", [note3, note4])
-  const discussion3 = mockDiscussion("aaaaffff3333", [note5])
+  const discussion1 = mockDiscussion("aaaaffff1111", [asDiscussionNote(note1), asDiscussionNote(note2)])
+  const discussion2 = mockDiscussion("aaaaffff2222", [asDiscussionNote(note3), asDiscussionNote(note4)])
+  const discussion3 = mockDiscussion("aaaaffff3333", [asDiscussionNote(note5)])
 
   const newNote = mockNote(4711, dangerUserId)
-  const newDiscussion = mockDiscussion("aaaaffff0000", [newNote])
+  const newDiscussion = mockDiscussion("aaaaffff0000", [asDiscussionNote(newNote)])
 
   const api: Partial<GitLabAPI> = {
     getUser,
@@ -218,20 +225,23 @@ describe("getInlineComments", () => {
     const autoresolvedDangerNote = mockDangerNote(2000, true)
     const autoresolveSystemNote1 = mockSystemAutoresolveNote(2001, 12345)
     const autoresolvedDiscussion = mockDiscussion("autoresolvedDiscussion", [
-      autoresolvedDangerNote,
-      autoresolveSystemNote1,
+      asDiscussionNote(autoresolvedDangerNote),
+      asDiscussionNote(autoresolveSystemNote1),
     ])
 
     const notAutoresolvedDangerNote = mockDangerNote(2001)
     const autoresolveSystemNote2 = mockSystemAutoresolveNote(2002, 12345)
     const notAutoresolvedDiscussion = mockDiscussion("notAutoresolvedDiscussion", [
-      notAutoresolvedDangerNote,
-      autoresolveSystemNote2,
+      asDiscussionNote(notAutoresolvedDangerNote),
+      asDiscussionNote(autoresolveSystemNote2),
     ])
 
     const notDangerNote = mockNote(2002, 12345)
     const notDangerDiscussionNote = mockNote(2003, 23456, "", false, "DiscussionNote")
-    const notDangerDiscussion = mockDiscussion("notDangerDiscussion", [notDangerNote, notDangerDiscussionNote])
+    const notDangerDiscussion = mockDiscussion("notDangerDiscussion", [
+      asDiscussionNote(notDangerNote),
+      asDiscussionNote(notDangerDiscussionNote),
+    ])
 
     const api = mockApi()
     api.getMergeRequestDiscussions = jest.fn(() =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1054,30 +1054,32 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
-"@gitbeaker/core@^38.12.1":
-  version "38.12.1"
-  resolved "https://registry.yarnpkg.com/@gitbeaker/core/-/core-38.12.1.tgz#d75d9f829aed9957a75c798d454324285366d0de"
-  integrity sha512-8XMVcBIdVAAoxn7JtqmZ2Ee8f+AZLcCPmqEmPFOXY2jPS84y/DERISg/+sbhhb18iRy+ZsZhpWgQ/r3CkYNJOQ==
+"@gitbeaker/core@^43.8.0":
+  version "43.8.0"
+  resolved "https://registry.yarnpkg.com/@gitbeaker/core/-/core-43.8.0.tgz#b9ff02c9c91296f5aaaa0b9c16c4396453610fca"
+  integrity sha512-H+LfKuf4dExBinb79c+CXViRBvTVQNf5BYLNSizm2SiqdED5JruhKX88payefleY0szp7G/mySlFSXPyGRH1dQ==
   dependencies:
-    "@gitbeaker/requester-utils" "^38.12.1"
-    qs "^6.11.1"
+    "@gitbeaker/requester-utils" "^43.8.0"
+    qs "^6.14.0"
     xcase "^2.0.1"
 
-"@gitbeaker/requester-utils@^38.12.1":
-  version "38.12.1"
-  resolved "https://registry.yarnpkg.com/@gitbeaker/requester-utils/-/requester-utils-38.12.1.tgz#8917647521e518ba74425c78a6dd91cf5787b4dc"
-  integrity sha512-Rc/DgngS0YPN+AY1s9UnexKSy4Lh0bkQVAq9p7PRbRpXb33SlTeCg8eg/8+A/mrMcHgYmP0XhH8lkizyA5tBUQ==
+"@gitbeaker/requester-utils@^43.8.0":
+  version "43.8.0"
+  resolved "https://registry.yarnpkg.com/@gitbeaker/requester-utils/-/requester-utils-43.8.0.tgz#6b9fb0cf93ce20c7a9b453161749c61a704c2849"
+  integrity sha512-d/SiJdxijc+aH5ZBQOw83XLxNSXqsBZNm5k3nPu1EHxGxK0fajXmxdMl0/vNXbKRggnIquFCxURkrQSEzfjqxQ==
   dependencies:
-    qs "^6.11.1"
+    picomatch-browser "^2.2.6"
+    qs "^6.14.0"
+    rate-limiter-flexible "^8.0.1"
     xcase "^2.0.1"
 
-"@gitbeaker/rest@^38.0.0":
-  version "38.12.1"
-  resolved "https://registry.yarnpkg.com/@gitbeaker/rest/-/rest-38.12.1.tgz#93c57104234ba9f4bd61959dca1e11a569089619"
-  integrity sha512-9KMSDtJ/sIov+5pcH+CAfiJXSiuYgN0KLKQFg0HHWR2DwcjGYkcbmhoZcWsaOWOqq4kihN1l7wX91UoRxxKKTQ==
+"@gitbeaker/rest@^43.8.0":
+  version "43.8.0"
+  resolved "https://registry.yarnpkg.com/@gitbeaker/rest/-/rest-43.8.0.tgz#e7ed39a2ae0a358f9c91c02aa0f3f946cd7ced5c"
+  integrity sha512-xxqsNsUXaFang9b2e/NTIgqUeuUlifA2Opy1mOVqTDuJZZNIOTgUNyziwBJoleBhMC0XuvY3JNVMWthufcVjRw==
   dependencies:
-    "@gitbeaker/core" "^38.12.1"
-    "@gitbeaker/requester-utils" "^38.12.1"
+    "@gitbeaker/core" "^43.8.0"
+    "@gitbeaker/requester-utils" "^43.8.0"
 
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"
@@ -5693,6 +5695,11 @@ picocolors@^1.0.0, picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
+picomatch-browser@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/picomatch-browser/-/picomatch-browser-2.2.6.tgz#e0626204575eb49f019f2f2feac24fc3b53e7a8a"
+  integrity sha512-0ypsOQt9D4e3hziV8O4elD9uN0z/jtUEfxVRtNaAAtXIyUx9m/SzlO020i8YNL2aL/E6blOvvHQcin6HZlFy/w==
+
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
@@ -5965,10 +5972,10 @@ pupa@^3.1.0:
   dependencies:
     escape-goat "^4.0.0"
 
-qs@^6.11.1:
-  version "6.14.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.1.tgz#a41d85b9d3902f31d27861790506294881871159"
-  integrity sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==
+qs@^6.14.0:
+  version "6.15.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.1.tgz#bdb55aed06bfac257a90c44a446a73fba5575c8f"
+  integrity sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==
   dependencies:
     side-channel "^1.1.0"
 
@@ -5981,6 +5988,11 @@ quote-unquote@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/quote-unquote/-/quote-unquote-1.0.0.tgz#67a9a77148effeaf81a4d428404a710baaac8a0b"
   integrity sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==
+
+rate-limiter-flexible@^8.0.1:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/rate-limiter-flexible/-/rate-limiter-flexible-8.3.0.tgz#3dd39ff8e4fb0fbee653bbea440039796a7caebf"
+  integrity sha512-mzwlfipDLlRinPgELqVDJetke6Snq26nL565m8nLWXIcWgosYSeNRgqwh7ZrZ4MfYs8CNfmLvR5SBVz3rISQsQ==
 
 rc@1.2.8, rc@^1.2.7:
   version "1.2.8"


### PR DESCRIPTION
Major release notes:
- [39.0.0](https://github.com/jdalrymple/gitbeaker/releases/tag/39.0.0)
  - @gitbeaker/core: Renaming downloadTraceFile to showLog and updating return type https://github.com/jdalrymple/gitbeaker/pull/3301 ([@jdalrymple](https://github.com/jdalrymple))
- [40.0.0](https://github.com/jdalrymple/gitbeaker/releases/tag/40.0.0)
  - @gitbeaker/core: Updating Access Token API wrapper https://github.com/jdalrymple/gitbeaker/pull/3554 ([@jdalrymple](https://github.com/jdalrymple)) 
- [41.0.0](https://github.com/jdalrymple/gitbeaker/releases/tag/41.0.0)
  - @gitbeaker/core, @gitbeaker/rest: Adding support for GroupJobTokenScopes and moved JobTokenScopes to ProjectJobTokenScopes(https://github.com/jdalrymple/gitbeaker/pull/3643) https://github.com/jdalrymple/gitbeaker/pull/3643 ([@jdalrymple](https://github.com/jdalrymple))
- [42.0.0](https://github.com/jdalrymple/gitbeaker/releases/tag/42.0.0)
  - @gitbeaker/core: Accept username in ProjectMembers#add https://github.com/jdalrymple/gitbeaker/pull/3666 ([@talyssonoc](https://github.com/talyssonoc) [@jdalrymple](https://github.com/jdalrymple))
- [43.0.0](https://github.com/jdalrymple/gitbeaker/releases/tag/43.0.0)
  - @gitbeaker/rest: Enhance error messaging in GitbeakerRequestError to clearly display only the description context https://github.com/jdalrymple/gitbeaker/pull/3731 ([@kang8](https://github.com/kang8))


Refs
- https://github.com/danger/danger-js/issues/1386