### PR TITLE
Fix GitHubReview state values to match the GitHub API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 <!-- Your comment below this -->
 
+- `github.reviews` now reports the review states GitHub actually sends, so checking for a review that requested changes works - fixes [#1443](https://github.com/danger/danger-js/issues/1443) [@Socialpranker]
 - Upgrade to undici 6.27.0 to resolve transitive CVEs - fixes [#1517](https://github.com/danger/danger-js/issues/1517) [@rjatkins]
 
 <!-- Your comment above this -->
@@ -2146,6 +2147,7 @@ Not usable for others, only stubs of classes etc. - [@orta]
 [@sharkysharks]: https://github.com/sharkysharks
 [@shyim]: https://github.com/shyim
 [@snowe2010]: https://github.com/snowe2010
+[@socialpranker]: https://github.com/Socialpranker
 [@sogame]: https://github.com/sogame
 [@soyn]: https://github.com/Soyn
 [@stefanbuck]: https://github.com/stefanbuck

--- a/source/danger-incoming-process-schema.json
+++ b/source/danger-incoming-process-schema.json
@@ -1888,13 +1888,7 @@
                     "type": "number"
                 },
                 "state": {
-                    "description": "The state of the review\nAPPROVED, REQUEST_CHANGES, COMMENT or PENDING",
-                    "enum": [
-                        "APPROVED",
-                        "COMMENT",
-                        "PENDING",
-                        "REQUEST_CHANGES"
-                    ],
+                    "description": "The state of the review, e.g. APPROVED, CHANGES_REQUESTED, COMMENTED,\nDISMISSED or PENDING. GitHub does not document a closed set of values for\nthis field, so it is typed as a union with `string` rather than an exact\none: the literals give you autocomplete, and `string` keeps the type honest\nabout values GitHub may add.",
                     "type": "string"
                 },
                 "user": {

--- a/source/danger.d.ts
+++ b/source/danger.d.ts
@@ -1450,10 +1450,13 @@ interface GitHubReview {
   commit_id?: string
 
   /**
-   * The state of the review
-   * APPROVED, REQUEST_CHANGES, COMMENT or PENDING
+   * The state of the review, e.g. APPROVED, CHANGES_REQUESTED, COMMENTED,
+   * DISMISSED or PENDING. GitHub does not document a closed set of values for
+   * this field, so it is typed as a union with `string` rather than an exact
+   * one: the literals give you autocomplete, and `string` keeps the type honest
+   * about values GitHub may add.
    */
-  state?: "APPROVED" | "REQUEST_CHANGES" | "COMMENT" | "PENDING"
+  state?: "APPROVED" | "CHANGES_REQUESTED" | "COMMENTED" | "DISMISSED" | "PENDING" | string
 }
 
 /** Provides the current PR in an easily used way for params in `github.api` calls  */

--- a/source/dsl/GitHubDSL.ts
+++ b/source/dsl/GitHubDSL.ts
@@ -289,13 +289,13 @@ export interface GitHubPRDSL {
 
   /** How does the PR author relate to this repo/org? */
   author_association:
-  | "COLLABORATOR"
-  | "CONTRIBUTOR"
-  | "FIRST_TIMER"
-  | "FIRST_TIME_CONTRIBUTOR"
-  | "MEMBER"
-  | "NONE"
-  | "OWNER"
+    | "COLLABORATOR"
+    | "CONTRIBUTOR"
+    | "FIRST_TIMER"
+    | "FIRST_TIME_CONTRIBUTOR"
+    | "MEMBER"
+    | "NONE"
+    | "OWNER"
 }
 
 // These are the individual subtypes of objects inside the larger DSL objects above.
@@ -450,10 +450,13 @@ export interface GitHubReview {
   commit_id?: string
 
   /**
-   * The state of the review
-   * APPROVED, REQUEST_CHANGES, COMMENT or PENDING
+   * The state of the review, e.g. APPROVED, CHANGES_REQUESTED, COMMENTED,
+   * DISMISSED or PENDING. GitHub does not document a closed set of values for
+   * this field, so it is typed as a union with `string` rather than an exact
+   * one: the literals give you autocomplete, and `string` keeps the type honest
+   * about values GitHub may add.
    */
-  state?: "APPROVED" | "REQUEST_CHANGES" | "COMMENT" | "PENDING"
+  state?: "APPROVED" | "CHANGES_REQUESTED" | "COMMENTED" | "DISMISSED" | "PENDING" | string
 }
 
 /** Provides the current PR in an easily used way for params in `github.api` calls  */
@@ -462,8 +465,8 @@ export interface GitHubAPIPR {
   owner: string
   /** The repo name */
   repo: string
-  /** 
-   * The PR number 
+  /**
+   * The PR number
    * @deprecated use `pull_number` instead
    */
   number: number


### PR DESCRIPTION
`GitHubReview.state` was typed as `"APPROVED" | "REQUEST_CHANGES" | "COMMENT" | "PENDING"`, but the reviews API doesn't send `REQUEST_CHANGES` or `COMMENT`. It sends `CHANGES_REQUESTED` and `COMMENTED`, which is why the check in #1443 silently never matches:

```ts
reviews.find(review => review.state === 'REQUEST_CHANGES')
```

`DISMISSED` was missing too, so a dismissed review had no valid type either.

On the shape of the fix: @orta suggested keeping the literal array and adding `| string`, and checking GitHub's own OpenAPI description makes that the right call rather than just a lenient one. `pull-request-review.state` there is a plain `type: string` with `CHANGES_REQUESTED` as the example, with no enum, so GitHub deliberately doesn't commit to a closed set. A fully exact union would still be wrong even with the names corrected. The literals give you autocomplete, and `| string` stops the type from claiming a guarantee GitHub doesn't make.

One side effect worth flagging: `source/danger-incoming-process-schema.json` is generated by `typescript-json-schema`, and adding `| string` drops the `enum` from that property, leaving `"type": "string"`. That's the honest description now, since the old enum listed two values GitHub never sends and would reject the two it does. Nothing validates against that schema at runtime; it's there for other `danger-process` implementations.

The regenerated `danger.d.ts` and schema are included. `source/dsl/GitHubDSL.ts` also picked up two unrelated formatting hunks (`author_association` indentation and a trailing space) because lint-staged runs prettier over the whole staged file on commit.

Ran the full suite: 682 passing. Note that the tests don't run on Node 25 at all on main, since `buffer-equal-constant-time` reads `SlowBuffer.prototype` which Node 25 removed, so 32 suites fail to load before any test executes. On Node 22 everything is green.

Written with Claude Code (Claude Opus 5); I reviewed and tested everything before submitting.
