### PR TITLE
Upgrade to undici 6.27.0 to resolve transitive CVEs - fixes #1517

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 <!-- Your comment below this -->
 
+- Upgrade to undici 6.27.0 to resolve transitive CVEs - fixes [#1517](https://github.com/danger/danger-js/issues/1517) [@rjatkins]
+
 <!-- Your comment above this -->
 
 ## 13.0.9

--- a/package.json
+++ b/package.json
@@ -173,10 +173,11 @@
     "regenerator-runtime": "^0.13.9",
     "require-from-string": "^2.0.2",
     "supports-hyperlinks": "^4.3.0",
-    "undici": "6.21.1"
+    "undici": "^6.27.0"
   },
   "resolutions": {
+    "@octokit/rest": "^20.1.2",
     "before-after-hook": "2.2.0",
-    "@octokit/rest": "^20.1.2"
+    "undici": "^6.27.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7022,10 +7022,10 @@ undici-types@~6.20.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
   integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
 
-undici@6.21.1:
-  version "6.21.1"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.21.1.tgz#336025a14162e6837e44ad7b819b35b6c6af0e05"
-  integrity sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==
+undici@6.21.1, undici@^6.27.0:
+  version "6.27.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/undici/-/undici-6.27.0.tgz#41f9e48f7c5a40d27376caaead8c9a9fc7bca9c4"
+  integrity sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Unpinning undici so that further fixes to undici@6.x will be fixable in consumers, through their lockfiles