### PR TITLE
docs: add TSDoc comment to GitHubReviewers interface

### DIFF
--- a/source/dsl/GitHubDSL.ts
+++ b/source/dsl/GitHubDSL.ts
@@ -471,6 +471,9 @@ export interface GitHubAPIPR {
   pull_number: number
 }
 
+/**
+ * The users and teams that have been requested to review a GitHub PR.
+ */
 export interface GitHubReviewers {
   /** Users that have been requested */
   users: GitHubUser[]


### PR DESCRIPTION
## Summary

Closes #1409.

`GitHubReviewers` (referenced from `GitHubJSONDSL.requested_reviewers`) had no top-level TSDoc comment, so it was silently dropped from the generated DSL Reference page — typedoc only emits a dedicated section for exported interfaces/types that have a leading doc comment. Other documented interfaces in the same file (e.g. `GitHubUser`) already follow this pattern.

## Change

Added a one-line TSDoc block above `export interface GitHubReviewers` in `source/dsl/GitHubDSL.ts`, mirroring the style used for `GitHubUser`.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx eslint source/dsl/GitHubDSL.ts` passes with no warnings
- [x] Comment-only change, no behavior/type change