### PR TITLE
fix(github): paginate pull request reviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 <!-- Your comment below this -->
 
+- GitHub: Fetch all pages of pull request reviews [#1383](https://github.com/danger/danger-js/issues/1383) [@LeonMAG]
 - Upgrade to undici 6.27.0 to resolve transitive CVEs - fixes [#1517](https://github.com/danger/danger-js/issues/1517) [@rjatkins]
 
 <!-- Your comment above this -->
@@ -2104,6 +2105,7 @@ Not usable for others, only stubs of classes etc. - [@orta]
 [@kristof0425]: https://github.com/kristof0425
 [@kwonoj]: https://github.com/kwonoj
 [@langovoi]: https://github.com/langovoi
+[@LeonMAG]: https://github.com/LeonMAG
 [@lucasmpaim]: https://github.com/lucasmpaim
 [@macklinu]: https://github.com/macklinu
 [@markelog]: https://github.com/markelog

--- a/source/platforms/github/GitHubAPI.ts
+++ b/source/platforms/github/GitHubAPI.ts
@@ -294,13 +294,8 @@ export class GitHubAPI {
     return await this.getAllOfResource(`repos/${repo}/pulls/${prID}/commits`)
   }
 
-  /**
-   * Get list of commits in pull requests. This'll try to iterate all available pages
-   * Until it reaches hard limit of api itself (250 commits).
-   * https://developer.github.com/v3/pulls/#list-commits-on-a-pull-request
-   *
-   */
-  getAllOfResource = async (path: string): Promise<any> => {
+  /** Get every available page from a GitHub list endpoint. */
+  getAllOfResource = async (path: string, headers: any = {}): Promise<any> => {
     const ret: Array<any> = []
 
     /**
@@ -328,16 +323,16 @@ export class GitHubAPI {
     let page = 0
     while (page >= 0) {
       const requestUrl = `${path}${page > 0 ? `?page=${page}` : ""}`
-      this.d(`getPullRequestCommits:: Sending pull request commit request for ${page === 0 ? "first" : `${page}`} page`)
-      this.d(`getPullRequestCommits:: Request url generated "${requestUrl}"`)
+      this.d(`getAllOfResource:: Sending request for ${page === 0 ? "first" : `${page}`} page`)
+      this.d(`getAllOfResource:: Request url generated "${requestUrl}"`)
 
-      const response = await this.get(requestUrl)
+      const response = await this.get(requestUrl, headers)
       if (response.ok) {
         ret.push(...(await response.json()))
         page = getNextPageFromLinkHeader(response)
       } else {
         this.d(
-          `getPullRequestCommits:: Failed to get response while traverse page ${page} with ${response.status}, bailing rest of pages if exists`
+          `getAllOfResource:: Failed to get response while traverse page ${page} with ${response.status}, bailing rest of pages if exists`
         )
         page = -1
       }
@@ -464,11 +459,9 @@ ${file.patch}
   getReviews = async (): Promise<any> => {
     const repo = this.repoMetadata.repoSlug
     const prID = this.repoMetadata.pullRequestID
-    const res = await this.get(`repos/${repo}/pulls/${prID}/reviews`, {
+    return await this.getAllOfResource(`repos/${repo}/pulls/${prID}/reviews`, {
       Accept: "application/vnd.github.v3+json",
     })
-
-    return res.ok ? res.json() : []
   }
 
   getIssue = async (): Promise<any> => {

--- a/source/platforms/github/_tests/_github_api.test.ts
+++ b/source/platforms/github/_tests/_github_api.test.ts
@@ -111,6 +111,69 @@ new file mode 0
     )
   })
 
+  it("getReviews follows every page returned by GitHub", async () => {
+    const firstPage = Array.from({ length: 30 }, (_, index) => ({ id: index + 1 }))
+    const secondPage = [{ id: 31 }]
+    api.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({
+          link: '<https://api.github.com/repos/artsy/emission/pulls/1/reviews?page=2>; rel="next"',
+        }),
+        json: jest.fn().mockResolvedValue(firstPage),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers(),
+        json: jest.fn().mockResolvedValue(secondPage),
+      })
+
+    const reviews = await api.getReviews()
+
+    expect(reviews).toHaveLength(31)
+    expect(api.fetch).toHaveBeenNthCalledWith(
+      1,
+      "https://api.github.com/repos/artsy/emission/pulls/1/reviews",
+      {
+        body: null,
+        headers: {
+          Accept: "application/vnd.github.v3+json",
+          Authorization: "token ABCDE",
+          "Content-Type": "application/json",
+        },
+        method: "GET",
+      },
+      undefined
+    )
+    expect(api.fetch).toHaveBeenNthCalledWith(
+      2,
+      "https://api.github.com/repos/artsy/emission/pulls/1/reviews?page=2",
+      {
+        body: null,
+        headers: {
+          Accept: "application/vnd.github.v3+json",
+          Authorization: "token ABCDE",
+          "Content-Type": "application/json",
+        },
+        method: "GET",
+      },
+      undefined
+    )
+  })
+
+  it("getReviews makes one request when GitHub has no next page", async () => {
+    const firstPage = [{ id: 1 }]
+    api.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers(),
+      json: jest.fn().mockResolvedValue(firstPage),
+    })
+
+    await expect(api.getReviews()).resolves.toEqual(firstPage)
+    expect(api.fetch).toHaveBeenCalledTimes(1)
+  })
+
   it("getDangerCommentIDs ignores comments not marked as generated", async () => {
     api.getAllOfResource = await requestWithFixturedJSON("github_inline_comments_with_danger.json")
     api.getUserID = () => new Promise<number>((r) => r(20229914))


### PR DESCRIPTION
## Summary

- paginate `danger.github.reviews` using the existing GitHub API helper
- preserve the review request's `Accept` header on every page
- add regression coverage for a second page of reviews and the single-page case
- add a changelog entry for #1383

Fixes #1383.

## Test plan

- [x] Added the pagination test first: it failed on the previous implementation with 30 reviews returned instead of 31.
- [x] `yarn test source/platforms/github/_tests/_github_api.test.ts --runInBand`
- [x] `yarn type-check`
- [x] `yarn lint`
- [x] `yarn build`
- [x] `yarn declarations`
- [x] `yarn tsc --esModuleInterop distribution/danger.d.ts`

The full Jest run reports all 62 suites passing (684 passing tests, 1 skipped), but exits with code 1 locally. The unchanged baseline branch has the same non-zero exit after all of its 62 suites pass, so this is not introduced by the patch.