### PR TITLE
Default to undici 7, make it an optional peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,24 @@
 
 <!-- Your comment below this -->
 
+Danger now installs undici 7 by default. undici is what Danger uses to talk to GitHub, GitLab and Bitbucket, and version
+7 requires node 20.18.1 or newer — so for most people that is Danger's new effective minimum. Node 18 has not been
+dropped: you can pin undici back to the 6.x line yourself and everything keeps working. - [@orta]
+
+The reason for the switch is that it puts you in control of your own undici version. Previously Danger pinned undici to
+the 6.x line, so if a security advisory landed you had to wait for a Danger release to pick up the fix. undici is now an
+optional peer dependency accepting `^6.28.0 || ^7`, which means moving it in either direction is a supported thing to do
+rather than a workaround.
+
 - `github.reviews` now reports the review states GitHub actually sends, so checking for a review that requested changes works - fixes [#1443](https://github.com/danger/danger-js/issues/1443) [@Socialpranker]
 - GitHub: Fetch all pages of pull request reviews [#1383](https://github.com/danger/danger-js/issues/1383) [@LeonMAG]
 - Upgrade to undici 6.27.0 to resolve transitive CVEs - fixes [#1517](https://github.com/danger/danger-js/issues/1517) [@rjatkins]
+- **Breaking** Default to undici 7, which raises the effective node requirement to 20.18.1. If you are on node 18, add
+  `"resolutions": { "undici": "^6.28.0" }` (yarn), `"overrides": { "undici": "^6.28.0" }` (npm), or the same `overrides`
+  block nested under `"pnpm"` (pnpm) to your `package.json`. [@orta]
+- undici is now an optional peer dependency (`^6.28.0 || ^7`), so you can move it forward yourself to pick up security
+  fixes without waiting for a Danger release [@orta]
+- Removed the `undici` entry from Danger's own `resolutions`, which had no effect on people installing Danger [@orta]
 
 <!-- Your comment above this -->
 

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   },
   "homepage": "https://github.com/danger/danger-js#readme",
   "engines": {
-    "node": ">=18"
+    "node": ">=18.17"
   },
   "devDependencies": {
     "@babel/cli": "7.16.7",
@@ -173,11 +173,18 @@
     "regenerator-runtime": "^0.13.9",
     "require-from-string": "^2.0.2",
     "supports-hyperlinks": "^4.3.0",
-    "undici": "^6.27.0"
+    "undici": "^7.16.0"
+  },
+  "peerDependencies": {
+    "undici": "^6.28.0 || ^7"
+  },
+  "peerDependenciesMeta": {
+    "undici": {
+      "optional": true
+    }
   },
   "resolutions": {
     "@octokit/rest": "^20.1.2",
-    "before-after-hook": "2.2.0",
-    "undici": "^6.27.0"
+    "before-after-hook": "2.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7022,10 +7022,15 @@ undici-types@~6.20.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
   integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
 
-undici@6.21.1, undici@^6.27.0:
-  version "6.27.0"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/undici/-/undici-6.27.0.tgz#41f9e48f7c5a40d27376caaead8c9a9fc7bca9c4"
-  integrity sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==
+undici@6.21.1:
+  version "6.21.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.21.1.tgz#336025a14162e6837e44ad7b819b35b6c6af0e05"
+  integrity sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==
+
+undici@^7.16.0:
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.29.0.tgz#ae0f6f62e06e057a9cbb7b2b5fde2bb74f791b8f"
+  integrity sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Settled my opinion on the undici issue.

---

Follow-up to #1518, which orta asked to reconsider in [this comment](https://github.com/danger/danger-js/pull/1518#issuecomment-4892453738).

**That comment's premise doesn't hold.** It said unlocking undici "drops a lot of node versions" — it doesn't. `6.21.1` and `6.27.0` both declare `engines.node >= 18.17`, and `^6.27.0` caps below 7. The node 20 cliff only starts at undici 7, so #1518 was node-identical to the old pin and there was nothing to undo on those grounds.

So rather than reverting it, this goes the other way.

## Why

Danger pinned undici to the 6.x line, which meant that when a security advisory landed against undici — as in #1517 — you had to wait for a Danger release to pick up the fix. That's the actual problem worth solving, and it's solved by handing control of the undici version to the person installing Danger.

## What

- `undici` moves to `^7.16.0` in `dependencies`.
- `undici` is additionally declared as an **optional peer dependency** accepting `^6.28.0 || ^7`, so moving it in either direction is a declared contract rather than folklore.

No source changes were needed. undici 7 exports `fetch`, `Headers`, `ProxyAgent` and the `Request`/`RequestInit`/`Response` types identically to 6, so `source/api/fetch.ts` works on either.

Not undici 8 — that requires node `>=22.19.0`, which is a step too far.

## Breaking

undici 7 requires node `>=20.18.1`, so that's the effective minimum for a default install. **Node 18 is not dropped** — pinning undici back keeps it working:

```json
{ "resolutions": { "undici": "^6.28.0" } }
```

## Two open questions for the maintainers

1. **`engines.node` is set to `>=18.17`, not `>=20.18.1`.** This was a close call. `>=18.17` is what Danger's own code genuinely needs, and it keeps the supported node-18-plus-override configuration warning-free — undici's own `engines` is what surfaces the real constraint. The counter-argument is that a node 18 user who *doesn't* add the override gets no warning from Danger and then hits a cryptic undici crash, and that the 12.0.0 precedent was to state the new floor in `engines` directly. It's a one-line change either way.

2. Listing `undici` in both `dependencies` and `peerDependencies` is the "ship a default but declare a compatible range" idiom. It behaves correctly on npm, yarn and pnpm, but it is the least conventional part of this diff.

## Also cleaned up

Dropped the `undici` entry from Danger's own `resolutions`, added in #1518. `resolutions` is yarn-only *and* only read at the install root, so it did nothing for anyone installing Danger — it only pinned Danger's own tree. It had also baked a private Atlassian registry URL into `yarn.lock` (`packages.atlassian.com/api/npm/npm-remote/undici/...`), which would break building from source outside that network. Both gone.

## Verification

- `yarn type-check` and `yarn build` pass on undici 7.29.0.
- `source/api/_tests/fetch.test.ts` passes, including the `ProxyAgent` path.
- Confirmed on real registry installs that yarn `resolutions` and npm `overrides` both actually re-resolve undici across the dependency boundary.

Caveat: the node-18-with-undici-6 configuration is **not** covered by CI, so it can regress unnoticed.

Unrelated, but surfaced while working on this: 4 GitHub test suites fail on node 26 (and on `main`) because `buffer-equal-constant-time` uses `SlowBuffer`, which node removed. Invisible in CI since it runs node 22, but it does break `yarn danger:prepush` locally. Probably worth its own issue.

Either way on `engines`, this needs a semver major.