### PR TITLE
Bump the Docker image to node 22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 
 <!-- Your comment below this -->
 
+The Docker image behind the Danger GitHub Action now runs on node 22 instead of node 20. The image had stopped building
+entirely after the recent binary changes, so this gets the action publishing again. - [@orta]
+
 <!-- Your comment above this -->
 
 ## 14.0.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim AS base
+FROM node:22-slim AS base
 
 LABEL maintainer="Orta Therox"
 LABEL "com.github.actions.name"="Danger JS Action"


### PR DESCRIPTION
The `Release Danger-JS package` workflow has been failing to build the action image since the prebuilt-binary changes landed:

```
error @yao-pkg/pkg@6.22.0: The engine "node" is incompatible with this module.
Expected version ">=22.0.0". Got "20.20.2"
```

The Dockerfile was still on `node:20-slim`. `@yao-pkg/pkg` is only a devDependency for the macOS binaries, but the Docker build runs a full `yarn install` to get `build:fast`, and yarn treats an engine mismatch as a hard error — so the build dies before it compiles anything.

Bumps the base image to `node:22-slim`: the smallest jump that clears the engine check, matching the version CI already tests against. Node 20 is EOL anyway.

[Failing run](https://github.com/danger/danger-js/actions/runs/33111791278/job/98656205885)

🤖 Generated with [Claude Code](https://claude.com/claude-code)