### PR TITLE
Require admin review for workflow changes, gate npm OIDC behind a tag-only environment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Changes to the release automation need sign-off from a repository admin.
+# Anyone with write access can open the PR; someone on this list has to approve it.
+#
+# This list is also what npm's trusted publishing trusts, so treat a change to
+# these files as a change to who can ship the `danger` package.
+/.github/workflows/ @orta @dbgrandi @KrauseFx @macklinu @f-meloni
+/.github/CODEOWNERS @orta @dbgrandi @KrauseFx @macklinu @f-meloni
+/.release-it.json @orta @dbgrandi @KrauseFx @macklinu @f-meloni

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -17,6 +17,10 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Only tags can deploy to this environment, and only admins can create tags
+    # (the "Release tags" ruleset). Without it, anyone with write access could
+    # push a branch with an edited copy of this file and get npm's OIDC creds.
+    environment: npm-release
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -101,11 +101,15 @@ repository ruleset, so the set of people who can ship a release is that ruleset'
 
 - Checkout the `main` branch. Ensure your working tree is clean, and make sure you have the latest changes by running
   `git pull; yarn`.
-- Bump and tag - `npm run release -- patch`. This bumps `package.json`, commits, tags and pushes. It no longer publishes
+- Bump and tag - `npm run release -- patch --ci`. This bumps `package.json`, commits, tags and pushes. It no longer publishes
   to npm from your machine, so there's no OTP to enter.
 - Pushing the tag runs [`npm_publish.yml`](.github/workflows/npm_publish.yml), which publishes to npm using npm's
   trusted publishing (there is no `NPM_TOKEN` secret) and then kicks off `release.yml` for the macOS native builds and
   the homebrew tap.
+
+The publish job runs in the `npm-release` environment, which only tags can deploy to. Combined with the tag ruleset,
+that means a branch can never obtain npm's OIDC credentials. Changes to anything under `.github/workflows/` need a
+review from an admin, via [CODEOWNERS](.github/CODEOWNERS).
 
 :ship:
 


### PR DESCRIPTION
Figured that someone could edit the workflow to drop the checks, so I've tightened up workflow security 

---

Follow-up to #1532, which merged before these commits landed.

#1532 moved publishing to a tag-triggered workflow, on the reasoning that the tag ruleset is the deploy gate. That reasoning has a hole: npm's trusted publishing grants OIDC credentials based on repo + workflow filename, **not** on the ref. Anyone with write access (241 people) could push a branch containing an edited `npm_publish.yml` with `on: push` and obtain publish rights.

Two fixes:

- **`environment: npm-release` on the publish job.** The environment is already created with a tag-only deployment policy and no branch policies, so a branch can never reach it and therefore never gets credentials. This is the actual fix.
- **[CODEOWNERS](.github/CODEOWNERS)** requiring admin review for `/.github/workflows/`, `CODEOWNERS` itself, and `.release-it.json`. `main` is already configured with `require_code_owner_reviews: true` and `required_approving_review_count: 0`, so only PRs touching those paths need an admin approval — normal PRs are unaffected.

### Needs doing on npmjs.com

The trusted publisher config for `danger` needs its **environment** field set to `npm-release`. Until then this PR will break publishing, so it should be set at merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)