### PR TITLE
Security: Unpin typescript in Dockerfile from 6.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY package.json yarn.lock ./
 RUN yarn install
 COPY . .
 RUN yarn run build:fast
-RUN yarn remove 'typescript' --dev && yarn add 'typescript@6.0.3'
+RUN yarn remove 'typescript' --dev && yarn add 'typescript@^6.0.3'
 RUN yarn install --production --frozen-lockfile
 RUN chmod +x distribution/commands/danger.js
 


### PR DESCRIPTION
The intention is to avoid installing 7.x, rather actually requiring the concrete 6.0.3 version
- https://github.com/danger/danger-js/pull/1522#issuecomment-5048922762