### PR TITLE
Run CI on Node 22

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       # Get local dependencies & test
       - run: yarn install


### PR DESCRIPTION
CI has been red on every PR for a while now, and it isn't the PRs. The "Make a small babel app" step runs `create-react-app`, whose template depends on `@testing-library/jest-dom` at `^6.9.1`. That range now resolves to 6.10.0, which declares `engines.node: ">=22"`, and the workflow pins Node 20, so yarn bails out before Danger ever runs:

```
error @testing-library/jest-dom@6.10.0: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.20.2"
```

The same failure shows up on #1524 (22 Jul) and on my #1525, which touch unrelated things, so it's the workflow rather than either change.

This bumps `node-version` in `CI.yml` from 20 to 22, the minimum that satisfies the new constraint.

I left the rest alone deliberately. `release.yml` also pins Node 20, but it never builds a CRA so it isn't affected, and I'd rather not touch the publishing path without a reason. `engines` in `package.json` still says `>=18`, which is about what Danger supports for its users and is a separate question from what CI runs on.

One caveat on verification: I couldn't reproduce the failure locally, because a local `create-react-app` run resolved jest-dom to 6.9.1 rather than 6.10.0, and 6.9.1 still allows Node 14. So my evidence is the CI logs plus the published `engines` field on 6.10.0, not a local repro. The run on this PR is the real test.

#trivial

Written with Claude Code (Claude Opus 5); I reviewed and tested everything before submitting.
