### PR TITLE
Add support for deploying via github actions

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -1,0 +1,48 @@
+name: Publish danger to npm
+
+# Pushing a version tag is the deploy trigger. Who can create tags is
+# restricted by the "Release tags" repository ruleset, so that ruleset's
+# bypass list is the list of people who can ship a release.
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+-*"
+
+permissions:
+  contents: read
+  id-token: write # npm trusted publishing
+  actions: write # to kick off release.yml below
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      # Trusted publishing needs a newer npm than node ships with
+      - run: npm install -g npm@latest
+
+      - run: yarn install
+
+      - name: Check the tag matches the version in package.json
+        run: |
+          PKG=$(node -p "require('./package.json').version")
+          if [ "$GITHUB_REF_NAME" != "$PKG" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match package.json version $PKG"
+            exit 1
+          fi
+
+      # There's no NPM_TOKEN here: npm trusts this repo + workflow via OIDC.
+      # prepublishOnly does the build, the tests and the type definitions.
+      - run: npm publish --provenance
+
+      - name: Build the macOS executables and update the homebrew tap
+        run: gh workflow run release.yml -f version="$GITHUB_REF_NAME"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.release-it.json
+++ b/.release-it.json
@@ -5,14 +5,18 @@
     "assets": "brew-distribution/*.zip",
     "releaseNotes": "npx auto-changelog --stdout --commit-limit false -u --template https://raw.githubusercontent.com/release-it/release-it/main/templates/changelog-compact.hbs"
   },
+  "npm": {
+    "_": "Publishing happens in .github/workflows/npm_publish.yml, triggered by the tag this pushes",
+    "publish": false
+  },
   "git": {
     "requireCleanWorkingDir": false,
+    "tagName": "${version}",
     "changelog": "npx auto-changelog --stdout --commit-limit false -u --template https://raw.githubusercontent.com/release-it/release-it/main/templates/changelog-compact.hbs"
   },
   "buildCommand": "yarn package:x64; yarn package:arm64",
   "hooks": {
     "before:bump": "yarn declarations; yarn build:schemas",
-    "after:release": "gh workflow run release.yml -f version=${version}",
     "_": "CI will remove the _ from both of the below lines",
     "_after:bump": "yarn package:x64; yarn package:arm64",
     "_after:release": "export VERSION=${version}; echo 'VERSION=${version}' >> $GITHUB_ENV"

--- a/README.md
+++ b/README.md
@@ -96,12 +96,16 @@ Check the issues, I try and keep my short term perspective there. Long term is i
 
 ### Releasing a new version of Danger
 
-Following [this commit](https://github.com/danger/danger-js/commit/a26ac3b3bd4f002acd37f6a363c8e74c9d5039ab) as a model:
+Releases are triggered by pushing a version tag. Tag creation on this repo is restricted by the "Release tags"
+repository ruleset, so the set of people who can ship a release is that ruleset's bypass list.
 
 - Checkout the `main` branch. Ensure your working tree is clean, and make sure you have the latest changes by running
   `git pull; yarn`.
-- Publish - `npm run release -- patch --npm.otp=<code>`.
-- This will trigger a CI run which updates homebrew for the native builds
+- Bump and tag - `npm run release -- patch`. This bumps `package.json`, commits, tags and pushes. It no longer publishes
+  to npm from your machine, so there's no OTP to enter.
+- Pushing the tag runs [`npm_publish.yml`](.github/workflows/npm_publish.yml), which publishes to npm using npm's
+  trusted publishing (there is no `NPM_TOKEN` secret) and then kicks off `release.yml` for the macOS native builds and
+  the homebrew tap.
 
 :ship:
 


### PR DESCRIPTION
Moves the npm publish off maintainer laptops and onto a tag-triggered Actions workflow, so the set of people who can ship a release is controlled by a repository ruleset rather than by who happens to hold write access (currently 241 people, via org membership).

### How releases work now

- `npm run release -- patch` bumps, commits, tags and pushes — it no longer publishes to npm, so there's no OTP to type.
- Pushing the version tag runs `npm_publish.yml`, which publishes to npm and then kicks off the existing `release.yml` for the macOS binaries and the homebrew tap.
- Tag creation is restricted by the [Release tags](https://github.com/danger/danger-js/rules/21251190) ruleset (already active), bypassable only by org admins — so that's the deploy gate.

### Notes

- npm auth uses [trusted publishing](https://docs.npmjs.com/trusted-publishers) via OIDC — there is no `NPM_TOKEN` secret to leak, and releases get a provenance attestation.
- **The `danger` package needs a trusted publisher configured on npmjs.com before the first tag push**, or the publish step will fail: org `danger`, repo `danger-js`, workflow `npm_publish.yml`, environment blank.
- The workflow asserts the tag matches `package.json` version before publishing.
- Tags here are unprefixed (`14.0.4`, not `v14.0.4`); `git.tagName` is now pinned in `.release-it.json` so that can't drift away from the workflow's trigger pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)